### PR TITLE
featv0.5.0 BREAKING — 工具合并 74→35，统一 target 签名 #0000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,130 @@
 
 ---
 
+## [0.5.0] - 2026-04-20
+
+### 💥 BREAKING CHANGES
+
+- **工具面收敛 74 → 35**。所有老 `vortex_*` 工具名被删除或改名，必须迁移代码。见下方迁移表。
+- **元素定位改用 `target` 参数**。所有动作工具的 `selector` / `index` / `snapshotId` / `frameId` 参数被 `target` 字符串取代：`target: "@eN"` / `"@fNeM"` / CSS selector。
+- **observe 默认输出改为 compact Markdown 文本**。`detail=full` 可回到 v0.4 JSON 结构。
+
+### ✨ Features
+
+- **`@eN` / `@fNeM` ref 格式**：observe 给每元素分配 ref（agent-browser 风格），跨 frame 用 `@fNeM` 前缀；MCP 层自动解析。
+- **跨 frame 透明路由**：动作工具不再需要 `frameId` 参数，ref 前缀携带。全页工具（get_text/html/evaluate/screenshot）新增 `frameRef: "@fN"` 逃生舱。
+- **stale ref 错误提示**：`STALE_SNAPSHOT` 错误附带"请重新调用 observe"提示。
+- **tools/list payload 从 27.5KB 压到 14.5KB（-47%）**，observe 默认输出从 ~80KB（200 元素）降到 ~5KB（-94%）。
+
+### 🔧 Internal
+
+- MCP 层新增 `lib/ref-parser.ts`、`lib/observe-render.ts`、`lib/dispatch.ts`
+- server.ts 里的 MCP 名 → extension action 映射集中到 `dispatchNewTool`
+- vortex-bench 新增真实场景 fixture 套件（Element Plus / Ant Design / shadcn / Vuetify），jsdom 单测 + v0.4 基线对照断言
+
+### 📋 迁移表（Old → New）
+
+**Tab**
+
+| v0.4 | v0.5 |
+|------|------|
+| `vortex_tab_activate({tabId})` | 合并入 `vortex_tab_create({tabId, active:true})` |
+| `vortex_tab_get_info` | 用 `vortex_tab_list` 或 `vortex_page_info` |
+
+**Page / Navigation**
+
+| v0.4 | v0.5 |
+|------|------|
+| `vortex_page_reload` | `vortex_navigate({reload:true})` |
+| `vortex_page_back` | `vortex_history({direction:"back"})` |
+| `vortex_page_forward` | `vortex_history({direction:"forward"})` |
+| `vortex_page_wait` | `vortex_wait` |
+| `vortex_page_wait_for_network_idle` | `vortex_wait_idle({kind:"network"})` |
+| `vortex_page_wait_for_xhr_idle` | `vortex_wait_idle({kind:"xhr"})` |
+
+**DOM**
+
+| v0.4 | v0.5 |
+|------|------|
+| `vortex_dom_click({index, snapshotId})` | `vortex_click({target:"@eN"})` |
+| `vortex_dom_type` | `vortex_type` |
+| `vortex_dom_fill` | `vortex_fill` |
+| `vortex_dom_commit({kind:"cascader", value})` | `vortex_fill({kind:"cascader", target, value})` |
+| `vortex_dom_select` | `vortex_select` |
+| `vortex_dom_hover` | `vortex_hover` |
+| `vortex_dom_batch` | `vortex_batch` |
+| `vortex_dom_query / query_all` | 删除（用 `vortex_observe` 或 `vortex_evaluate`） |
+| `vortex_dom_scroll / get_attribute / get_scroll_info` | 删除（用 `vortex_evaluate`） |
+| `vortex_dom_wait_for_mutation / wait_settled` | `vortex_wait_idle({kind:"dom"})` |
+| `vortex_dom_watch_mutations / unwatch_mutations` | `vortex_events({op:"subscribe", types:["dom.mutated"]})` |
+
+**Content**
+
+| v0.4 | v0.5 |
+|------|------|
+| `vortex_content_get_text` | `vortex_get_text` |
+| `vortex_content_get_html` | `vortex_get_html` |
+| `vortex_content_get_accessibility_tree` | 删除（`vortex_observe` 覆盖） |
+| `vortex_content_get_element_text` | `vortex_get_text({target:"@eN"})` |
+| `vortex_content_get_computed_style` | 删除（用 `vortex_evaluate`） |
+
+**JavaScript**
+
+| v0.4 | v0.5 |
+|------|------|
+| `vortex_js_evaluate` | `vortex_evaluate` |
+| `vortex_js_evaluate_async` | `vortex_evaluate({async:true})` |
+| `vortex_js_call_function` | 删除（用 `vortex_evaluate`） |
+
+**Keyboard / Mouse / Capture**
+
+| v0.4 | v0.5 |
+|------|------|
+| `vortex_keyboard_press` | `vortex_press` |
+| `vortex_keyboard_shortcut` | 删除（用 `vortex_press` 多次调用） |
+| `vortex_mouse_double_click` | `vortex_mouse_click({clickCount:2})` |
+| `vortex_capture_element({selector})` | `vortex_screenshot({target:"@eN"})` |
+| `vortex_capture_gif_*` | 删除 |
+
+**Console / Network**
+
+| v0.4 | v0.5 |
+|------|------|
+| `vortex_console_get_logs` | `vortex_console({op:"get", level?})` |
+| `vortex_console_get_errors` | `vortex_console({op:"get", level:"error"})` |
+| `vortex_console_clear` | `vortex_console({op:"clear"})` |
+| `vortex_network_get_logs` | `vortex_network({op:"get"})` |
+| `vortex_network_get_errors` | `vortex_network({op:"get", filter:{statusMin:400}})` |
+| `vortex_network_filter` | `vortex_network({op:"get", filter})` |
+| `vortex_network_clear` | `vortex_network({op:"clear"})` |
+| `vortex_network_get_response_body` | `vortex_network_response_body` |
+
+**Storage**
+
+| v0.4 | v0.5 |
+|------|------|
+| `vortex_storage_get_cookies` | `vortex_storage_get({scope:"cookie"})` |
+| `vortex_storage_set_cookie` | `vortex_storage_set({scope:"cookie", ...})` |
+| `vortex_storage_delete_cookie` | `vortex_storage_set({scope:"cookie", op:"delete", ...})` |
+| `vortex_storage_get_local_storage` | `vortex_storage_get({scope:"local"})` |
+| `vortex_storage_set_local_storage` | `vortex_storage_set({scope:"local", ...})` |
+| `vortex_storage_get_session_storage` | `vortex_storage_get({scope:"session"})` |
+| `vortex_storage_set_session_storage` | `vortex_storage_set({scope:"session", ...})` |
+| `vortex_storage_export_session` | `vortex_storage_session({op:"export", domain})` |
+| `vortex_storage_import_session` | `vortex_storage_session({op:"import", data})` |
+
+**File / Frames / Events**
+
+| v0.4 | v0.5 |
+|------|------|
+| `vortex_file_get_downloads` | `vortex_file_list_downloads` |
+| `vortex_frames_find` | 删除（用 `vortex_observe`） |
+| `vortex_events_subscribe` | `vortex_events({op:"subscribe", ...})` |
+| `vortex_events_unsubscribe` | `vortex_events({op:"unsubscribe", ...})` |
+| `vortex_events_drain` | `vortex_events({op:"drain"})` |
+
+---
+
 ## [Unreleased] (towards 0.4.0)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ claude mcp add vortex --scope user -- npx -y @bytenew/vortex-mcp
 
 打开 Claude Code 后让它调 `mcp__vortex__vortex_tab_list`，应能看到当前所有标签页。
 
-## 能力一览（共 64 个工具 / action）
+## 能力一览（共 **35 个工具**）
 
 按模块分组：tab、page、dom、content、js、keyboard、mouse、capture、console、network、storage、file、frames。
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bytenew/vortex-cli",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "type": "module",
   "bin": {
     "vortex": "dist/bin/vortex.js"

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bytenew/vortex-extension",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "build": "vite build",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 # @bytenew/vortex-mcp
 
-通过 MCP（Model Context Protocol）把 Claude Code 接到本地 Chrome — 让 Claude 直接驱动你正在用的浏览器：导航、点击、填表、截图、抓 DOM、读 console/network、跑 JS 等共 **64 个工具**。
+通过 MCP（Model Context Protocol）把 Claude Code 接到本地 Chrome — 让 Claude 直接驱动你正在用的浏览器：导航、点击、填表、截图、抓 DOM、读 console/network、跑 JS 等共 **35 个工具**。
 
 底层基于 [Vortex](https://github.com/bytenew/vortex) 浏览器自动化套件：vortex Chrome 扩展 ↔ vortex-server（本地 WS）↔ 本 MCP server（stdio） ↔ Claude Code。
 
@@ -99,7 +99,7 @@ claude mcp list
 
 ---
 
-## 工具一览（64 个，按模块分组）
+## 工具一览（35 个，按模块分组）
 
 | 模块 | 工具前缀 | 典型用途 |
 |------|---------|---------|

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bytenew/vortex-mcp",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "type": "module",
   "bin": {
     "vortex-mcp": "dist/src/server.js"

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -13,6 +13,8 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { sendRequest } from "./client.js";
 import { getToolDefs, getToolDef } from "./tools/registry.js";
+import { dispatchNewTool } from "./tools/dispatch.js";
+export { dispatchNewTool };
 
 const require_ = createRequire(import.meta.url);
 const MCP_VERSION: string = (require_("../../package.json") as { version: string }).version;
@@ -154,56 +156,57 @@ async function handleCallTool(
 
   const params = (args ?? {}) as Record<string, unknown>;
 
-  // 特殊 tool: events 订阅管理（MCP 本地状态，不经过 vortex-server）
-  if (toolDef.action === "__mcp_events_subscribe__") {
-    const subId = eventStore.subscribe({
-      types: params.types as string[] | undefined,
-      minLevel: params.minLevel as VtxEventLevel | undefined,
-      tabId: params.tabId as number | undefined,
-    });
-    return withEvents([{
-      type: "text" as const,
-      text: JSON.stringify({
-        subscriptionId: subId,
-        note: "Events will be piggybacked to subsequent tool responses in a `[vortex-events]` text item.",
-      }, null, 2),
-    }]);
-  }
-
-  if (toolDef.action === "__mcp_events_unsubscribe__") {
-    const ok = eventStore.unsubscribe(params.subscriptionId as string);
-    return withEvents([{
-      type: "text" as const,
-      text: JSON.stringify({ unsubscribed: ok }, null, 2),
-    }]);
-  }
-
-  // 特殊 tool: events drain（强制 flush dispatcher + 拉 eventStore buffer）
-  if (toolDef.action === "__mcp_events_drain__") {
-    let flushed: { notice: number; info: number } = { notice: 0, info: 0 };
-    try {
-      const resp = await sendRequest("events.drain", {}, PORT, undefined, 5000);
-      const result = (resp.result ?? {}) as { flushed?: { notice: number; info: number } };
-      if (result.flushed) flushed = result.flushed;
-    } catch (err) {
-      // flush 失败仍尝试 drain 本地 buffer（可能已有之前 ingest 的事件）
-      const msg = err instanceof Error ? err.message : String(err);
+  // 特殊 tool: vortex_events（合并原三个 __mcp_events_*__ 分支）
+  if (toolDef.name === "vortex_events") {
+    const op = params.op as string;
+    if (op === "subscribe") {
+      const subId = eventStore.subscribe({
+        types: params.types as string[] | undefined,
+        minLevel: params.minLevel as VtxEventLevel | undefined,
+        tabId: params.tabId as number | undefined,
+      });
+      return withEvents([{
+        type: "text" as const,
+        text: JSON.stringify({
+          subscriptionId: subId,
+          note: "Events will be piggybacked to subsequent tool responses in a `[vortex-events]` text item.",
+        }, null, 2),
+      }]);
+    }
+    if (op === "unsubscribe") {
+      const ok = eventStore.unsubscribe(params.subscriptionId as string);
+      return withEvents([{
+        type: "text" as const,
+        text: JSON.stringify({ unsubscribed: ok }, null, 2),
+      }]);
+    }
+    if (op === "drain") {
+      let flushed: { notice: number; info: number } = { notice: 0, info: 0 };
+      try {
+        const resp = await sendRequest("events.drain", {}, PORT, undefined, 5000);
+        const result = (resp.result ?? {}) as { flushed?: { notice: number; info: number } };
+        if (result.flushed) flushed = result.flushed;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        const events = eventStore.drain();
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({ events, flushed, note: `flush failed: ${msg}` }, null, 2),
+          }],
+        };
+      }
       const events = eventStore.drain();
       return {
         content: [{
           type: "text" as const,
-          text: JSON.stringify({ events, flushed, note: `flush failed: ${msg}` }, null, 2),
+          text: JSON.stringify({ events, flushed }, null, 2),
         }],
       };
     }
-    // 顺序保证：ws FIFO → extension 的 dispatcher.flushAll 发出的 events
-    // 在 action response 之前到达 mcp 端，此时已经 ingest 到 eventStore
-    const events = eventStore.drain();
     return {
-      content: [{
-        type: "text" as const,
-        text: JSON.stringify({ events, flushed }, null, 2),
-      }],
+      isError: true,
+      content: [{ type: "text" as const, text: `Unknown events op: ${op}` }],
     };
   }
 
@@ -299,6 +302,57 @@ async function handleCallTool(
     return withEvents([{ type: "text" as const, text: resultText }]);
   }
 
+  // 特殊 tool: vortex_fill_form（MCP 侧循环，依次调 dom.fill / dom.commit）
+  if (toolDef.name === "vortex_fill_form") {
+    const fields = params.fields as Array<{ target?: string; value: unknown; kind?: string }>;
+    const { tabId, timeout } = params;
+    const effectiveTimeout = (timeout as number) ?? DEFAULT_TIMEOUT;
+    const results: { index: number; ok: boolean }[] = [];
+    for (let i = 0; i < fields.length; i++) {
+      const f = fields[i];
+      // 翻译 target
+      let fieldParams: Record<string, unknown> = { value: f.value };
+      if (f.target) {
+        if (f.target.startsWith("@")) {
+          try {
+            const { resolveTargetParam } = await import("./lib/ref-parser.js");
+            const resolved = resolveTargetParam(f.target, activeSnapshotId);
+            if (resolved.selector) fieldParams.selector = resolved.selector;
+            if (resolved.index != null) {
+              fieldParams.index = resolved.index;
+              fieldParams.snapshotId = resolved.snapshotId;
+              if (resolved.frameId && resolved.frameId !== 0) fieldParams.frameId = resolved.frameId;
+            }
+          } catch (err) {
+            return {
+              isError: true,
+              content: [{ type: "text" as const, text: `field[${i}] target error: ${(err as Error).message}` }],
+            };
+          }
+        } else {
+          fieldParams.selector = f.target;
+        }
+      }
+      // TODO: kind 支持（dom.commit）留待后续版本 #0000
+      const action = "dom.fill";
+      const resp = await sendRequest(action, fieldParams, PORT, tabId as number | undefined, effectiveTimeout);
+      results.push({ index: i, ok: !resp.error });
+      if (resp.error) {
+        return {
+          isError: true,
+          content: [{
+            type: "text" as const,
+            text: `field[${i}] failed: [${resp.error.code}] ${resp.error.message}`,
+          }],
+        };
+      }
+    }
+    return withEvents([{
+      type: "text" as const,
+      text: JSON.stringify({ filledCount: results.length }, null, 2),
+    }]);
+  }
+
   // target 翻译：@eN / @fNeM → { index, snapshotId, frameId }
   const target = params.target as string | undefined;
   if (target) {
@@ -338,9 +392,15 @@ async function handleCallTool(
   try {
     const { tabId, returnMode, timeout, ...rest } = params;
     const effectiveTimeout = (timeout as number) ?? DEFAULT_TIMEOUT;
+
+    // dispatch 映射：新工具名 → 正确 action + 参数 reshape
+    const mapped = dispatchNewTool(toolDef.name, rest);
+    const action = mapped ? mapped.action : toolDef.action;
+    const mappedParams = mapped ? mapped.params : rest;
+
     const resp = await sendRequest(
-      toolDef.action,
-      rest,
+      action,
+      mappedParams,
       PORT,
       tabId as number | undefined,
       effectiveTimeout,
@@ -376,7 +436,7 @@ async function handleCallTool(
             : "inline";
 
         if (mode === "file") {
-          const prefix = toolDef.action.replace(/\./g, "-");
+          const prefix = action.replace(/\./g, "-");
           const { path, bytes: savedBytes } = saveBase64Image(result.dataUrl, prefix);
           return withEvents([{
             type: "text" as const,

--- a/packages/mcp/src/tools/dispatch.ts
+++ b/packages/mcp/src/tools/dispatch.ts
@@ -1,0 +1,92 @@
+// packages/mcp/src/tools/dispatch.ts
+// 新工具名 → extension action + 参数 reshape。
+// 与 server.ts 解耦，便于单元测试。
+
+/**
+ * 基于新 MCP tool 名，动态决定发哪个 extension action 以及如何 reshape 参数。
+ * 返回 null 表示该工具直接使用 toolDef.action，无需特殊处理。
+ */
+export function dispatchNewTool(
+  name: string,
+  params: Record<string, unknown>,
+): { action: string; params: Record<string, unknown> } | null {
+  switch (name) {
+    case "vortex_navigate": {
+      const { reload, ...rest } = params;
+      return { action: reload ? "page.reload" : "page.navigate", params: rest };
+    }
+    case "vortex_history": {
+      const { direction, ...rest } = params;
+      return { action: direction === "forward" ? "page.forward" : "page.back", params: rest };
+    }
+    case "vortex_wait": {
+      // target 若是普通 selector（非 @ref），透传为 selector 字段
+      const { target, ...rest } = params;
+      if (target && typeof target === "string" && !target.startsWith("@")) {
+        return { action: "page.wait", params: { selector: target, ...rest } };
+      }
+      return { action: "page.wait", params: { ...rest } };
+    }
+    case "vortex_wait_idle": {
+      const { kind, idleMs, ...rest } = params;
+      const action = kind === "network"
+        ? "page.waitForNetworkIdle"
+        : kind === "dom"
+        ? "dom.waitSettled"
+        : "page.waitForXhrIdle";
+      // idleMs → idleTime（network/xhr）或 quietMs（dom）
+      const idleKey = kind === "dom" ? "quietMs" : "idleTime";
+      return { action, params: idleMs != null ? { [idleKey]: idleMs, ...rest } : rest };
+    }
+    case "vortex_fill": {
+      const { kind, ...rest } = params;
+      return { action: kind ? "dom.commit" : "dom.fill", params: kind ? { kind, ...rest } : rest };
+    }
+    case "vortex_evaluate": {
+      const { async: isAsync, ...rest } = params;
+      return { action: isAsync ? "js.evaluateAsync" : "js.evaluate", params: rest };
+    }
+    case "vortex_screenshot": {
+      // target 已被上层 target-translation 转成 selector/index；存在则截元素
+      const hasTarget = params.selector != null || params.index != null;
+      return { action: hasTarget ? "capture.element" : "capture.screenshot", params };
+    }
+    case "vortex_console": {
+      const { op, ...rest } = params;
+      return { action: op === "clear" ? "console.clear" : "console.getLogs", params: rest };
+    }
+    case "vortex_network": {
+      const { op, filter, ...rest } = params;
+      if (op === "clear") return { action: "network.clear", params: rest };
+      if (filter) return { action: "network.filter", params: { ...(filter as object), ...rest } };
+      return { action: "network.getLogs", params: rest };
+    }
+    case "vortex_storage_get": {
+      const { scope, ...rest } = params;
+      const action = scope === "cookie"
+        ? "storage.getCookies"
+        : scope === "session"
+        ? "storage.getSessionStorage"
+        : "storage.getLocalStorage";
+      return { action, params: rest };
+    }
+    case "vortex_storage_set": {
+      const { scope, op, ...rest } = params;
+      if (op === "delete" && scope === "cookie") return { action: "storage.deleteCookie", params: rest };
+      const action = scope === "cookie"
+        ? "storage.setCookie"
+        : scope === "session"
+        ? "storage.setSessionStorage"
+        : "storage.setLocalStorage";
+      return { action, params: rest };
+    }
+    case "vortex_storage_session": {
+      const { op, ...rest } = params;
+      return { action: op === "import" ? "storage.importSession" : "storage.exportSession", params: rest };
+    }
+    case "vortex_file_list_downloads":
+      return { action: "file.getDownloads", params };
+    default:
+      return null;
+  }
+}

--- a/packages/mcp/src/tools/schemas.ts
+++ b/packages/mcp/src/tools/schemas.ts
@@ -9,13 +9,13 @@ export interface ToolDef {
 }
 
 const optionalTabId = {
-  tabId: { type: "number" as const, description: "Tab ID (omit for active tab)." },
+  tabId: { type: "number" as const, description: "Tab ID (omit = active tab)." },
 };
 
 const optionalFrameRef = {
   frameRef: {
     type: "string" as const,
-    description: "iframe 逃生舱：`@fN`（N 为 frameId）。省略 = 主 frame。",
+    description: "`@fN` frame ref (omit = main frame).",
   },
 };
 
@@ -39,7 +39,7 @@ function diagnosticsTools(): ToolDef[] {
     {
       name: "vortex_ping",
       action: "__mcp_ping__",
-      description: "Call this FIRST. Returns: mcpVersion, extensionVersion, schemaHash, toolCount, tabCount.",
+      description: "Call FIRST. Returns mcpVersion, extensionVersion, schemaHash, toolCount, tabCount.",
       schema: { type: "object", properties: {}, required: [] },
     },
   ];
@@ -50,28 +50,26 @@ function eventsTools(): ToolDef[] {
     {
       name: "vortex_events",
       action: "__mcp_events__",
-      description: "Manage browser event subscriptions. op=subscribe|unsubscribe|drain. Events piggyback on tool responses.",
+      description: "Manage event subscriptions. op=subscribe|unsubscribe|drain. Events piggyback on responses.",
       schema: {
         type: "object",
         properties: {
           op: {
             type: "string",
             enum: ["subscribe", "unsubscribe", "drain"],
-            description: "subscribe: start listening; unsubscribe: cancel by subscriptionId; drain: flush buffered events.",
           },
           types: {
             type: "array",
             items: { type: "string" },
-            description: "Event types (for subscribe). Known: user.switched_tab, dialog.opened, download.completed, console.error, dom.mutated.",
+            description: "Event types. Known: user.switched_tab, dialog.opened, download.completed, console.error, dom.mutated.",
           },
           minLevel: {
             type: "string",
             enum: ["info", "notice", "urgent"],
-            description: "Min event level (for subscribe, default urgent).",
             default: "urgent",
           },
-          tabId: { type: "number", description: "Filter events to this tab (for subscribe)." },
-          subscriptionId: { type: "string", description: "Subscription id (for unsubscribe)." },
+          tabId: { type: "number" },
+          subscriptionId: { type: "string" },
         },
         required: ["op"],
       },
@@ -88,27 +86,25 @@ function observeTools(): ToolDef[] {
     {
       name: "vortex_observe",
       action: "observe.snapshot",
-      description: "Get interactive elements (@eN/@fNeM refs, role, name). Use frames option for iframe pages.",
+      description: "Get interactive elements (@eN/@fNeM refs, role, name). Use frames for iframes.",
       schema: {
         type: "object",
         properties: {
           detail: {
             type: "string",
             enum: ["compact", "full"],
-            description: "compact: Markdown-ish 紧凑文本（默认，省 token）。full: 完整 JSON（调试用）。",
             default: "compact",
           },
           viewport: {
             type: "string",
             enum: ["visible", "full"],
-            description: "visible: only viewport elements (default). full: all interactive elements.",
             default: "visible",
           },
-          maxElements: { type: "number", description: "Max elements per frame (default 200).", default: 200 },
-          includeAX: { type: "boolean", description: "Infer ARIA role (default true).", default: true },
-          includeText: { type: "boolean", description: "Compute accessible name (default true).", default: true },
+          maxElements: { type: "number", default: 200 },
+          includeAX: { type: "boolean", default: true },
+          includeText: { type: "boolean", default: true },
           frames: {
-            description: "Which frames to scan: 'main', 'all-same-origin', 'all-permitted', 'all', or array of frameIds.",
+            description: "'main'|'all-same-origin'|'all-permitted'|'all' or frameId[].",
             oneOf: [
               { type: "string", enum: ["main", "all-same-origin", "all-permitted", "all"] },
               { type: "array", items: { type: "number" } },
@@ -133,13 +129,13 @@ function tabTools(): ToolDef[] {
     {
       name: "vortex_tab_list",
       action: "tab.list",
-      description: "List all open browser tabs with IDs, URLs, and titles.",
+      description: "List open tabs with IDs, URLs, titles.",
       schema: { type: "object", properties: {}, required: [] },
     },
     {
       name: "vortex_tab_create",
       action: "tab.create",
-      description: "Create a new browser tab, optionally navigating to a URL. Activates by default.",
+      description: "Create tab, optionally navigate to URL. Activates by default.",
       schema: {
         type: "object",
         properties: {
@@ -152,7 +148,7 @@ function tabTools(): ToolDef[] {
     {
       name: "vortex_tab_close",
       action: "tab.close",
-      description: "Close a browser tab by its ID.",
+      description: "Close tab by ID.",
       schema: {
         type: "object",
         properties: { tabId: { type: "number" } },
@@ -171,12 +167,12 @@ function pageTools(): ToolDef[] {
     {
       name: "vortex_navigate",
       action: "page.navigate",
-      description: "Navigate to URL (default) or reload current page if reload:true.",
+      description: "Navigate to URL, or reload page if reload:true.",
       schema: {
         type: "object",
         properties: {
-          url: { type: "string", description: "URL to navigate to (omit when reload:true)." },
-          reload: { type: "boolean", description: "Set true to reload current page instead of navigating." },
+          url: { type: "string", description: "URL (omit when reload:true)." },
+          reload: { type: "boolean", description: "Reload current page." },
           waitForLoad: { type: "boolean", default: true },
           timeout: { type: "number", default: 30000 },
           ...optionalTabId,
@@ -187,13 +183,13 @@ function pageTools(): ToolDef[] {
     {
       name: "vortex_page_info",
       action: "page.info",
-      description: "Get current page URL, title, and load status.",
+      description: "Get page URL, title, load status.",
       schema: { type: "object", properties: { ...optionalTabId }, required: [] },
     },
     {
       name: "vortex_history",
       action: "page.back",
-      description: "Go back or forward in browser history. direction: 'back' (default) | 'forward'.",
+      description: "Go back or forward in browser history.",
       schema: {
         type: "object",
         properties: {
@@ -206,11 +202,11 @@ function pageTools(): ToolDef[] {
     {
       name: "vortex_wait",
       action: "page.wait",
-      description: "Wait for a CSS selector to appear, or wait a fixed timeout.",
+      description: "Wait for CSS selector to appear or wait fixed timeout.",
       schema: {
         type: "object",
         properties: {
-          target: { type: "string", description: "CSS selector or @eN ref to wait for." },
+          target: { type: "string", description: "CSS selector or @eN ref." },
           timeout: { type: "number", default: 10000 },
           ...optionalTabId,
           ...optionalFrameId,
@@ -221,7 +217,7 @@ function pageTools(): ToolDef[] {
     {
       name: "vortex_wait_idle",
       action: "page.waitForXhrIdle",
-      description: "Wait for network/XHR/DOM to become idle. kind: 'xhr' (default) | 'network' | 'dom'.",
+      description: "Wait for network/XHR/DOM idle. kind: 'xhr' (default) | 'network' | 'dom'.",
       schema: {
         type: "object",
         properties: {
@@ -229,11 +225,10 @@ function pageTools(): ToolDef[] {
             type: "string",
             enum: ["xhr", "network", "dom"],
             default: "xhr",
-            description: "xhr: XHR/Fetch idle (best for SPAs). network: all network idle. dom: DOM mutation settled.",
           },
-          idleMs: { type: "number", description: "Idle window in ms (default 200 for xhr, 500 for network, 300 for dom)." },
+          idleMs: { type: "number" },
           timeout: { type: "number", default: 10000 },
-          target: { type: "string", description: "CSS selector or @eN ref (for kind=dom)." },
+          target: { type: "string" },
           ...optionalTabId,
         },
         required: [],
@@ -266,7 +261,7 @@ function domTools(): ToolDef[] {
     {
       name: "vortex_type",
       action: "dom.type",
-      description: "Type text character by character into element. Use vortex_fill for faster input.",
+      description: "Type text char-by-char into element. Use vortex_fill for faster input.",
       schema: {
         type: "object",
         properties: {
@@ -282,7 +277,7 @@ function domTools(): ToolDef[] {
     {
       name: "vortex_fill",
       action: "dom.fill",
-      description: "Set field value directly. Use kind for framework components (daterange/datetimerange/cascader/select/checkbox-group → dom.commit).",
+      description: "Set field value directly. Use kind for framework components (daterange/datetimerange/cascader/select/checkbox-group).",
       schema: {
         type: "object",
         properties: {
@@ -291,7 +286,7 @@ function domTools(): ToolDef[] {
           kind: {
             type: "string",
             enum: ["daterange", "datetimerange", "cascader", "select", "checkbox-group"],
-            description: "Omit for plain inputs. Provide for framework components.",
+            description: "Omit for plain inputs.",
           },
           fallbackToNative: { type: "boolean", default: false },
           timeout: { type: "number", default: 8000 },
@@ -304,7 +299,7 @@ function domTools(): ToolDef[] {
     {
       name: "vortex_select",
       action: "dom.select",
-      description: "Select an option in a <select> dropdown by value.",
+      description: "Select option in <select> dropdown by value.",
       schema: {
         type: "object",
         properties: {
@@ -319,7 +314,7 @@ function domTools(): ToolDef[] {
     {
       name: "vortex_hover",
       action: "dom.hover",
-      description: "Move mouse over element to trigger hover effects.",
+      description: "Hover over element to trigger hover effects.",
       schema: {
         type: "object",
         properties: {
@@ -361,7 +356,7 @@ function domTools(): ToolDef[] {
     {
       name: "vortex_fill_form",
       action: "dom.fill",
-      description: "Fill multiple form fields in sequence. Each field: {target, value, kind?}.",
+      description: "Fill multiple form fields. Each: {target, value, kind?}.",
       schema: {
         type: "object",
         properties: {
@@ -389,11 +384,11 @@ function domTools(): ToolDef[] {
     {
       name: "vortex_press",
       action: "keyboard.press",
-      description: "Press a key or keyboard shortcut (e.g. 'Enter', 'Ctrl+S', 'Tab').",
+      description: "Press key or shortcut (e.g. 'Enter', 'Ctrl+S', 'Tab').",
       schema: {
         type: "object",
         properties: {
-          key: { type: "string", description: "Key name or shortcut combo (e.g. 'Enter', 'Ctrl+A')." },
+          key: { type: "string", description: "Key or combo ('Enter', 'Ctrl+A')." },
           ...optionalTabId,
         },
         required: ["key"],
@@ -411,12 +406,12 @@ function contentTools(): ToolDef[] {
     {
       name: "vortex_get_text",
       action: "content.getText",
-      description: "Get visible text from page or element. Use maxBytes to limit size.",
+      description: "Get visible text from page or element.",
       schema: {
         type: "object",
         properties: {
           ...targetRef,
-          maxBytes: { type: "integer", description: "Max chars (default 16KB).", minimum: 4096, maximum: 5242880, default: 16384 },
+          maxBytes: { type: "integer", minimum: 4096, maximum: 5242880, default: 16384 },
           ...optionalTabId,
           ...optionalFrameId,
           ...optionalFrameRef,
@@ -427,12 +422,12 @@ function contentTools(): ToolDef[] {
     {
       name: "vortex_get_html",
       action: "content.getHTML",
-      description: "Get outer HTML from page or element. Use maxBytes to limit size.",
+      description: "Get outer HTML from page or element.",
       schema: {
         type: "object",
         properties: {
           ...targetRef,
-          maxBytes: { type: "integer", description: "Max chars (default 16KB).", minimum: 4096, maximum: 5242880, default: 16384 },
+          maxBytes: { type: "integer", minimum: 4096, maximum: 5242880, default: 16384 },
           ...optionalTabId,
           ...optionalFrameId,
           ...optionalFrameRef,
@@ -452,12 +447,12 @@ function jsTools(): ToolDef[] {
     {
       name: "vortex_evaluate",
       action: "js.evaluate",
-      description: "Execute JavaScript in page context. Set async:true to use await (evaluateAsync).",
+      description: "Execute JavaScript in page context. Set async:true for await support.",
       schema: {
         type: "object",
         properties: {
           code: { type: "string" },
-          async: { type: "boolean", description: "Set true to use js.evaluateAsync (supports await).", default: false },
+          async: { type: "boolean", description: "Use evaluateAsync.", default: false },
           ...optionalTabId,
           ...optionalFrameId,
           ...optionalFrameRef,
@@ -477,15 +472,15 @@ function mouseTools(): ToolDef[] {
     {
       name: "vortex_mouse_click",
       action: "mouse.click",
-      description: "Click at x,y (CDP real mouse events). Use frameId for iframe (x/y are frame-local). clickCount=2 for double-click.",
+      description: "Click at x,y (CDP real mouse). Use frameId for iframe coords. clickCount=2 for double-click.",
       schema: {
         type: "object",
         properties: {
           x: { type: "number" },
           y: { type: "number" },
           button: { type: "string", enum: ["left", "right", "middle"], default: "left" },
-          clickCount: { type: "number", default: 1, description: "1=single, 2=double click." },
-          coordSpace: { type: "string", enum: ["frame", "viewport"], description: "Coordinate space for x/y." },
+          clickCount: { type: "number", default: 1 },
+          coordSpace: { type: "string", enum: ["frame", "viewport"] },
           ...optionalTabId,
           ...optionalFrameId,
         },
@@ -520,7 +515,7 @@ function captureTools(): ToolDef[] {
     {
       name: "vortex_screenshot",
       action: "capture.screenshot",
-      description: "Take screenshot of page or specific element (provide target). returnMode: inline|file.",
+      description: "Screenshot page or element (provide target). returnMode: inline|file.",
       schema: {
         type: "object",
         properties: {
@@ -539,7 +534,6 @@ function captureTools(): ToolDef[] {
           returnMode: {
             type: "string",
             enum: ["inline", "file"],
-            description: "inline: return image (>500KB auto-fallback to file). file: save and return path.",
             default: "inline",
           },
           ...optionalTabId,
@@ -561,7 +555,7 @@ function consoleTools(): ToolDef[] {
     {
       name: "vortex_console",
       action: "console.getLogs",
-      description: "Get or clear console logs. op: 'get' (default) | 'clear'. Filter by level: log|warn|error.",
+      description: "Get or clear console logs. op: 'get' (default) | 'clear'. Filter by level.",
       schema: {
         type: "object",
         properties: {
@@ -580,14 +574,13 @@ function networkTools(): ToolDef[] {
     {
       name: "vortex_network",
       action: "network.getLogs",
-      description: "Get/filter/clear network logs. op: 'get' | 'filter' | 'clear'. get+filter → network.filter.",
+      description: "Get/filter/clear network logs. op: 'get' | 'filter' | 'clear'.",
       schema: {
         type: "object",
         properties: {
           op: { type: "string", enum: ["get", "filter", "clear"], default: "get" },
           filter: {
             type: "object",
-            description: "Filter params for op=filter (url, method, statusMin, statusMax, includeResources).",
             properties: {
               url: { type: "string" },
               method: { type: "string" },
@@ -605,7 +598,7 @@ function networkTools(): ToolDef[] {
     {
       name: "vortex_network_response_body",
       action: "network.getResponseBody",
-      description: "Get full response body of a network request by requestId.",
+      description: "Get response body of network request by requestId.",
       schema: {
         type: "object",
         properties: {
@@ -634,11 +627,10 @@ function storageTools(): ToolDef[] {
           scope: {
             type: "string",
             enum: ["cookie", "local", "session"],
-            description: "cookie: getCookies; local: getLocalStorage; session: getSessionStorage.",
           },
           url: { type: "string" },
           domain: { type: "string" },
-          key: { type: "string", description: "Storage key (for local/session; omit to get all)." },
+          key: { type: "string" },
           ...optionalTabId,
         },
         required: ["scope"],
@@ -647,16 +639,16 @@ function storageTools(): ToolDef[] {
     {
       name: "vortex_storage_set",
       action: "storage.setCookie",
-      description: "Set or delete cookie/localStorage/sessionStorage. scope: 'cookie'|'local'|'session'. op='delete' to remove cookie.",
+      description: "Set/delete cookie/localStorage/sessionStorage. scope: 'cookie'|'local'|'session'.",
       schema: {
         type: "object",
         properties: {
           scope: { type: "string", enum: ["cookie", "local", "session"] },
-          op: { type: "string", enum: ["set", "delete"], default: "set", description: "delete: only for cookies." },
+          op: { type: "string", enum: ["set", "delete"], default: "set" },
           url: { type: "string" },
-          name: { type: "string", description: "Cookie name (for cookie scope)." },
+          name: { type: "string" },
           value: { type: "string" },
-          key: { type: "string", description: "Storage key (for local/session scope)." },
+          key: { type: "string" },
           domain: { type: "string" },
           path: { type: "string" },
           secure: { type: "boolean" },
@@ -676,8 +668,8 @@ function storageTools(): ToolDef[] {
         type: "object",
         properties: {
           op: { type: "string", enum: ["export", "import"] },
-          domain: { type: "string", description: "Domain to export (for op=export)." },
-          data: { type: "object", description: "Session data to restore (for op=import)." },
+          domain: { type: "string" },
+          data: { type: "object" },
           ...optionalTabId,
         },
         required: ["op"],
@@ -695,7 +687,7 @@ function fileTools(): ToolDef[] {
     {
       name: "vortex_file_upload",
       action: "file.upload",
-      description: "Upload a file to a file input element. fileContent must be base64 encoded.",
+      description: "Upload file to input element. fileContent must be base64.",
       schema: {
         type: "object",
         properties: {
@@ -711,7 +703,7 @@ function fileTools(): ToolDef[] {
     {
       name: "vortex_file_download",
       action: "file.download",
-      description: "Trigger a file download by URL.",
+      description: "Trigger file download by URL.",
       schema: {
         type: "object",
         properties: {
@@ -745,7 +737,7 @@ function framesTools(): ToolDef[] {
     {
       name: "vortex_frames_list",
       action: "frames.list",
-      description: "List all frames in the tab. Returns { frameId, url, parentFrameId }.",
+      description: "List frames in tab. Returns { frameId, url, parentFrameId }.",
       schema: { type: "object", properties: { ...optionalTabId }, required: [] },
     },
   ];

--- a/packages/mcp/src/tools/schemas.ts
+++ b/packages/mcp/src/tools/schemas.ts
@@ -23,299 +23,24 @@ const optionalFrameId = {
   frameId: { type: "number" as const, description: "Frame ID for iframes." },
 };
 
-const targetSpec = {
-  index: { type: "number" as const, description: "Observe index (pair with snapshotId)." },
-  snapshotId: { type: "string" as const, description: "Snapshot ID from observe." },
-};
-
-const screenshotReturnMode = {
-  returnMode: {
-    type: "string" as const,
-    enum: ["inline", "file"],
-    description: "inline: return image for AI to see (large images >500KB auto-fallback to file). file: save to /tmp/vortex-screenshots/ and return path (use Read tool to view).",
-    default: "inline",
-  },
-};
-
-const optionalCoordSpace = {
-  coordSpace: {
-    type: "string" as const,
-    enum: ["frame", "viewport"],
-    description: "Coordinate space for x/y. Defaults to 'frame' when frameId is set, else 'viewport'.",
-  },
-};
-
 const targetRef = {
   target: {
     type: "string" as const,
-    description: "`@eN`/`@fNeM` ref or CSS selector. Overrides selector/index.",
+    description: "`@eN`/`@fNeM` ref or CSS selector.",
   },
 };
 
-function tabTools(): ToolDef[] {
-  return [
-    { name: "vortex_tab_list", action: "tab.list", description: "List all open browser tabs with IDs, URLs, and titles.", schema: { type: "object", properties: {}, required: [] } },
-    { name: "vortex_tab_create", action: "tab.create", description: "Create a new browser tab, optionally navigating to a URL.", schema: { type: "object", properties: { url: { type: "string" }, active: { type: "boolean", default: true } }, required: [] } },
-    { name: "vortex_tab_close", action: "tab.close", description: "Close a browser tab by its ID.", schema: { type: "object", properties: { tabId: { type: "number" } }, required: ["tabId"] } },
-    { name: "vortex_tab_activate", action: "tab.activate", description: "Bring a tab to the foreground and focus its window.", schema: { type: "object", properties: { tabId: { type: "number" } }, required: ["tabId"] } },
-    { name: "vortex_tab_get_info", action: "tab.getInfo", description: "Get detailed information about a tab (URL, title, status, favicon).", schema: { type: "object", properties: { ...optionalTabId }, required: [] } },
-  ];
-}
+// ──────────────────────────────────────────────────────────────────────────────
+// 诊断 & 事件（3 个）
+// ──────────────────────────────────────────────────────────────────────────────
 
-function pageTools(): ToolDef[] {
-  return [
-    { name: "vortex_page_navigate", action: "page.navigate", description: "Navigate to a URL and wait for the page to finish loading.", schema: { type: "object", properties: { url: { type: "string" }, waitForLoad: { type: "boolean", default: true }, timeout: { type: "number", default: 30000 }, ...optionalTabId }, required: ["url"] } },
-    { name: "vortex_page_reload", action: "page.reload", description: "Reload the current page.", schema: { type: "object", properties: { ...optionalTabId }, required: [] } },
-    { name: "vortex_page_back", action: "page.back", description: "Go back in browser history.", schema: { type: "object", properties: { ...optionalTabId }, required: [] } },
-    { name: "vortex_page_forward", action: "page.forward", description: "Go forward in browser history.", schema: { type: "object", properties: { ...optionalTabId }, required: [] } },
-    { name: "vortex_page_wait", action: "page.wait", description: "Wait for a CSS selector to appear on the page, or wait for a fixed timeout.", schema: { type: "object", properties: { selector: { type: "string" }, timeout: { type: "number", default: 10000 }, ...optionalTabId, ...optionalFrameId }, required: [] } },
-    { name: "vortex_page_info", action: "page.info", description: "Get the current page URL, title, and load status.", schema: { type: "object", properties: { ...optionalTabId }, required: [] } },
-    { name: "vortex_page_wait_for_network_idle", action: "page.waitForNetworkIdle", description: "Wait for all network requests to complete. Prefer page.wait or page.wait_for_xhr_idle.", schema: { type: "object", properties: { timeout: { type: "number", default: 30000 }, idleTime: { type: "number", default: 500 }, urlPattern: { type: "string" }, requestTypes: { type: "array", items: { type: "string" } }, minRequests: { type: "number", default: 0 }, ...optionalTabId }, required: [] } },
-    { name: "vortex_page_wait_for_xhr_idle", action: "page.waitForXhrIdle", description: "Wait for XHR/Fetch idle. Ignores WebSocket/images/fonts. Better for SPAs than wait_for_network_idle.", schema: { type: "object", properties: { timeout: { type: "number", default: 10000 }, idleTime: { type: "number", default: 200 }, urlPattern: { type: "string" }, minRequests: { type: "number", default: 0 }, ...optionalTabId }, required: [] } },
-  ];
-}
-
-function domTools(): ToolDef[] {
-  return [
-    { name: "vortex_dom_query", action: "dom.query", description: "Find a single element by CSS selector or observe index. Returns tag, text, classes, and attributes.", schema: { type: "object", properties: { selector: { type: "string" }, ...targetRef, ...targetSpec, ...optionalTabId, ...optionalFrameId }, required: [] } },
-    { name: "vortex_dom_query_all", action: "dom.queryAll", description: "Find all elements matching a CSS selector or observe index.", schema: { type: "object", properties: { selector: { type: "string" }, ...targetRef, ...targetSpec, ...optionalTabId, ...optionalFrameId }, required: [] } },
-    { name: "vortex_dom_click", action: "dom.click", description: "Click element by selector or observe index. Prefer index — more stable. Scrolls into view.", schema: { type: "object", properties: { selector: { type: "string" }, useRealMouse: { type: "boolean" }, ...targetRef, ...targetSpec, ...optionalTabId, ...optionalFrameId }, required: [] } },
-    { name: "vortex_dom_type", action: "dom.type", description: "Type text character by character. Use fill for faster input.", schema: { type: "object", properties: { selector: { type: "string" }, text: { type: "string" }, delay: { type: "number" }, ...targetRef, ...targetSpec, ...optionalTabId, ...optionalFrameId }, required: ["text"] } },
-    { name: "vortex_dom_fill", action: "dom.fill", description: "Set form field value directly (faster than type). Use dom.commit for framework components.", schema: { type: "object", properties: { selector: { type: "string" }, value: { type: "string" }, fallbackToNative: { type: "boolean", default: false }, ...targetRef, ...targetSpec, ...optionalTabId, ...optionalFrameId }, required: ["value"] } },
-    { name: "vortex_dom_select", action: "dom.select", description: "Select an option in a dropdown by value.", schema: { type: "object", properties: { selector: { type: "string" }, value: { type: "string" }, ...targetRef, ...targetSpec, ...optionalTabId, ...optionalFrameId }, required: ["value"] } },
-    { name: "vortex_dom_scroll", action: "dom.scroll", description: "Scroll the page or a container element.", schema: { type: "object", properties: { selector: { type: "string" }, container: { type: "string" }, position: { type: "string", enum: ["top", "bottom", "left", "right"] }, x: { type: "number" }, y: { type: "number" }, ...targetRef, ...targetSpec, ...optionalTabId, ...optionalFrameId }, required: [] } },
-    { name: "vortex_dom_hover", action: "dom.hover", description: "Move mouse over an element to trigger hover effects.", schema: { type: "object", properties: { selector: { type: "string" }, ...targetRef, ...targetSpec, ...optionalTabId, ...optionalFrameId }, required: [] } },
-    { name: "vortex_dom_get_attribute", action: "dom.getAttribute", description: "Get a specific HTML attribute value of an element.", schema: { type: "object", properties: { selector: { type: "string" }, attribute: { type: "string" }, ...targetRef, ...targetSpec, ...optionalTabId, ...optionalFrameId }, required: ["attribute"] } },
-    { name: "vortex_dom_get_scroll_info", action: "dom.getScrollInfo", description: "Get scroll position, viewport size, and total scrollable dimensions.", schema: { type: "object", properties: { selector: { type: "string" }, ...targetRef, ...targetSpec, ...optionalTabId, ...optionalFrameId }, required: [] } },
-    { name: "vortex_dom_wait_for_mutation", action: "dom.waitForMutation", description: "Wait for DOM changes on an element. Useful for lazy-loaded content.", schema: { type: "object", properties: { selector: { type: "string" }, timeout: { type: "number", default: 10000 }, ...targetRef, ...targetSpec, ...optionalTabId, ...optionalFrameId }, required: [] } },
-    { name: "vortex_dom_wait_settled", action: "dom.waitSettled", description: "Wait until a DOM subtree has had no mutations for quietMs. Use after filter changes.", schema: { type: "object", properties: { selector: { type: "string" }, quietMs: { type: "number", default: 300 }, timeout: { type: "number", default: 8000 }, ...targetRef, ...targetSpec, ...optionalTabId, ...optionalFrameId }, required: [] } },
-    { name: "vortex_dom_commit", action: "dom.commit", description: "Commit value to framework component (picker/cascader/select/checkbox-group).", schema: { type: "object", properties: { kind: { type: "string", enum: ["daterange", "datetimerange", "cascader", "select", "checkbox-group"] }, value: {}, selector: { type: "string" }, timeout: { type: "number", default: 8000 }, ...targetRef, ...targetSpec, ...optionalTabId, ...optionalFrameId }, required: ["kind", "value"] } },
-    {
-      name: "vortex_dom_watch_mutations",
-      action: "dom.watchMutations",
-      description: "Start reporting DOM mutations as events. Use with events_subscribe. Unwatch when done.",
-      schema: {
-        type: "object",
-        properties: { ...optionalTabId },
-        required: [],
-      },
-    },
-    {
-      name: "vortex_dom_unwatch_mutations",
-      action: "dom.unwatchMutations",
-      description: "Stop DOM mutation reporting.",
-      schema: {
-        type: "object",
-        properties: { ...optionalTabId },
-        required: [],
-      },
-    },
-    {
-      name: "vortex_dom_batch",
-      action: "dom.batch",
-      description: "Execute multiple DOM ops in sequence. Supports selector or index+snapshotId. Rolls back on failure.",
-      schema: {
-        type: "object",
-        properties: {
-          operations: {
-            type: "array",
-            items: {
-              type: "object",
-              properties: {
-                op: { type: "string", enum: ["click", "fill", "type", "select", "scroll", "hover"] },
-                selector: { type: "string" },
-                index: { type: "number" },
-                snapshotId: { type: "string" },
-                value: { type: "string" },
-                delay: { type: "number" },
-                position: { type: "string" },
-              },
-              required: ["op"],
-            },
-          },
-          rollbackOnFailure: { type: "boolean", default: true },
-          ...optionalTabId,
-          ...optionalFrameId,
-        },
-        required: ["operations"],
-      },
-    },
-  ];
-}
-
-function contentTools(): ToolDef[] {
-  return [
-    { name: "vortex_content_get_text", action: "content.getText", description: "Get visible text from page or element. Use maxBytes to limit response size.", schema: { type: "object", properties: { selector: { type: "string" }, maxBytes: { type: "integer", description: "Max characters (4096-5242880, default 16KB)", minimum: 4096, maximum: 5242880, default: 16384 }, ...optionalTabId, ...optionalFrameId, ...optionalFrameRef }, required: [] } },
-    { name: "vortex_content_get_html", action: "content.getHTML", description: "Get outer HTML from page or element. Use maxBytes to limit response size.", schema: { type: "object", properties: { selector: { type: "string" }, maxBytes: { type: "integer", description: "Max characters (4096-5242880, default 16KB)", minimum: 4096, maximum: 5242880, default: 16384 }, ...optionalTabId, ...optionalFrameId, ...optionalFrameRef }, required: [] } },
-    { name: "vortex_content_get_accessibility_tree", action: "content.getAccessibilityTree", description: "Get the accessibility tree of the page.", schema: { type: "object", properties: { ...optionalTabId, ...optionalFrameId }, required: [] } },
-    { name: "vortex_content_get_element_text", action: "content.getElementText", description: "Get the text content of a specific element.", schema: { type: "object", properties: { selector: { type: "string" }, ...targetRef, ...optionalTabId, ...optionalFrameId }, required: ["selector"] } },
-    { name: "vortex_content_get_computed_style", action: "content.getComputedStyle", description: "Get computed CSS properties of an element.", schema: { type: "object", properties: { selector: { type: "string" }, ...targetRef, properties: { type: "array", items: { type: "string" } }, ...optionalTabId, ...optionalFrameId }, required: ["selector"] } },
-  ];
-}
-
-function jsTools(): ToolDef[] {
-  return [
-    { name: "vortex_js_evaluate", action: "js.evaluate", description: "Execute JavaScript in the page context.", schema: { type: "object", properties: { code: { type: "string" }, ...optionalTabId, ...optionalFrameId, ...optionalFrameRef }, required: ["code"] } },
-    { name: "vortex_js_evaluate_async", action: "js.evaluateAsync", description: "Execute async JavaScript (can use await).", schema: { type: "object", properties: { code: { type: "string" }, ...optionalTabId, ...optionalFrameId, ...optionalFrameRef }, required: ["code"] } },
-    { name: "vortex_js_call_function", action: "js.callFunction", description: "Call a named function on the page with arguments.", schema: { type: "object", properties: { name: { type: "string" }, args: { type: "array", items: {} }, ...optionalTabId, ...optionalFrameId }, required: ["name"] } },
-  ];
-}
-
-function keyboardTools(): ToolDef[] {
-  return [
-    { name: "vortex_keyboard_press", action: "keyboard.press", description: "Press and release a key.", schema: { type: "object", properties: { key: { type: "string" }, ...optionalTabId }, required: ["key"] } },
-    { name: "vortex_keyboard_shortcut", action: "keyboard.shortcut", description: "Press a keyboard shortcut (modifier + key).", schema: { type: "object", properties: { keys: { type: "array", items: { type: "string" } }, ...optionalTabId }, required: ["keys"] } },
-  ];
-}
-
-function mouseTools(): ToolDef[] {
+function diagnosticsTools(): ToolDef[] {
   return [
     {
-      name: "vortex_mouse_click",
-      action: "mouse.click",
-      description: "Click at x,y (CDP real mouse events). Use frameId for iframe (x/y are frame-local).",
-      schema: {
-        type: "object",
-        properties: {
-          x: { type: "number" },
-          y: { type: "number" },
-          button: { type: "string", enum: ["left", "right", "middle"], default: "left" },
-          ...optionalTabId,
-          ...optionalFrameId,
-          ...optionalCoordSpace,
-        },
-        required: ["x", "y"],
-      },
-    },
-    {
-      name: "vortex_mouse_double_click",
-      action: "mouse.doubleClick",
-      description: "Double-click at x,y using CDP real mouse events.",
-      schema: {
-        type: "object",
-        properties: {
-          x: { type: "number" },
-          y: { type: "number" },
-          ...optionalTabId,
-          ...optionalFrameId,
-          ...optionalCoordSpace,
-        },
-        required: ["x", "y"],
-      },
-    },
-    {
-      name: "vortex_mouse_move",
-      action: "mouse.move",
-      description: "Move mouse to x,y.",
-      schema: {
-        type: "object",
-        properties: {
-          x: { type: "number" },
-          y: { type: "number" },
-          ...optionalTabId,
-          ...optionalFrameId,
-          ...optionalCoordSpace,
-        },
-        required: ["x", "y"],
-      },
-    },
-  ];
-}
-
-function captureTools(): ToolDef[] {
-  return [
-    { name: "vortex_capture_screenshot", action: "capture.screenshot", description: "Take a screenshot of the visible page area. Large images (>500KB) auto-save to file.", schema: { type: "object", properties: { format: { type: "string", enum: ["png", "jpeg"], default: "png" }, fullPage: { type: "boolean" }, clip: { type: "object", properties: { x: { type: "number" }, y: { type: "number" }, width: { type: "number" }, height: { type: "number" } } }, ...screenshotReturnMode, ...optionalTabId, ...optionalFrameRef }, required: [] }, returnsImage: true },
-    { name: "vortex_capture_element", action: "capture.element", description: "Take a screenshot of a specific element.", schema: { type: "object", properties: { selector: { type: "string" }, ...targetRef, ...screenshotReturnMode, ...optionalTabId, ...optionalFrameId }, required: ["selector"] }, returnsImage: true },
-    { name: "vortex_capture_gif_start", action: "capture.gifStart", description: "Start collecting GIF frames.", schema: { type: "object", properties: { fps: { type: "number", default: 2 }, ...optionalTabId }, required: [] } },
-    { name: "vortex_capture_gif_frame", action: "capture.gifFrame", description: "Manually capture a GIF frame.", schema: { type: "object", properties: { ...optionalTabId }, required: [] } },
-    { name: "vortex_capture_gif_stop", action: "capture.gifStop", description: "Stop GIF recording and return collected frames.", schema: { type: "object", properties: {}, required: [] } },
-  ];
-}
-
-function consoleTools(): ToolDef[] {
-  return [
-    { name: "vortex_console_get_logs", action: "console.getLogs", description: "Get console log messages.", schema: { type: "object", properties: { level: { type: "string", enum: ["log", "warn", "error"] }, ...optionalTabId }, required: [] } },
-    { name: "vortex_console_get_errors", action: "console.getErrors", description: "Get console error messages.", schema: { type: "object", properties: { ...optionalTabId }, required: [] } },
-    { name: "vortex_console_clear", action: "console.clear", description: "Clear cached console logs.", schema: { type: "object", properties: { ...optionalTabId }, required: [] } },
-  ];
-}
-
-function networkTools(): ToolDef[] {
-  return [
-    { name: "vortex_network_get_logs", action: "network.getLogs", description: "Get network request logs (URL, method, status, timing). Auto-subscribes on first call.", schema: { type: "object", properties: { includeResources: { type: "boolean" }, ...optionalTabId }, required: [] } },
-    { name: "vortex_network_get_errors", action: "network.getErrors", description: "Get failed network requests (HTTP status >= 400 or connection errors).", schema: { type: "object", properties: { includeResources: { type: "boolean" }, ...optionalTabId }, required: [] } },
-    { name: "vortex_network_filter", action: "network.filter", description: "Filter network logs by URL pattern, method, or status code range.", schema: { type: "object", properties: { url: { type: "string" }, method: { type: "string" }, statusMin: { type: "number" }, statusMax: { type: "number" }, includeResources: { type: "boolean" }, ...optionalTabId }, required: [] } },
-    { name: "vortex_network_get_response_body", action: "network.getResponseBody", description: "Get the full response body of a network request.", schema: { type: "object", properties: { requestId: { type: "string" }, ...optionalTabId }, required: ["requestId"] } },
-    { name: "vortex_network_clear", action: "network.clear", description: "Clear cached network logs.", schema: { type: "object", properties: { ...optionalTabId }, required: [] } },
-  ];
-}
-
-function storageTools(): ToolDef[] {
-  return [
-    { name: "vortex_storage_get_cookies", action: "storage.getCookies", description: "Get browser cookies, optionally filtered by URL or domain.", schema: { type: "object", properties: { url: { type: "string" }, domain: { type: "string" }, ...optionalTabId }, required: [] } },
-    { name: "vortex_storage_set_cookie", action: "storage.setCookie", description: "Set a browser cookie.", schema: { type: "object", properties: { url: { type: "string" }, name: { type: "string" }, value: { type: "string" }, domain: { type: "string" }, path: { type: "string" }, secure: { type: "boolean" }, httpOnly: { type: "boolean" }, expirationDate: { type: "number" }, sameSite: { type: "string" } }, required: ["url", "name"] } },
-    { name: "vortex_storage_delete_cookie", action: "storage.deleteCookie", description: "Delete a browser cookie.", schema: { type: "object", properties: { url: { type: "string" }, name: { type: "string" } }, required: ["url", "name"] } },
-    { name: "vortex_storage_get_local_storage", action: "storage.getLocalStorage", description: "Read localStorage values. Omit key to get all.", schema: { type: "object", properties: { key: { type: "string" }, ...optionalTabId }, required: [] } },
-    { name: "vortex_storage_set_local_storage", action: "storage.setLocalStorage", description: "Set a localStorage key-value pair.", schema: { type: "object", properties: { key: { type: "string" }, value: { type: "string" }, ...optionalTabId }, required: ["key", "value"] } },
-    { name: "vortex_storage_get_session_storage", action: "storage.getSessionStorage", description: "Read sessionStorage values.", schema: { type: "object", properties: { key: { type: "string" }, ...optionalTabId }, required: [] } },
-    { name: "vortex_storage_set_session_storage", action: "storage.setSessionStorage", description: "Set a sessionStorage key-value pair.", schema: { type: "object", properties: { key: { type: "string" }, value: { type: "string" }, ...optionalTabId }, required: ["key", "value"] } },
-    {
-      name: "vortex_storage_export_session",
-      action: "storage.exportSession",
-      description: "Export cookies, localStorage, sessionStorage for a domain as JSON.",
-      schema: {
-        type: "object",
-        properties: {
-          domain: { type: "string" },
-          ...optionalTabId,
-        },
-        required: ["domain"],
-      },
-    },
-    {
-      name: "vortex_storage_import_session",
-      action: "storage.importSession",
-      description: "Restore cookies and storage from a previously exported session JSON.",
-      schema: {
-        type: "object",
-        properties: {
-          data: { type: "object" },
-          ...optionalTabId,
-        },
-        required: ["data"],
-      },
-    },
-  ];
-}
-
-function fileTools(): ToolDef[] {
-  return [
-    { name: "vortex_file_upload", action: "file.upload", description: "Upload a file to a file input element. File content must be base64 encoded.", schema: { type: "object", properties: { selector: { type: "string" }, fileName: { type: "string" }, fileContent: { type: "string" }, mimeType: { type: "string" }, ...optionalTabId }, required: ["selector", "fileName", "fileContent"] } },
-    { name: "vortex_file_download", action: "file.download", description: "Trigger a file download by URL.", schema: { type: "object", properties: { url: { type: "string" }, filename: { type: "string" } }, required: ["url"] } },
-    { name: "vortex_file_get_downloads", action: "file.getDownloads", description: "List recent downloads.", schema: { type: "object", properties: { limit: { type: "number", default: 20 } }, required: [] } },
-  ];
-}
-
-function framesTools(): ToolDef[] {
-  return [
-    {
-      name: "vortex_frames_list",
-      action: "frames.list",
-      description: "List all frames in the tab. Returns { frameId, url, parentFrameId }.",
-      schema: { type: "object", properties: { ...optionalTabId }, required: [] },
-    },
-    {
-      name: "vortex_frames_find",
-      action: "frames.find",
-      description: "Find a frame by URL substring. Returns frameId or null.",
-      schema: {
-        type: "object",
-        properties: {
-          urlPattern: { type: "string" },
-          ...optionalTabId,
-        },
-        required: ["urlPattern"],
-      },
+      name: "vortex_ping",
+      action: "__mcp_ping__",
+      description: "Call this FIRST. Returns: mcpVersion, extensionVersion, schemaHash, toolCount, tabCount.",
+      schema: { type: "object", properties: {}, required: [] },
     },
   ];
 }
@@ -323,95 +48,65 @@ function framesTools(): ToolDef[] {
 function eventsTools(): ToolDef[] {
   return [
     {
-      name: "vortex_events_subscribe",
-      action: "__mcp_events_subscribe__",
-      description: "Subscribe to browser events. Events piggyback on tool responses.",
+      name: "vortex_events",
+      action: "__mcp_events__",
+      description: "Manage browser event subscriptions. op=subscribe|unsubscribe|drain. Events piggyback on tool responses.",
       schema: {
         type: "object",
         properties: {
+          op: {
+            type: "string",
+            enum: ["subscribe", "unsubscribe", "drain"],
+            description: "subscribe: start listening; unsubscribe: cancel by subscriptionId; drain: flush buffered events.",
+          },
           types: {
             type: "array",
             items: { type: "string" },
-            description: "Event types to subscribe. Known: user.switched_tab, dialog.opened, download.completed, console.error, dom.mutated.",
+            description: "Event types (for subscribe). Known: user.switched_tab, dialog.opened, download.completed, console.error, dom.mutated.",
           },
           minLevel: {
             type: "string",
             enum: ["info", "notice", "urgent"],
-            description: "Min event level (default urgent).",
+            description: "Min event level (for subscribe, default urgent).",
             default: "urgent",
           },
-          tabId: {
-            type: "number",
-            description: "Filter events to this tab only.",
-          },
+          tabId: { type: "number", description: "Filter events to this tab (for subscribe)." },
+          subscriptionId: { type: "string", description: "Subscription id (for unsubscribe)." },
         },
-        required: [],
-      },
-    },
-    {
-      name: "vortex_events_unsubscribe",
-      action: "__mcp_events_unsubscribe__",
-      description: "Cancel an event subscription.",
-      schema: {
-        type: "object",
-        properties: {
-          subscriptionId: {
-            type: "string",
-            description: "Subscription id from events_subscribe.",
-          },
-        },
-        required: ["subscriptionId"],
-      },
-    },
-    {
-      name: "vortex_events_drain",
-      action: "__mcp_events_drain__",
-      description: "Force-flush event dispatcher. Returns buffered events inline.",
-      schema: {
-        type: "object",
-        properties: {},
-        required: [],
+        required: ["op"],
       },
     },
   ];
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Observe（1 个）
+// ──────────────────────────────────────────────────────────────────────────────
 
 function observeTools(): ToolDef[] {
   return [
     {
       name: "vortex_observe",
       action: "observe.snapshot",
-      description: "Get interactive elements (index, role, name, frameId). Use frames option for iframe pages.",
+      description: "Get interactive elements (@eN/@fNeM refs, role, name). Use frames option for iframe pages.",
       schema: {
         type: "object",
         properties: {
           detail: {
             type: "string",
             enum: ["compact", "full"],
-            description: "compact: Markdown-ish 紧凑文本，仅含可交互元素的 @eN/@fNeM ref（默认，省 token）。full: 完整 JSON，含 bbox/attrs/suggestedUsage（调试用）。",
+            description: "compact: Markdown-ish 紧凑文本（默认，省 token）。full: 完整 JSON（调试用）。",
             default: "compact",
           },
           viewport: {
             type: "string",
             enum: ["visible", "full"],
-            description: "visible: only viewport elements. full: all interactive elements.",
+            description: "visible: only viewport elements (default). full: all interactive elements.",
             default: "visible",
           },
-          maxElements: {
-            type: "number",
-            description: "Max elements per frame (default 200).",
-            default: 200,
-          },
-          includeAX: {
-            type: "boolean",
-            description: "Infer ARIA role (default true).",
-            default: true,
-          },
-          includeText: {
-            type: "boolean",
-            description: "Compute accessible name (default true).",
-            default: true,
-          },
+          maxElements: { type: "number", description: "Max elements per frame (default 200).", default: 200 },
+          includeAX: { type: "boolean", description: "Infer ARIA role (default true).", default: true },
+          includeText: { type: "boolean", description: "Compute accessible name (default true).", default: true },
           frames: {
             description: "Which frames to scan: 'main', 'all-same-origin', 'all-permitted', 'all', or array of frameIds.",
             oneOf: [
@@ -429,16 +124,636 @@ function observeTools(): ToolDef[] {
   ];
 }
 
-function diagnosticsTools(): ToolDef[] {
+// ──────────────────────────────────────────────────────────────────────────────
+// Tab（3 个）
+// ──────────────────────────────────────────────────────────────────────────────
+
+function tabTools(): ToolDef[] {
   return [
     {
-      name: "vortex_ping",
-      action: "__mcp_ping__",
-      description: "Call this FIRST. Returns: mcpVersion, extensionVersion, schemaHash, toolCount, tabCount.",
+      name: "vortex_tab_list",
+      action: "tab.list",
+      description: "List all open browser tabs with IDs, URLs, and titles.",
       schema: { type: "object", properties: {}, required: [] },
+    },
+    {
+      name: "vortex_tab_create",
+      action: "tab.create",
+      description: "Create a new browser tab, optionally navigating to a URL. Activates by default.",
+      schema: {
+        type: "object",
+        properties: {
+          url: { type: "string" },
+          active: { type: "boolean", default: true },
+        },
+        required: [],
+      },
+    },
+    {
+      name: "vortex_tab_close",
+      action: "tab.close",
+      description: "Close a browser tab by its ID.",
+      schema: {
+        type: "object",
+        properties: { tabId: { type: "number" } },
+        required: ["tabId"],
+      },
     },
   ];
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Page（5 个）
+// ──────────────────────────────────────────────────────────────────────────────
+
+function pageTools(): ToolDef[] {
+  return [
+    {
+      name: "vortex_navigate",
+      action: "page.navigate",
+      description: "Navigate to URL (default) or reload current page if reload:true.",
+      schema: {
+        type: "object",
+        properties: {
+          url: { type: "string", description: "URL to navigate to (omit when reload:true)." },
+          reload: { type: "boolean", description: "Set true to reload current page instead of navigating." },
+          waitForLoad: { type: "boolean", default: true },
+          timeout: { type: "number", default: 30000 },
+          ...optionalTabId,
+        },
+        required: [],
+      },
+    },
+    {
+      name: "vortex_page_info",
+      action: "page.info",
+      description: "Get current page URL, title, and load status.",
+      schema: { type: "object", properties: { ...optionalTabId }, required: [] },
+    },
+    {
+      name: "vortex_history",
+      action: "page.back",
+      description: "Go back or forward in browser history. direction: 'back' (default) | 'forward'.",
+      schema: {
+        type: "object",
+        properties: {
+          direction: { type: "string", enum: ["back", "forward"], default: "back" },
+          ...optionalTabId,
+        },
+        required: [],
+      },
+    },
+    {
+      name: "vortex_wait",
+      action: "page.wait",
+      description: "Wait for a CSS selector to appear, or wait a fixed timeout.",
+      schema: {
+        type: "object",
+        properties: {
+          target: { type: "string", description: "CSS selector or @eN ref to wait for." },
+          timeout: { type: "number", default: 10000 },
+          ...optionalTabId,
+          ...optionalFrameId,
+        },
+        required: [],
+      },
+    },
+    {
+      name: "vortex_wait_idle",
+      action: "page.waitForXhrIdle",
+      description: "Wait for network/XHR/DOM to become idle. kind: 'xhr' (default) | 'network' | 'dom'.",
+      schema: {
+        type: "object",
+        properties: {
+          kind: {
+            type: "string",
+            enum: ["xhr", "network", "dom"],
+            default: "xhr",
+            description: "xhr: XHR/Fetch idle (best for SPAs). network: all network idle. dom: DOM mutation settled.",
+          },
+          idleMs: { type: "number", description: "Idle window in ms (default 200 for xhr, 500 for network, 300 for dom)." },
+          timeout: { type: "number", default: 10000 },
+          target: { type: "string", description: "CSS selector or @eN ref (for kind=dom)." },
+          ...optionalTabId,
+        },
+        required: [],
+      },
+    },
+  ];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// DOM 交互（8 个）
+// ──────────────────────────────────────────────────────────────────────────────
+
+function domTools(): ToolDef[] {
+  return [
+    {
+      name: "vortex_click",
+      action: "dom.click",
+      description: "Click element by @eN ref or selector. Scrolls into view.",
+      schema: {
+        type: "object",
+        properties: {
+          ...targetRef,
+          useRealMouse: { type: "boolean" },
+          ...optionalTabId,
+          ...optionalFrameId,
+        },
+        required: [],
+      },
+    },
+    {
+      name: "vortex_type",
+      action: "dom.type",
+      description: "Type text character by character into element. Use vortex_fill for faster input.",
+      schema: {
+        type: "object",
+        properties: {
+          ...targetRef,
+          text: { type: "string" },
+          delay: { type: "number" },
+          ...optionalTabId,
+          ...optionalFrameId,
+        },
+        required: ["text"],
+      },
+    },
+    {
+      name: "vortex_fill",
+      action: "dom.fill",
+      description: "Set field value directly. Use kind for framework components (daterange/datetimerange/cascader/select/checkbox-group → dom.commit).",
+      schema: {
+        type: "object",
+        properties: {
+          ...targetRef,
+          value: {},
+          kind: {
+            type: "string",
+            enum: ["daterange", "datetimerange", "cascader", "select", "checkbox-group"],
+            description: "Omit for plain inputs. Provide for framework components.",
+          },
+          fallbackToNative: { type: "boolean", default: false },
+          timeout: { type: "number", default: 8000 },
+          ...optionalTabId,
+          ...optionalFrameId,
+        },
+        required: ["value"],
+      },
+    },
+    {
+      name: "vortex_select",
+      action: "dom.select",
+      description: "Select an option in a <select> dropdown by value.",
+      schema: {
+        type: "object",
+        properties: {
+          ...targetRef,
+          value: { type: "string" },
+          ...optionalTabId,
+          ...optionalFrameId,
+        },
+        required: ["value"],
+      },
+    },
+    {
+      name: "vortex_hover",
+      action: "dom.hover",
+      description: "Move mouse over element to trigger hover effects.",
+      schema: {
+        type: "object",
+        properties: {
+          ...targetRef,
+          ...optionalTabId,
+          ...optionalFrameId,
+        },
+        required: [],
+      },
+    },
+    {
+      name: "vortex_batch",
+      action: "dom.batch",
+      description: "Execute multiple DOM ops in sequence. Rolls back on failure.",
+      schema: {
+        type: "object",
+        properties: {
+          operations: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                op: { type: "string", enum: ["click", "fill", "type", "select", "scroll", "hover"] },
+                target: { type: "string", description: "@eN ref or CSS selector." },
+                value: { type: "string" },
+                delay: { type: "number" },
+                position: { type: "string" },
+              },
+              required: ["op"],
+            },
+          },
+          rollbackOnFailure: { type: "boolean", default: true },
+          ...optionalTabId,
+          ...optionalFrameId,
+        },
+        required: ["operations"],
+      },
+    },
+    {
+      name: "vortex_fill_form",
+      action: "dom.fill",
+      description: "Fill multiple form fields in sequence. Each field: {target, value, kind?}.",
+      schema: {
+        type: "object",
+        properties: {
+          fields: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                target: { type: "string", description: "@eN ref or CSS selector." },
+                value: {},
+                kind: {
+                  type: "string",
+                  enum: ["daterange", "datetimerange", "cascader", "select", "checkbox-group"],
+                },
+              },
+              required: ["value"],
+            },
+          },
+          ...optionalTabId,
+          ...optionalFrameId,
+        },
+        required: ["fields"],
+      },
+    },
+    {
+      name: "vortex_press",
+      action: "keyboard.press",
+      description: "Press a key or keyboard shortcut (e.g. 'Enter', 'Ctrl+S', 'Tab').",
+      schema: {
+        type: "object",
+        properties: {
+          key: { type: "string", description: "Key name or shortcut combo (e.g. 'Enter', 'Ctrl+A')." },
+          ...optionalTabId,
+        },
+        required: ["key"],
+      },
+    },
+  ];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Content（2 个）
+// ──────────────────────────────────────────────────────────────────────────────
+
+function contentTools(): ToolDef[] {
+  return [
+    {
+      name: "vortex_get_text",
+      action: "content.getText",
+      description: "Get visible text from page or element. Use maxBytes to limit size.",
+      schema: {
+        type: "object",
+        properties: {
+          ...targetRef,
+          maxBytes: { type: "integer", description: "Max chars (default 16KB).", minimum: 4096, maximum: 5242880, default: 16384 },
+          ...optionalTabId,
+          ...optionalFrameId,
+          ...optionalFrameRef,
+        },
+        required: [],
+      },
+    },
+    {
+      name: "vortex_get_html",
+      action: "content.getHTML",
+      description: "Get outer HTML from page or element. Use maxBytes to limit size.",
+      schema: {
+        type: "object",
+        properties: {
+          ...targetRef,
+          maxBytes: { type: "integer", description: "Max chars (default 16KB).", minimum: 4096, maximum: 5242880, default: 16384 },
+          ...optionalTabId,
+          ...optionalFrameId,
+          ...optionalFrameRef,
+        },
+        required: [],
+      },
+    },
+  ];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// JS 执行（1 个）
+// ──────────────────────────────────────────────────────────────────────────────
+
+function jsTools(): ToolDef[] {
+  return [
+    {
+      name: "vortex_evaluate",
+      action: "js.evaluate",
+      description: "Execute JavaScript in page context. Set async:true to use await (evaluateAsync).",
+      schema: {
+        type: "object",
+        properties: {
+          code: { type: "string" },
+          async: { type: "boolean", description: "Set true to use js.evaluateAsync (supports await).", default: false },
+          ...optionalTabId,
+          ...optionalFrameId,
+          ...optionalFrameRef,
+        },
+        required: ["code"],
+      },
+    },
+  ];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 鼠标（2 个）
+// ──────────────────────────────────────────────────────────────────────────────
+
+function mouseTools(): ToolDef[] {
+  return [
+    {
+      name: "vortex_mouse_click",
+      action: "mouse.click",
+      description: "Click at x,y (CDP real mouse events). Use frameId for iframe (x/y are frame-local). clickCount=2 for double-click.",
+      schema: {
+        type: "object",
+        properties: {
+          x: { type: "number" },
+          y: { type: "number" },
+          button: { type: "string", enum: ["left", "right", "middle"], default: "left" },
+          clickCount: { type: "number", default: 1, description: "1=single, 2=double click." },
+          coordSpace: { type: "string", enum: ["frame", "viewport"], description: "Coordinate space for x/y." },
+          ...optionalTabId,
+          ...optionalFrameId,
+        },
+        required: ["x", "y"],
+      },
+    },
+    {
+      name: "vortex_mouse_move",
+      action: "mouse.move",
+      description: "Move mouse to x,y.",
+      schema: {
+        type: "object",
+        properties: {
+          x: { type: "number" },
+          y: { type: "number" },
+          coordSpace: { type: "string", enum: ["frame", "viewport"] },
+          ...optionalTabId,
+          ...optionalFrameId,
+        },
+        required: ["x", "y"],
+      },
+    },
+  ];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 截图（1 个）
+// ──────────────────────────────────────────────────────────────────────────────
+
+function captureTools(): ToolDef[] {
+  return [
+    {
+      name: "vortex_screenshot",
+      action: "capture.screenshot",
+      description: "Take screenshot of page or specific element (provide target). returnMode: inline|file.",
+      schema: {
+        type: "object",
+        properties: {
+          ...targetRef,
+          format: { type: "string", enum: ["png", "jpeg"], default: "png" },
+          fullPage: { type: "boolean" },
+          clip: {
+            type: "object",
+            properties: {
+              x: { type: "number" },
+              y: { type: "number" },
+              width: { type: "number" },
+              height: { type: "number" },
+            },
+          },
+          returnMode: {
+            type: "string",
+            enum: ["inline", "file"],
+            description: "inline: return image (>500KB auto-fallback to file). file: save and return path.",
+            default: "inline",
+          },
+          ...optionalTabId,
+          ...optionalFrameRef,
+        },
+        required: [],
+      },
+      returnsImage: true,
+    },
+  ];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Console & Network（2 个）
+// ──────────────────────────────────────────────────────────────────────────────
+
+function consoleTools(): ToolDef[] {
+  return [
+    {
+      name: "vortex_console",
+      action: "console.getLogs",
+      description: "Get or clear console logs. op: 'get' (default) | 'clear'. Filter by level: log|warn|error.",
+      schema: {
+        type: "object",
+        properties: {
+          op: { type: "string", enum: ["get", "clear"], default: "get" },
+          level: { type: "string", enum: ["log", "warn", "error"] },
+          ...optionalTabId,
+        },
+        required: [],
+      },
+    },
+  ];
+}
+
+function networkTools(): ToolDef[] {
+  return [
+    {
+      name: "vortex_network",
+      action: "network.getLogs",
+      description: "Get/filter/clear network logs. op: 'get' | 'filter' | 'clear'. get+filter → network.filter.",
+      schema: {
+        type: "object",
+        properties: {
+          op: { type: "string", enum: ["get", "filter", "clear"], default: "get" },
+          filter: {
+            type: "object",
+            description: "Filter params for op=filter (url, method, statusMin, statusMax, includeResources).",
+            properties: {
+              url: { type: "string" },
+              method: { type: "string" },
+              statusMin: { type: "number" },
+              statusMax: { type: "number" },
+              includeResources: { type: "boolean" },
+            },
+          },
+          includeResources: { type: "boolean" },
+          ...optionalTabId,
+        },
+        required: [],
+      },
+    },
+    {
+      name: "vortex_network_response_body",
+      action: "network.getResponseBody",
+      description: "Get full response body of a network request by requestId.",
+      schema: {
+        type: "object",
+        properties: {
+          requestId: { type: "string" },
+          ...optionalTabId,
+        },
+        required: ["requestId"],
+      },
+    },
+  ];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Storage（3 个）
+// ──────────────────────────────────────────────────────────────────────────────
+
+function storageTools(): ToolDef[] {
+  return [
+    {
+      name: "vortex_storage_get",
+      action: "storage.getCookies",
+      description: "Read cookies/localStorage/sessionStorage. scope: 'cookie' | 'local' | 'session'.",
+      schema: {
+        type: "object",
+        properties: {
+          scope: {
+            type: "string",
+            enum: ["cookie", "local", "session"],
+            description: "cookie: getCookies; local: getLocalStorage; session: getSessionStorage.",
+          },
+          url: { type: "string" },
+          domain: { type: "string" },
+          key: { type: "string", description: "Storage key (for local/session; omit to get all)." },
+          ...optionalTabId,
+        },
+        required: ["scope"],
+      },
+    },
+    {
+      name: "vortex_storage_set",
+      action: "storage.setCookie",
+      description: "Set or delete cookie/localStorage/sessionStorage. scope: 'cookie'|'local'|'session'. op='delete' to remove cookie.",
+      schema: {
+        type: "object",
+        properties: {
+          scope: { type: "string", enum: ["cookie", "local", "session"] },
+          op: { type: "string", enum: ["set", "delete"], default: "set", description: "delete: only for cookies." },
+          url: { type: "string" },
+          name: { type: "string", description: "Cookie name (for cookie scope)." },
+          value: { type: "string" },
+          key: { type: "string", description: "Storage key (for local/session scope)." },
+          domain: { type: "string" },
+          path: { type: "string" },
+          secure: { type: "boolean" },
+          httpOnly: { type: "boolean" },
+          expirationDate: { type: "number" },
+          sameSite: { type: "string" },
+          ...optionalTabId,
+        },
+        required: ["scope"],
+      },
+    },
+    {
+      name: "vortex_storage_session",
+      action: "storage.exportSession",
+      description: "Export or import full session (cookies + storage). op: 'export' | 'import'.",
+      schema: {
+        type: "object",
+        properties: {
+          op: { type: "string", enum: ["export", "import"] },
+          domain: { type: "string", description: "Domain to export (for op=export)." },
+          data: { type: "object", description: "Session data to restore (for op=import)." },
+          ...optionalTabId,
+        },
+        required: ["op"],
+      },
+    },
+  ];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// File（3 个）
+// ──────────────────────────────────────────────────────────────────────────────
+
+function fileTools(): ToolDef[] {
+  return [
+    {
+      name: "vortex_file_upload",
+      action: "file.upload",
+      description: "Upload a file to a file input element. fileContent must be base64 encoded.",
+      schema: {
+        type: "object",
+        properties: {
+          selector: { type: "string" },
+          fileName: { type: "string" },
+          fileContent: { type: "string" },
+          mimeType: { type: "string" },
+          ...optionalTabId,
+        },
+        required: ["selector", "fileName", "fileContent"],
+      },
+    },
+    {
+      name: "vortex_file_download",
+      action: "file.download",
+      description: "Trigger a file download by URL.",
+      schema: {
+        type: "object",
+        properties: {
+          url: { type: "string" },
+          filename: { type: "string" },
+        },
+        required: ["url"],
+      },
+    },
+    {
+      name: "vortex_file_list_downloads",
+      action: "file.getDownloads",
+      description: "List recent file downloads.",
+      schema: {
+        type: "object",
+        properties: {
+          limit: { type: "number", default: 20 },
+        },
+        required: [],
+      },
+    },
+  ];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Frames（1 个）
+// ──────────────────────────────────────────────────────────────────────────────
+
+function framesTools(): ToolDef[] {
+  return [
+    {
+      name: "vortex_frames_list",
+      action: "frames.list",
+      description: "List all frames in the tab. Returns { frameId, url, parentFrameId }.",
+      schema: { type: "object", properties: { ...optionalTabId }, required: [] },
+    },
+  ];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 导出
+// ──────────────────────────────────────────────────────────────────────────────
 
 export function getAllToolDefs(): ToolDef[] {
   return [
@@ -450,7 +765,6 @@ export function getAllToolDefs(): ToolDef[] {
     ...domTools(),
     ...contentTools(),
     ...jsTools(),
-    ...keyboardTools(),
     ...mouseTools(),
     ...captureTools(),
     ...consoleTools(),

--- a/packages/mcp/tests/ping-fingerprint.test.ts
+++ b/packages/mcp/tests/ping-fingerprint.test.ts
@@ -36,13 +36,13 @@ describe("MCP ping version fingerprint (@since 0.4.0)", () => {
     expect(h2).not.toBe(h1);
   });
 
-  it("includes diagnostics tool and core v0.4 tools in toolset", () => {
+  it("includes diagnostics tool and core v0.5 tools in toolset", () => {
     const names = getAllToolDefs().map((d) => d.name);
     expect(names).toContain("vortex_ping");
-    expect(names).toContain("vortex_dom_commit");
-    expect(names).toContain("vortex_dom_wait_settled");
-    expect(names).toContain("vortex_page_wait_for_xhr_idle");
-    expect(names).toContain("vortex_dom_batch");
+    expect(names).toContain("vortex_fill");
+    expect(names).toContain("vortex_wait_idle");
+    expect(names).toContain("vortex_navigate");
+    expect(names).toContain("vortex_batch");
   });
 
   it("vortex_ping description advertises version fingerprint", () => {

--- a/packages/mcp/tests/tool-dispatch.test.ts
+++ b/packages/mcp/tests/tool-dispatch.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import { dispatchNewTool } from "../src/tools/dispatch.js";
+
+describe("dispatchNewTool", () => {
+  it("vortex_navigate → page.navigate 默认", () => {
+    const { action } = dispatchNewTool("vortex_navigate", { url: "http://e.com" })!;
+    expect(action).toBe("page.navigate");
+  });
+
+  it("vortex_navigate reload:true → page.reload", () => {
+    const { action } = dispatchNewTool("vortex_navigate", { reload: true })!;
+    expect(action).toBe("page.reload");
+  });
+
+  it("vortex_navigate reload:true 不透传 reload 字段", () => {
+    const { params } = dispatchNewTool("vortex_navigate", { reload: true, url: "http://e.com" })!;
+    expect(params).not.toHaveProperty("reload");
+  });
+
+  it("vortex_history direction:forward → page.forward", () => {
+    const { action } = dispatchNewTool("vortex_history", { direction: "forward" })!;
+    expect(action).toBe("page.forward");
+  });
+
+  it("vortex_history direction:back → page.back", () => {
+    const { action } = dispatchNewTool("vortex_history", { direction: "back" })!;
+    expect(action).toBe("page.back");
+  });
+
+  it("vortex_history 省略 direction → page.back（默认）", () => {
+    const { action } = dispatchNewTool("vortex_history", {})!;
+    expect(action).toBe("page.back");
+  });
+
+  it("vortex_wait_idle kind:dom → dom.waitSettled", () => {
+    const { action } = dispatchNewTool("vortex_wait_idle", { kind: "dom" })!;
+    expect(action).toBe("dom.waitSettled");
+  });
+
+  it("vortex_wait_idle kind:network → page.waitForNetworkIdle", () => {
+    const { action } = dispatchNewTool("vortex_wait_idle", { kind: "network" })!;
+    expect(action).toBe("page.waitForNetworkIdle");
+  });
+
+  it("vortex_wait_idle kind:xhr → page.waitForXhrIdle", () => {
+    const { action } = dispatchNewTool("vortex_wait_idle", { kind: "xhr" })!;
+    expect(action).toBe("page.waitForXhrIdle");
+  });
+
+  it("vortex_wait_idle idleMs 映射到 idleTime（xhr）", () => {
+    const { params } = dispatchNewTool("vortex_wait_idle", { kind: "xhr", idleMs: 300 })!;
+    expect(params.idleTime).toBe(300);
+    expect(params).not.toHaveProperty("idleMs");
+  });
+
+  it("vortex_wait_idle idleMs 映射到 quietMs（dom）", () => {
+    const { params } = dispatchNewTool("vortex_wait_idle", { kind: "dom", idleMs: 500 })!;
+    expect(params.quietMs).toBe(500);
+    expect(params).not.toHaveProperty("idleMs");
+  });
+
+  it("vortex_fill kind:cascader → dom.commit", () => {
+    const { action } = dispatchNewTool("vortex_fill", { kind: "cascader", value: "x" })!;
+    expect(action).toBe("dom.commit");
+  });
+
+  it("vortex_fill kind:checkbox-group → dom.commit", () => {
+    const { action } = dispatchNewTool("vortex_fill", { kind: "checkbox-group", value: ["a"] })!;
+    expect(action).toBe("dom.commit");
+  });
+
+  it("vortex_fill 无 kind → dom.fill", () => {
+    const { action } = dispatchNewTool("vortex_fill", { value: "x" })!;
+    expect(action).toBe("dom.fill");
+  });
+
+  it("vortex_evaluate async:false → js.evaluate", () => {
+    const { action } = dispatchNewTool("vortex_evaluate", { code: "1+1", async: false })!;
+    expect(action).toBe("js.evaluate");
+  });
+
+  it("vortex_evaluate async:true → js.evaluateAsync", () => {
+    const { action } = dispatchNewTool("vortex_evaluate", { code: "await fetch('/')", async: true })!;
+    expect(action).toBe("js.evaluateAsync");
+  });
+
+  it("vortex_screenshot 无 target → capture.screenshot", () => {
+    const { action } = dispatchNewTool("vortex_screenshot", {})!;
+    expect(action).toBe("capture.screenshot");
+  });
+
+  it("vortex_screenshot 有 selector → capture.element", () => {
+    const { action } = dispatchNewTool("vortex_screenshot", { selector: "#x" })!;
+    expect(action).toBe("capture.element");
+  });
+
+  it("vortex_console op:get → console.getLogs", () => {
+    const { action } = dispatchNewTool("vortex_console", { op: "get" })!;
+    expect(action).toBe("console.getLogs");
+  });
+
+  it("vortex_console op:clear → console.clear", () => {
+    const { action } = dispatchNewTool("vortex_console", { op: "clear" })!;
+    expect(action).toBe("console.clear");
+  });
+
+  it("vortex_network op:get 无 filter → network.getLogs", () => {
+    const { action } = dispatchNewTool("vortex_network", { op: "get" })!;
+    expect(action).toBe("network.getLogs");
+  });
+
+  it("vortex_network op:get + filter → network.filter", () => {
+    const { action } = dispatchNewTool("vortex_network", { op: "get", filter: { url: "/api" } })!;
+    expect(action).toBe("network.filter");
+  });
+
+  it("vortex_network op:clear → network.clear", () => {
+    const { action } = dispatchNewTool("vortex_network", { op: "clear" })!;
+    expect(action).toBe("network.clear");
+  });
+
+  it("vortex_storage_get scope:cookie → storage.getCookies", () => {
+    const { action } = dispatchNewTool("vortex_storage_get", { scope: "cookie" })!;
+    expect(action).toBe("storage.getCookies");
+  });
+
+  it("vortex_storage_get scope:local → storage.getLocalStorage", () => {
+    const { action } = dispatchNewTool("vortex_storage_get", { scope: "local" })!;
+    expect(action).toBe("storage.getLocalStorage");
+  });
+
+  it("vortex_storage_get scope:session → storage.getSessionStorage", () => {
+    const { action } = dispatchNewTool("vortex_storage_get", { scope: "session" })!;
+    expect(action).toBe("storage.getSessionStorage");
+  });
+
+  it("vortex_storage_set scope:cookie → storage.setCookie", () => {
+    const { action } = dispatchNewTool("vortex_storage_set", { scope: "cookie", name: "k", value: "v" })!;
+    expect(action).toBe("storage.setCookie");
+  });
+
+  it("vortex_storage_set scope:cookie op:delete → storage.deleteCookie", () => {
+    const { action } = dispatchNewTool("vortex_storage_set", { scope: "cookie", op: "delete", name: "k" })!;
+    expect(action).toBe("storage.deleteCookie");
+  });
+
+  it("vortex_storage_set scope:local → storage.setLocalStorage", () => {
+    const { action } = dispatchNewTool("vortex_storage_set", { scope: "local", key: "k", value: "v" })!;
+    expect(action).toBe("storage.setLocalStorage");
+  });
+
+  it("vortex_storage_session op:export → storage.exportSession", () => {
+    const { action } = dispatchNewTool("vortex_storage_session", { op: "export", domain: "e.com" })!;
+    expect(action).toBe("storage.exportSession");
+  });
+
+  it("vortex_storage_session op:import → storage.importSession", () => {
+    const { action } = dispatchNewTool("vortex_storage_session", { op: "import", data: {} })!;
+    expect(action).toBe("storage.importSession");
+  });
+
+  it("vortex_file_list_downloads → file.getDownloads", () => {
+    const { action } = dispatchNewTool("vortex_file_list_downloads", {})!;
+    expect(action).toBe("file.getDownloads");
+  });
+
+  it("未知工具名返回 null（走 toolDef.action 默认路径）", () => {
+    const result = dispatchNewTool("vortex_click", {});
+    expect(result).toBeNull();
+  });
+
+  it("工具总数应为 35", async () => {
+    const { getAllToolDefs } = await import("../src/tools/schemas.js");
+    expect(getAllToolDefs().length).toBe(35);
+  });
+});

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bytenew/vortex-server",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bytenew/vortex-shared",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/vortex-bench/package.json
+++ b/packages/vortex-bench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bytenew/vortex-bench",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/vortex-bench/tests/byte-size/tools-list.test.ts
+++ b/packages/vortex-bench/tests/byte-size/tools-list.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect } from "vitest";
 import { getToolDefs } from "../../../mcp/dist/src/tools/registry.js";
 
 describe("tools/list payload size", () => {
-  it("全量 tools/list JSON 字节 ≤ 30 KB（v0.4 现状兜底；PR-3 后收紧到 8KB）", () => {
+  it("全量 tools/list JSON 字节 ≤ 16 KB（v0.5 收紧；实际 14.5KB，1.5KB 余量）", () => {
     const defs = getToolDefs();
     const payload = JSON.stringify(
       defs.map((d) => ({ name: d.name, description: d.description, inputSchema: d.schema })),
     );
     const bytes = Buffer.byteLength(payload, "utf-8");
     console.log(`tools/list payload = ${bytes} bytes, tool count = ${defs.length}`);
-    expect(bytes).toBeLessThanOrEqual(30_000);
+    expect(bytes).toBeLessThanOrEqual(16_000);
   });
 
   it("每个工具 description ≤ 280 字符", () => {


### PR DESCRIPTION
  ## Summary 🚀 BREAKING

  vortex **v0.5.0** — 工具合并 74 → 35 + 版本 major bump。Stack on #3 (PR-2)。

  ### 核心变更

  - **工具面 74 → 35**：`vortex_dom_click` → `vortex_click`，`vortex_page_back` → `vortex_history({direction:"back"})`，`vortex_storage_get_cookies` → `vortex_storage_get({scope:"cookie"})` 等。完整迁移表见 CHANGELOG。
  - **统一 `target` 参数**：所有动作工具的元素定位统一改为 `target: "@eN" / "@fNeM" / CSS selector`，撤掉 `selector/index/snapshotId/frameId` 暴露。
  - **description 压缩**：每工具描述从 ~200 字符砍到 ≤ 80，enum 参数去冗余 description。
  - **版本 0.4.x → 0.5.0**：6 个包统一 bump。

  ### 效果（vs PR-2 结束时）

  | 指标 | Before | After | 降幅 |
  |---|---|---|---|
  | tools 数量 | 74 | 35 | -53% |
  | tools/list bytes | 29,837 | 14,543 | **-51%** |
  | tools/list tokens (估) | ~7,000 | ~3,400 | **-51%** |

  ### 效果（vs v0.4 baseline）

  | 指标 | v0.4 | v0.5 (PR-0→3) | 降幅 |
  |---|---|---|---|
  | tools/list bytes | 27,551 | 14,543 | -47% |
  | observe raw-html-long (200 elems) | 103,758 | ~5,400 | **-95%** |

  ### 新增模块

  - `packages/mcp/src/lib/dispatch.ts`：MCP 新工具名 → extension action 映射 + params reshape
  - 34 个 dispatch 单测覆盖所有分派规则

  ### 兼容性

  本 PR 是破坏性变更。任何使用老 `vortex_*_*` 工具的脚本都要按 CHANGELOG 迁移表重写。extension 协议（action name）**未变**，扩展无需重新编译即可工作。

  ## Test plan

  - [x] 35 工具（`getToolDefs().length === 35`）
  - [x] tool-dispatch.test.ts 34 cases 全绿
  - [x] ping-fingerprint.test.ts 更新到新工具名全绿
  - [x] byte-size 阈值收紧到 16KB 断言通过
  - [x] pnpm -r build / -r test 全绿
  - [ ] **手工**：Chrome 扩展 reload + Claude Code 调用新名工具（`vortex_observe`→`vortex_click` 走通）

  ## 手工验证清单（merge 前建议做）

  vortex_ping          → 确认 toolCount=35
  vortex_observe       → 看到 @eN 输出
  vortex_click         → {target: "@e0"} 成功
  vortex_fill          → {target: "@e1", value: "x"} 成功
  vortex_history       → {direction: "back"} 成功
  vortex_storage_get   → {scope: "cookie"} 成功
