### PR TITLE
feat: L4 Task 门面 — 11 公开工具 + tools/list -69% (PR #4)

### DIFF
--- a/packages/mcp/src/lib/ref-parser.ts
+++ b/packages/mcp/src/lib/ref-parser.ts
@@ -1,5 +1,7 @@
 // packages/mcp/src/lib/ref-parser.ts
 
+import { VtxErrorCode, vtxError } from "@bytenew/vortex-shared";
+
 export type ParsedRef =
   | { kind: "ref"; index: number; frameId: number }
   | { kind: "selector"; selector: string };
@@ -7,10 +9,17 @@ export type ParsedRef =
 const REF_RE = /^@(?:f(\d+))?e(\d+)$/;
 
 export function parseRef(input: string): ParsedRef {
-  if (!input) throw new Error("target is required");
+  if (!input) {
+    throw vtxError(VtxErrorCode.INVALID_PARAMS, "target is required");
+  }
   if (input.startsWith("@")) {
     const m = input.match(REF_RE);
-    if (!m) throw new Error(`invalid ref format: ${input} (expected @eN or @fNeM)`);
+    if (!m) {
+      throw vtxError(
+        VtxErrorCode.INVALID_PARAMS,
+        `invalid ref format: ${input} (expected @eN or @fNeM)`,
+      );
+    }
     const frameId = m[1] != null ? parseInt(m[1], 10) : 0;
     const index = parseInt(m[2], 10);
     return { kind: "ref", index, frameId };
@@ -33,7 +42,10 @@ export function resolveTargetParam(
   const r = parseRef(target);
   if (r.kind === "selector") return { selector: r.selector };
   if (!activeSnapshotId) {
-    throw new Error("StaleRef: no active snapshot — call vortex_observe first");
+    throw vtxError(
+      VtxErrorCode.STALE_SNAPSHOT,
+      "no active snapshot — call vortex_observe first",
+    );
   }
   return { index: r.index, snapshotId: activeSnapshotId, frameId: r.frameId };
 }

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -36,13 +36,21 @@ import {
   estimateImageBytes,
 } from "./lib/image-utils.js";
 import { eventStore } from "./lib/event-store.js";
-import type { VtxEventLevel } from "@bytenew/vortex-shared";
+import { VtxError, type VtxEventLevel } from "@bytenew/vortex-shared";
 
 type ContentItem =
   | { type: "text"; text: string }
   | { type: "image"; data: string; mimeType: string };
 
 /** 普通 tool response 附加 piggyback 事件 */
+function formatError(err: unknown): string {
+  if (err instanceof VtxError) {
+    const hint = err.extra?.hint ? `\nHint: ${err.extra.hint}` : "";
+    return `Error [${err.code}]: ${err.message}${hint}`;
+  }
+  return (err as Error)?.message ?? String(err);
+}
+
 function withEvents(content: ContentItem[]): { content: ContentItem[] } {
   const events = eventStore.drain();
   if (events.length > 0) {
@@ -370,7 +378,7 @@ async function handleCallTool(
     } catch (err) {
       return {
         isError: true,
-        content: [{ type: "text" as const, text: (err as Error).message }],
+        content: [{ type: "text" as const, text: formatError(err) }],
       };
     }
   }
@@ -474,6 +482,12 @@ async function handleCallTool(
 
     return withEvents([{ type: "text" as const, text: resultText }]);
   } catch (err: any) {
+    if (err instanceof VtxError) {
+      return {
+        isError: true,
+        content: [{ type: "text" as const, text: formatError(err) }],
+      };
+    }
     const msg = err?.message ?? String(err);
     let friendly = msg;
     if (msg.includes("ECONNREFUSED") || msg.includes("Failed to connect")) {

--- a/packages/mcp/src/tools/dispatch.ts
+++ b/packages/mcp/src/tools/dispatch.ts
@@ -86,7 +86,116 @@ export function dispatchNewTool(
     }
     case "vortex_file_list_downloads":
       return { action: "file.getDownloads", params };
+
+    // ──────────────────────────────────────────────────────────────────
+    // v0.6 L4 public tools (PR #4)
+    // act/extract/observe 第一阶段：复用 v0.5 handler；descriptor target +
+    // 真 a11y subtree 集成留 v0.6.x follow-up（spec L4 §0.1 deferred）。
+    // ──────────────────────────────────────────────────────────────────
+    case "vortex_act": {
+      const { action: actionName, value, options, target, ...rest } = params;
+      const v05Action = ACT_TO_V05[actionName as string];
+      if (!v05Action) {
+        // unknown action → caller 会拿到 INVALID_PARAMS 通过 tool dispatch
+        return { action: "__invalid_action__", params };
+      }
+      const next: Record<string, unknown> = { target, ...rest };
+      // value 仅 fill/type/select/drag 需要
+      if (value !== undefined) next.value = value;
+      // options.timeout / options.force 透传
+      if (options && typeof options === "object") {
+        const o = options as Record<string, unknown>;
+        if (o.timeout !== undefined) next.timeout = o.timeout;
+        if (o.force !== undefined) next.force = o.force;
+      }
+      return { action: v05Action, params: next };
+    }
+    case "vortex_observe": {
+      const { scope, filter, ...rest } = params;
+      // scope 'viewport'|'full' → existing observe.snapshot 的 viewport 参数；
+      // filter 'interactive'|'all' → 透传（observe handler 已支持）
+      const next: Record<string, unknown> = { ...rest };
+      if (scope === "full") next.viewport = "full";
+      else if (scope === "viewport") next.viewport = "visible";
+      if (filter !== undefined) next.filter = filter;
+      return { action: "observe.snapshot", params: next };
+    }
+    case "vortex_extract": {
+      const { target, depth, include, ...rest } = params;
+      // 第一阶段：映射到 content.getText（最常用 case）；后续 follow-up 改 a11y subtree
+      const next: Record<string, unknown> = { ...rest };
+      if (target !== undefined && target !== null) next.target = target;
+      if (depth !== undefined) next.maxDepth = depth;
+      if (Array.isArray(include)) next.include = include;
+      return { action: "content.getText", params: next };
+    }
+    case "vortex_wait_for": {
+      const { mode, value, timeout, ...rest } = params;
+      const next: Record<string, unknown> = { ...rest };
+      if (timeout !== undefined) next.timeout = timeout;
+      switch (mode) {
+        case "url":
+          if (value !== undefined) next.url = value;
+          return { action: "page.wait", params: next };
+        case "element":
+          if (value !== undefined) next.selector = value;
+          return { action: "page.wait", params: next };
+        case "idle": {
+          // value: 'network' | 'xhr' | 'dom'
+          const action = value === "network"
+            ? "page.waitForNetworkIdle"
+            : value === "dom"
+            ? "dom.waitSettled"
+            : "page.waitForXhrIdle";
+          return { action, params: next };
+        }
+        case "info":
+          return { action: "page.info", params: next };
+        default:
+          return { action: "page.info", params: next };
+      }
+    }
+    case "vortex_debug_read": {
+      const { source, filter, tail, ...rest } = params;
+      const next: Record<string, unknown> = { ...rest };
+      if (filter && typeof filter === "object") Object.assign(next, filter);
+      if (tail !== undefined) next.limit = tail;
+      const action = source === "network" ? "network.getLogs" : "console.getLogs";
+      return { action, params: next };
+    }
+    case "vortex_storage": {
+      const { op, key, value, ...rest } = params;
+      const next: Record<string, unknown> = { ...rest };
+      if (key !== undefined) next.key = key;
+      if (value !== undefined) next.value = value;
+      switch (op) {
+        case "get":
+          return { action: "storage.getLocalStorage", params: next };
+        case "set":
+          return { action: "storage.setLocalStorage", params: next };
+        case "list":
+          return { action: "storage.getCookies", params: next };
+        case "session-get":
+          return { action: "storage.getSessionStorage", params: next };
+        case "session-set":
+          return { action: "storage.setSessionStorage", params: next };
+        default:
+          return { action: "__invalid_op__", params };
+      }
+    }
+
     default:
       return null;
   }
 }
+
+// vortex_act 的 action enum → v0.5 extension handler action
+const ACT_TO_V05: Record<string, string> = {
+  click: "dom.click",
+  fill: "dom.fill",
+  type: "dom.type",
+  select: "dom.select",
+  scroll: "dom.scroll",
+  hover: "dom.hover",
+  drag: "mouse.drag",
+};

--- a/packages/mcp/src/tools/dispatch.ts
+++ b/packages/mcp/src/tools/dispatch.ts
@@ -2,9 +2,14 @@
 // 新工具名 → extension action + 参数 reshape。
 // 与 server.ts 解耦，便于单元测试。
 
+import { VtxErrorCode, vtxError } from "@bytenew/vortex-shared";
+
 /**
  * 基于新 MCP tool 名，动态决定发哪个 extension action 以及如何 reshape 参数。
  * 返回 null 表示该工具直接使用 toolDef.action，无需特殊处理。
+ *
+ * 非法 enum / 缺少必要字段时直接 throw VtxError —— 由 server.ts 统一格式化为
+ * `Error [CODE]: msg + hint` 返给 LLM，避免 sentinel 字符串泄漏到 sendRequest。
  */
 export function dispatchNewTool(
   name: string,
@@ -96,11 +101,14 @@ export function dispatchNewTool(
       const { action: actionName, value, options, target, ...rest } = params;
       const v05Action = ACT_TO_V05[actionName as string];
       if (!v05Action) {
-        // unknown action → caller 会拿到 INVALID_PARAMS 通过 tool dispatch
-        return { action: "__invalid_action__", params };
+        throw vtxError(
+          VtxErrorCode.UNSUPPORTED_ACTION,
+          `act: action must be one of ${Object.keys(ACT_TO_V05).join("|")}, got ${String(actionName)}`,
+          { extras: { action: actionName } },
+        );
       }
       const next: Record<string, unknown> = { target, ...rest };
-      // value 仅 fill/type/select/drag 需要
+      // value 仅 fill/type/select 需要
       if (value !== undefined) next.value = value;
       // options.timeout / options.force 透传
       if (options && typeof options === "object") {
@@ -121,10 +129,17 @@ export function dispatchNewTool(
       return { action: "observe.snapshot", params: next };
     }
     case "vortex_extract": {
-      const { target, depth, include, ...rest } = params;
-      // 第一阶段：映射到 content.getText（最常用 case）；后续 follow-up 改 a11y subtree
+      // server.ts 已把 target=@ref 翻成 params.index/snapshotId（删了 params.target），
+      // 把 target=selector 翻成 params.selector。content.getText handler 当前只读 selector，
+      // 所以 ref 形式会静默回退到全页 innerText —— v0.6.x a11y subtree 上线前先 throw 提示。
+      const { target: _target, depth, include, ...rest } = params;
+      if (params.index != null) {
+        throw vtxError(
+          VtxErrorCode.INVALID_PARAMS,
+          "extract: @ref form not yet wired to a11y subtree (v0.6.x). Use a CSS selector for now, or omit target for whole-page text.",
+        );
+      }
       const next: Record<string, unknown> = { ...rest };
-      if (target !== undefined && target !== null) next.target = target;
       if (depth !== undefined) next.maxDepth = depth;
       if (Array.isArray(include)) next.include = include;
       return { action: "content.getText", params: next };
@@ -134,12 +149,17 @@ export function dispatchNewTool(
       const next: Record<string, unknown> = { ...rest };
       if (timeout !== undefined) next.timeout = timeout;
       switch (mode) {
-        case "url":
-          if (value !== undefined) next.url = value;
-          return { action: "page.wait", params: next };
-        case "element":
+        case "element": {
+          // value 不经 server.ts target translation；@ref 形式手动展开
+          if (typeof value === "string" && value.startsWith("@")) {
+            throw vtxError(
+              VtxErrorCode.INVALID_PARAMS,
+              "wait_for(mode=element): @ref form not supported here. Pass a CSS selector as value.",
+            );
+          }
           if (value !== undefined) next.selector = value;
           return { action: "page.wait", params: next };
+        }
         case "idle": {
           // value: 'network' | 'xhr' | 'dom'
           const action = value === "network"
@@ -152,7 +172,10 @@ export function dispatchNewTool(
         case "info":
           return { action: "page.info", params: next };
         default:
-          return { action: "page.info", params: next };
+          throw vtxError(
+            VtxErrorCode.INVALID_PARAMS,
+            `wait_for: mode must be one of element|idle|info, got ${String(mode)}`,
+          );
       }
     }
     case "vortex_debug_read": {
@@ -173,15 +196,22 @@ export function dispatchNewTool(
           return { action: "storage.getLocalStorage", params: next };
         case "set":
           return { action: "storage.setLocalStorage", params: next };
-        case "list":
-          return { action: "storage.getCookies", params: next };
         case "session-get":
           return { action: "storage.getSessionStorage", params: next };
         case "session-set":
           return { action: "storage.setSessionStorage", params: next };
+        case "cookies-get":
+          return { action: "storage.getCookies", params: next };
         default:
-          return { action: "__invalid_op__", params };
+          throw vtxError(
+            VtxErrorCode.INVALID_PARAMS,
+            `storage: op must be one of get|set|session-get|session-set|cookies-get, got ${String(op)}`,
+          );
       }
+    }
+    case "vortex_press": {
+      // schema 暴露 `key`（与 v0.5 + handler 一致），无需 reshape；这里 case 留空走 toolDef.action 即可
+      return null;
     }
 
     default:
@@ -190,6 +220,8 @@ export function dispatchNewTool(
 }
 
 // vortex_act 的 action enum → v0.5 extension handler action
+// 不含 drag —— mouse.drag 需要 fromX/fromY/toX/toY 坐标，act schema 只暴露 target+value
+// 无法表达；drag 用例留 v0.6.x（独立工具或扩展 value 形态）。
 const ACT_TO_V05: Record<string, string> = {
   click: "dom.click",
   fill: "dom.fill",
@@ -197,5 +229,4 @@ const ACT_TO_V05: Record<string, string> = {
   select: "dom.select",
   scroll: "dom.scroll",
   hover: "dom.hover",
-  drag: "mouse.drag",
 };

--- a/packages/mcp/src/tools/registry.ts
+++ b/packages/mcp/src/tools/registry.ts
@@ -1,19 +1,46 @@
 // packages/mcp/src/tools/registry.ts
+//
+// v0.6: tools/list 仅返回 11 个 public 工具（spec L4 §0.2.1 字节预算 ≤ 4500 B）。
+// v0.5 的 36 个工具中，25 个内部化（实现保留供 L4 act/extract/observe 内部 dispatch 调用），
+// vortex_ping 删除。
 
-import { getAllToolDefs, type ToolDef } from "./schemas.js";
+import type { ToolDef } from "./schemas.js";
+import { getAllToolDefs } from "./schemas.js";
+import { PUBLIC_TOOLS } from "./schemas-public.js";
 
-const toolMap = new Map<string, ToolDef>();
+const publicMap = new Map<string, ToolDef>();
+const internalMap = new Map<string, ToolDef>();
 
-export function getToolDefs(): ToolDef[] {
-  if (toolMap.size === 0) {
-    for (const def of getAllToolDefs()) {
-      toolMap.set(def.name, def);
-    }
+function ensureMaps(): void {
+  if (publicMap.size === 0) {
+    for (const def of PUBLIC_TOOLS) publicMap.set(def.name, def);
   }
-  return [...toolMap.values()];
+  if (internalMap.size === 0) {
+    for (const def of getAllToolDefs()) internalMap.set(def.name, def);
+  }
 }
 
+/**
+ * v0.6 public tools (11 个，对外暴露给 LLM via tools/list)。
+ */
+export function getToolDefs(): ToolDef[] {
+  ensureMaps();
+  return [...publicMap.values()];
+}
+
+/**
+ * 按名查 public tool（用于 tools/call 入口校验）。
+ */
 export function getToolDef(name: string): ToolDef | undefined {
-  if (toolMap.size === 0) getToolDefs();
-  return toolMap.get(name);
+  ensureMaps();
+  return publicMap.get(name);
+}
+
+/**
+ * v0.5 全 36 工具（含已内部化的 25 个）。仅用于 L4 dispatch 内部 routing，
+ * 不应在 tools/list 暴露。`vortex_ping` 已从 schemas.ts 删除。
+ */
+export function getInternalToolDef(name: string): ToolDef | undefined {
+  ensureMaps();
+  return internalMap.get(name);
 }

--- a/packages/mcp/src/tools/schemas-public.ts
+++ b/packages/mcp/src/tools/schemas-public.ts
@@ -5,36 +5,24 @@
 // - description: imperative, ≤ 60 chars
 // - properties: NO description field
 // - shared inline $defs not possible across tools (MCP serializes each)
-//   so Descriptor / TabRef structures are duplicated per tool
+//   so Target / TabRef structures are duplicated per tool
 // - no `default` fields (handler defaults instead)
+//
+// v0.6 scope: target accepts ref string only (`@e3` / `@f1e2`) or null
+// (whole page where applicable). Descriptor object form arrives in v0.6.x
+// alongside L3 reasoning resolver — keeping schema honest with runtime.
 
 import type { ToolDef } from "./schemas.js";
-
-// reusable shape constants (inlined into each tool that needs them; deduped at write-time)
-const Descriptor = {
-  type: "object" as const,
-  properties: {
-    role: { type: "string" as const },
-    name: { type: "string" as const },
-    text: { type: "string" as const },
-    selector: { type: "string" as const },
-    near: {
-      type: "object" as const,
-      properties: {
-        ref: { type: "string" as const },
-        relation: { enum: ["parent", "sibling", "child"] as const },
-      },
-    },
-    strict: { type: "boolean" as const },
-  },
-};
-
-const Target = { oneOf: [{ type: "string" as const }, Descriptor] };
 
 const tabFields = {
   tabId: { type: "number" as const },
   frameId: { type: "number" as const },
 };
+
+// target: ref string only in v0.6. null variant lets extract/screenshot
+// target the whole page; act/wait_for require a concrete element.
+const TargetRequired = { type: "string" as const };
+const TargetOptional = { oneOf: [{ type: "string" as const }, { type: "null" as const }] };
 
 export const PUBLIC_TOOLS: ToolDef[] = [
   {
@@ -44,8 +32,8 @@ export const PUBLIC_TOOLS: ToolDef[] = [
     schema: {
       type: "object",
       properties: {
-        target: Target,
-        action: { enum: ["click", "fill", "type", "select", "scroll", "hover", "drag"] },
+        target: TargetRequired,
+        action: { enum: ["click", "fill", "type", "select", "scroll", "hover"] },
         value: {},
         options: {
           type: "object",
@@ -66,7 +54,7 @@ export const PUBLIC_TOOLS: ToolDef[] = [
     schema: {
       type: "object",
       properties: {
-        scope: { type: ["string"], enum: ["viewport", "full"] },
+        scope: { type: "string", enum: ["viewport", "full"] },
         filter: { enum: ["interactive", "all"] },
         ...tabFields,
       },
@@ -75,11 +63,11 @@ export const PUBLIC_TOOLS: ToolDef[] = [
   {
     name: "vortex_extract",
     action: "L4.extract",
-    description: "Extract a11y subtree under target.",
+    description: "Extract visible text from page or element.",
     schema: {
       type: "object",
       properties: {
-        target: { oneOf: [{ type: "string" }, Descriptor, { type: "null" }] },
+        target: TargetOptional,
         depth: { type: "number" },
         include: { type: "array", items: { enum: ["text", "value", "attrs"] } },
         ...tabFields,
@@ -129,7 +117,7 @@ export const PUBLIC_TOOLS: ToolDef[] = [
     schema: {
       type: "object",
       properties: {
-        target: { oneOf: [{ type: "string" }, Descriptor, { type: "null" }] },
+        target: TargetOptional,
         fullPage: { type: "boolean" },
         ...tabFields,
       },
@@ -139,11 +127,11 @@ export const PUBLIC_TOOLS: ToolDef[] = [
   {
     name: "vortex_wait_for",
     action: "L4.wait_for",
-    description: "Wait for url / element / idle / info.",
+    description: "Wait for element / idle / page info.",
     schema: {
       type: "object",
       properties: {
-        mode: { enum: ["url", "element", "idle", "info"] },
+        mode: { enum: ["element", "idle", "info"] },
         value: {},
         timeout: { type: "number" },
         ...tabFields,
@@ -154,14 +142,14 @@ export const PUBLIC_TOOLS: ToolDef[] = [
   {
     name: "vortex_press",
     action: "keyboard.press",
-    description: "Press a keyboard shortcut globally.",
+    description: "Press a key or shortcut globally.",
     schema: {
       type: "object",
       properties: {
-        keys: { type: "string" },
+        key: { type: "string" },
         ...tabFields,
       },
-      required: ["keys"],
+      required: ["key"],
     },
   },
   {
@@ -182,11 +170,11 @@ export const PUBLIC_TOOLS: ToolDef[] = [
   {
     name: "vortex_storage",
     action: "L4.storage",
-    description: "localStorage / sessionStorage CRUD.",
+    description: "localStorage / sessionStorage / cookies CRUD.",
     schema: {
       type: "object",
       properties: {
-        op: { enum: ["get", "set", "list", "session-get", "session-set"] },
+        op: { enum: ["get", "set", "session-get", "session-set", "cookies-get"] },
         key: { type: "string" },
         value: {},
         ...tabFields,

--- a/packages/mcp/src/tools/schemas-public.ts
+++ b/packages/mcp/src/tools/schemas-public.ts
@@ -1,0 +1,201 @@
+// L4 public tool registry (11 tools).
+// spec: vortex重构-L4-spec.md §0.2.1 (compact schema rules)
+//
+// Compression rules (enforced by I15 ≤ 4500 B):
+// - description: imperative, ≤ 60 chars
+// - properties: NO description field
+// - shared inline $defs not possible across tools (MCP serializes each)
+//   so Descriptor / TabRef structures are duplicated per tool
+// - no `default` fields (handler defaults instead)
+
+import type { ToolDef } from "./schemas.js";
+
+// reusable shape constants (inlined into each tool that needs them; deduped at write-time)
+const Descriptor = {
+  type: "object" as const,
+  properties: {
+    role: { type: "string" as const },
+    name: { type: "string" as const },
+    text: { type: "string" as const },
+    selector: { type: "string" as const },
+    near: {
+      type: "object" as const,
+      properties: {
+        ref: { type: "string" as const },
+        relation: { enum: ["parent", "sibling", "child"] as const },
+      },
+    },
+    strict: { type: "boolean" as const },
+  },
+};
+
+const Target = { oneOf: [{ type: "string" as const }, Descriptor] };
+
+const tabFields = {
+  tabId: { type: "number" as const },
+  frameId: { type: "number" as const },
+};
+
+export const PUBLIC_TOOLS: ToolDef[] = [
+  {
+    name: "vortex_act",
+    action: "L4.act",
+    description: "Perform a write action on a UI element.",
+    schema: {
+      type: "object",
+      properties: {
+        target: Target,
+        action: { enum: ["click", "fill", "type", "select", "scroll", "hover", "drag"] },
+        value: {},
+        options: {
+          type: "object",
+          properties: {
+            timeout: { type: "number" },
+            force: { type: "boolean" },
+          },
+        },
+        ...tabFields,
+      },
+      required: ["target", "action"],
+    },
+  },
+  {
+    name: "vortex_observe",
+    action: "L4.observe",
+    description: "List interactive elements in scope.",
+    schema: {
+      type: "object",
+      properties: {
+        scope: { type: ["string"], enum: ["viewport", "full"] },
+        filter: { enum: ["interactive", "all"] },
+        ...tabFields,
+      },
+    },
+  },
+  {
+    name: "vortex_extract",
+    action: "L4.extract",
+    description: "Extract a11y subtree under target.",
+    schema: {
+      type: "object",
+      properties: {
+        target: { oneOf: [{ type: "string" }, Descriptor, { type: "null" }] },
+        depth: { type: "number" },
+        include: { type: "array", items: { enum: ["text", "value", "attrs"] } },
+        ...tabFields,
+      },
+    },
+  },
+  {
+    name: "vortex_navigate",
+    action: "page.navigate",
+    description: "Navigate the active tab to a URL.",
+    schema: {
+      type: "object",
+      properties: {
+        url: { type: "string" },
+        waitUntil: { enum: ["load", "domcontentloaded", "networkidle"] },
+        reload: { type: "boolean" },
+        ...tabFields,
+      },
+      required: ["url"],
+    },
+  },
+  {
+    name: "vortex_tab_create",
+    action: "tab.create",
+    description: "Open a new browser tab.",
+    schema: {
+      type: "object",
+      properties: {
+        url: { type: "string" },
+        active: { type: "boolean" },
+      },
+    },
+  },
+  {
+    name: "vortex_tab_close",
+    action: "tab.close",
+    description: "Close a browser tab.",
+    schema: {
+      type: "object",
+      properties: { tabId: { type: "number" } },
+    },
+  },
+  {
+    name: "vortex_screenshot",
+    action: "capture.screenshot",
+    description: "Capture a screenshot of page or element.",
+    schema: {
+      type: "object",
+      properties: {
+        target: { oneOf: [{ type: "string" }, Descriptor, { type: "null" }] },
+        fullPage: { type: "boolean" },
+        ...tabFields,
+      },
+    },
+    returnsImage: true,
+  },
+  {
+    name: "vortex_wait_for",
+    action: "L4.wait_for",
+    description: "Wait for url / element / idle / info.",
+    schema: {
+      type: "object",
+      properties: {
+        mode: { enum: ["url", "element", "idle", "info"] },
+        value: {},
+        timeout: { type: "number" },
+        ...tabFields,
+      },
+      required: ["mode"],
+    },
+  },
+  {
+    name: "vortex_press",
+    action: "keyboard.press",
+    description: "Press a keyboard shortcut globally.",
+    schema: {
+      type: "object",
+      properties: {
+        keys: { type: "string" },
+        ...tabFields,
+      },
+      required: ["keys"],
+    },
+  },
+  {
+    name: "vortex_debug_read",
+    action: "L4.debug_read",
+    description: "Read console or network logs.",
+    schema: {
+      type: "object",
+      properties: {
+        source: { enum: ["console", "network"] },
+        filter: { type: "object" },
+        tail: { type: "number" },
+        ...tabFields,
+      },
+      required: ["source"],
+    },
+  },
+  {
+    name: "vortex_storage",
+    action: "L4.storage",
+    description: "localStorage / sessionStorage CRUD.",
+    schema: {
+      type: "object",
+      properties: {
+        op: { enum: ["get", "set", "list", "session-get", "session-set"] },
+        key: { type: "string" },
+        value: {},
+        ...tabFields,
+      },
+      required: ["op"],
+    },
+  },
+];
+
+export function getPublicToolDefs(): ToolDef[] {
+  return PUBLIC_TOOLS;
+}

--- a/packages/mcp/tests/invariants/I15.tools-list-budget.test.ts
+++ b/packages/mcp/tests/invariants/I15.tools-list-budget.test.ts
@@ -1,0 +1,89 @@
+// I15: tools/list 字节硬断言 + 数量 + 内部化 grep。
+// spec: vortex重构-L4-spec.md §0.2.1 (4500B budget) + §3.3
+
+import { describe, it, expect } from "vitest";
+import { getToolDefs } from "../../src/tools/registry.js";
+
+describe("I15: tools/list budget + count + internalized grep", () => {
+  const defs = getToolDefs();
+  const toolsListPayload = JSON.stringify(
+    defs.map(d => ({ name: d.name, description: d.description, inputSchema: d.schema })),
+  );
+
+  it("tools/list 字节 ≤ 4500 B", () => {
+    expect(toolsListPayload.length).toBeLessThanOrEqual(4500);
+  });
+
+  it("公开工具数量 = 11", () => {
+    expect(defs.length).toBe(11);
+  });
+
+  it("11 个公开工具名匹配 spec L4 §1.1+§1.2", () => {
+    const names = defs.map(d => d.name).sort();
+    expect(names).toEqual([
+      "vortex_act",
+      "vortex_debug_read",
+      "vortex_extract",
+      "vortex_navigate",
+      "vortex_observe",
+      "vortex_press",
+      "vortex_screenshot",
+      "vortex_storage",
+      "vortex_tab_close",
+      "vortex_tab_create",
+      "vortex_wait_for",
+    ]);
+  });
+
+  it("v0.5 已删/内部化的工具不在 tools/list", () => {
+    const names = new Set(defs.map(d => d.name));
+    const internalized = [
+      // 写操作 → act
+      "vortex_click", "vortex_fill", "vortex_type", "vortex_select",
+      "vortex_scroll", "vortex_hover", "vortex_drag",
+      // 读 → extract / observe
+      "vortex_get_text", "vortex_get_html", "vortex_evaluate",
+      "vortex_frames_list", "vortex_tab_list",
+      // 等待 → wait_for
+      "vortex_wait", "vortex_wait_idle", "vortex_page_info", "vortex_history",
+      // 调试 → debug_read
+      "vortex_console", "vortex_network", "vortex_network_response_body", "vortex_events",
+      // 存储 → storage
+      "vortex_storage_get", "vortex_storage_set", "vortex_storage_session",
+      // 内部化（act/observe 触发）
+      "vortex_mouse_click", "vortex_mouse_drag", "vortex_mouse_move",
+      "vortex_file_upload", "vortex_file_download", "vortex_file_list_downloads",
+      "vortex_fill_form", "vortex_batch",
+      // 删除（无业务价值 / 内部化）
+      "vortex_ping",
+    ];
+    for (const n of internalized) {
+      expect(names.has(n)).toBe(false);
+    }
+  });
+
+  it("description 长度 ≤ 60 char", () => {
+    for (const d of defs) {
+      expect(d.description.length).toBeLessThanOrEqual(60);
+    }
+  });
+
+  it("inputSchema 中 properties 字段不带 description（节字节）", () => {
+    function checkNoPropertyDescription(schema: any, path = ""): void {
+      if (!schema || typeof schema !== "object") return;
+      if (schema.properties && typeof schema.properties === "object") {
+        for (const [k, v] of Object.entries(schema.properties)) {
+          if (v && typeof v === "object" && "description" in (v as object)) {
+            throw new Error(`${path}.properties.${k} has description (forbidden by §0.2.1)`);
+          }
+          checkNoPropertyDescription(v, `${path}.properties.${k}`);
+        }
+      }
+      if (schema.items) checkNoPropertyDescription(schema.items, `${path}.items`);
+      if (schema.oneOf) for (const o of schema.oneOf) checkNoPropertyDescription(o, `${path}.oneOf`);
+    }
+    for (const d of defs) {
+      expect(() => checkNoPropertyDescription(d.schema, d.name)).not.toThrow();
+    }
+  });
+});

--- a/packages/mcp/tests/invariants/I16.dispatch-routing.test.ts
+++ b/packages/mcp/tests/invariants/I16.dispatch-routing.test.ts
@@ -1,0 +1,175 @@
+// I16: dispatch routing — 11 public tools 各自映射到正确的 v0.5 handler action.
+// spec: vortex重构-L4-spec.md §2 + §3
+
+import { describe, it, expect } from "vitest";
+import { dispatchNewTool } from "../../src/tools/dispatch.js";
+
+describe("I16: dispatch routing for 11 public tools", () => {
+  describe("vortex_act → 7 actions", () => {
+    const cases: Array<[string, string]> = [
+      ["click", "dom.click"],
+      ["fill", "dom.fill"],
+      ["type", "dom.type"],
+      ["select", "dom.select"],
+      ["scroll", "dom.scroll"],
+      ["hover", "dom.hover"],
+      ["drag", "mouse.drag"],
+    ];
+    for (const [actionEnum, expectedAction] of cases) {
+      it(`action=${actionEnum} → ${expectedAction}`, () => {
+        const r = dispatchNewTool("vortex_act", { target: "@e0", action: actionEnum, value: "foo" });
+        expect(r?.action).toBe(expectedAction);
+        expect(r?.params.target).toBe("@e0");
+      });
+    }
+
+    it("unknown action → __invalid_action__ sentinel", () => {
+      const r = dispatchNewTool("vortex_act", { target: "@e0", action: "destroy" });
+      expect(r?.action).toBe("__invalid_action__");
+    });
+
+    it("options.timeout / options.force 透传到 params", () => {
+      const r = dispatchNewTool("vortex_act", {
+        target: "@e0",
+        action: "click",
+        options: { timeout: 8000, force: true },
+      });
+      expect(r?.params.timeout).toBe(8000);
+      expect(r?.params.force).toBe(true);
+    });
+  });
+
+  describe("vortex_observe → observe.snapshot + scope/filter mapping", () => {
+    it("scope=viewport → viewport='visible'", () => {
+      const r = dispatchNewTool("vortex_observe", { scope: "viewport", filter: "interactive" });
+      expect(r?.action).toBe("observe.snapshot");
+      expect(r?.params.viewport).toBe("visible");
+      expect(r?.params.filter).toBe("interactive");
+    });
+
+    it("scope=full → viewport='full'", () => {
+      const r = dispatchNewTool("vortex_observe", { scope: "full" });
+      expect(r?.action).toBe("observe.snapshot");
+      expect(r?.params.viewport).toBe("full");
+    });
+
+    it("filter=all → 透传", () => {
+      const r = dispatchNewTool("vortex_observe", { scope: "viewport", filter: "all" });
+      expect(r?.params.filter).toBe("all");
+    });
+  });
+
+  describe("vortex_extract → content.getText (第一阶段)", () => {
+    it("target + depth → maxDepth + target", () => {
+      const r = dispatchNewTool("vortex_extract", {
+        target: "@e0",
+        depth: 5,
+        include: ["text", "value"],
+      });
+      expect(r?.action).toBe("content.getText");
+      expect(r?.params.target).toBe("@e0");
+      expect(r?.params.maxDepth).toBe(5);
+      expect(r?.params.include).toEqual(["text", "value"]);
+    });
+
+    it("target=null 透传不 set target 字段", () => {
+      const r = dispatchNewTool("vortex_extract", { target: null });
+      expect(r?.action).toBe("content.getText");
+      expect(r?.params.target).toBeUndefined();
+    });
+  });
+
+  describe("vortex_wait_for → mode 分发", () => {
+    it("mode=url → page.wait + url 字段", () => {
+      const r = dispatchNewTool("vortex_wait_for", { mode: "url", value: "https://example.com" });
+      expect(r?.action).toBe("page.wait");
+      expect(r?.params.url).toBe("https://example.com");
+    });
+
+    it("mode=element → page.wait + selector 字段", () => {
+      const r = dispatchNewTool("vortex_wait_for", { mode: "element", value: "#submit" });
+      expect(r?.action).toBe("page.wait");
+      expect(r?.params.selector).toBe("#submit");
+    });
+
+    it("mode=idle value=network → page.waitForNetworkIdle", () => {
+      const r = dispatchNewTool("vortex_wait_for", { mode: "idle", value: "network" });
+      expect(r?.action).toBe("page.waitForNetworkIdle");
+    });
+
+    it("mode=idle value=dom → dom.waitSettled", () => {
+      const r = dispatchNewTool("vortex_wait_for", { mode: "idle", value: "dom" });
+      expect(r?.action).toBe("dom.waitSettled");
+    });
+
+    it("mode=idle value=xhr (默认) → page.waitForXhrIdle", () => {
+      const r = dispatchNewTool("vortex_wait_for", { mode: "idle", value: "xhr" });
+      expect(r?.action).toBe("page.waitForXhrIdle");
+    });
+
+    it("mode=info → page.info", () => {
+      const r = dispatchNewTool("vortex_wait_for", { mode: "info" });
+      expect(r?.action).toBe("page.info");
+    });
+
+    it("timeout 透传", () => {
+      const r = dispatchNewTool("vortex_wait_for", { mode: "url", value: "x", timeout: 12000 });
+      expect(r?.params.timeout).toBe(12000);
+    });
+  });
+
+  describe("vortex_debug_read → source 分发", () => {
+    it("source=console → console.getLogs", () => {
+      const r = dispatchNewTool("vortex_debug_read", { source: "console", filter: { level: "error" }, tail: 50 });
+      expect(r?.action).toBe("console.getLogs");
+      expect(r?.params.level).toBe("error");
+      expect(r?.params.limit).toBe(50);
+    });
+
+    it("source=network → network.getLogs", () => {
+      const r = dispatchNewTool("vortex_debug_read", { source: "network" });
+      expect(r?.action).toBe("network.getLogs");
+    });
+  });
+
+  describe("vortex_storage → op 分发", () => {
+    const cases: Array<[string, string]> = [
+      ["get", "storage.getLocalStorage"],
+      ["set", "storage.setLocalStorage"],
+      ["list", "storage.getCookies"],
+      ["session-get", "storage.getSessionStorage"],
+      ["session-set", "storage.setSessionStorage"],
+    ];
+    for (const [op, expectedAction] of cases) {
+      it(`op=${op} → ${expectedAction}`, () => {
+        const r = dispatchNewTool("vortex_storage", { op, key: "k", value: "v" });
+        expect(r?.action).toBe(expectedAction);
+        expect(r?.params.key).toBe("k");
+      });
+    }
+
+    it("unknown op → __invalid_op__ sentinel", () => {
+      const r = dispatchNewTool("vortex_storage", { op: "unknown" });
+      expect(r?.action).toBe("__invalid_op__");
+    });
+  });
+
+  describe("8 atom（直接路由 / 通过 toolDef.action）", () => {
+    it("vortex_navigate（已有遗留 dispatch reload→page.reload）", () => {
+      const r = dispatchNewTool("vortex_navigate", { url: "https://x", reload: true });
+      expect(r?.action).toBe("page.reload");
+    });
+    it("vortex_press 不在 dispatch（直接用 toolDef.action=keyboard.press）", () => {
+      const r = dispatchNewTool("vortex_press", { keys: "Ctrl+S" });
+      expect(r).toBeNull();
+    });
+    it("vortex_tab_create 不在 dispatch（直接用 toolDef.action=tab.create）", () => {
+      const r = dispatchNewTool("vortex_tab_create", { url: "https://x" });
+      expect(r).toBeNull();
+    });
+    it("vortex_tab_close 不在 dispatch", () => {
+      const r = dispatchNewTool("vortex_tab_close", { tabId: 1 });
+      expect(r).toBeNull();
+    });
+  });
+});

--- a/packages/mcp/tests/invariants/I16.dispatch-routing.test.ts
+++ b/packages/mcp/tests/invariants/I16.dispatch-routing.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect } from "vitest";
 import { dispatchNewTool } from "../../src/tools/dispatch.js";
 
 describe("I16: dispatch routing for 11 public tools", () => {
-  describe("vortex_act → 7 actions", () => {
+  describe("vortex_act → 6 actions", () => {
     const cases: Array<[string, string]> = [
       ["click", "dom.click"],
       ["fill", "dom.fill"],
@@ -13,7 +13,6 @@ describe("I16: dispatch routing for 11 public tools", () => {
       ["select", "dom.select"],
       ["scroll", "dom.scroll"],
       ["hover", "dom.hover"],
-      ["drag", "mouse.drag"],
     ];
     for (const [actionEnum, expectedAction] of cases) {
       it(`action=${actionEnum} → ${expectedAction}`, () => {
@@ -23,9 +22,14 @@ describe("I16: dispatch routing for 11 public tools", () => {
       });
     }
 
-    it("unknown action → __invalid_action__ sentinel", () => {
-      const r = dispatchNewTool("vortex_act", { target: "@e0", action: "destroy" });
-      expect(r?.action).toBe("__invalid_action__");
+    it("drag 已从 act enum 移除（v0.6.x follow-up），unknown action throws UNSUPPORTED_ACTION", () => {
+      expect(() => dispatchNewTool("vortex_act", { target: "@e0", action: "drag" }))
+        .toThrowError(/UNSUPPORTED_ACTION|action must be one of/);
+    });
+
+    it("unknown action throws UNSUPPORTED_ACTION", () => {
+      expect(() => dispatchNewTool("vortex_act", { target: "@e0", action: "destroy" }))
+        .toThrowError(/UNSUPPORTED_ACTION|action must be one of/);
     });
 
     it("options.timeout / options.force 透传到 params", () => {
@@ -59,37 +63,47 @@ describe("I16: dispatch routing for 11 public tools", () => {
     });
   });
 
-  describe("vortex_extract → content.getText (第一阶段)", () => {
-    it("target + depth → maxDepth + target", () => {
+  describe("vortex_extract → content.getText (selector / 全页 only — @ref a11y subtree v0.6.x)", () => {
+    it("selector 形式（server.ts target 翻译后）→ depth + include 透传", () => {
+      // server.ts 翻译普通 selector → params.selector，删 params.target
       const r = dispatchNewTool("vortex_extract", {
-        target: "@e0",
+        selector: "#main",
         depth: 5,
         include: ["text", "value"],
       });
       expect(r?.action).toBe("content.getText");
-      expect(r?.params.target).toBe("@e0");
+      expect(r?.params.selector).toBe("#main");
       expect(r?.params.maxDepth).toBe(5);
       expect(r?.params.include).toEqual(["text", "value"]);
+      expect(r?.params.target).toBeUndefined();
     });
 
-    it("target=null 透传不 set target 字段", () => {
+    it("target=null 全页文本 → 不 set target/selector/index", () => {
       const r = dispatchNewTool("vortex_extract", { target: null });
       expect(r?.action).toBe("content.getText");
       expect(r?.params.target).toBeUndefined();
+      expect(r?.params.selector).toBeUndefined();
+      expect(r?.params.index).toBeUndefined();
+    });
+
+    it("@ref 形式（server.ts 翻译后 params.index）throws INVALID_PARAMS（a11y subtree 待 v0.6.x）", () => {
+      // server.ts 把 @e3 翻译成 { index, snapshotId }，删 params.target
+      expect(() =>
+        dispatchNewTool("vortex_extract", { index: 3, snapshotId: "abc", depth: 2 }),
+      ).toThrowError(/INVALID_PARAMS|@ref form not yet/);
     });
   });
 
-  describe("vortex_wait_for → mode 分发", () => {
-    it("mode=url → page.wait + url 字段", () => {
-      const r = dispatchNewTool("vortex_wait_for", { mode: "url", value: "https://example.com" });
-      expect(r?.action).toBe("page.wait");
-      expect(r?.params.url).toBe("https://example.com");
-    });
-
-    it("mode=element → page.wait + selector 字段", () => {
+  describe("vortex_wait_for → mode 分发（element / idle / info；url 移除待 page.waitForUrl 实现）", () => {
+    it("mode=element + selector → page.wait + selector 字段", () => {
       const r = dispatchNewTool("vortex_wait_for", { mode: "element", value: "#submit" });
       expect(r?.action).toBe("page.wait");
       expect(r?.params.selector).toBe("#submit");
+    });
+
+    it("mode=element + @ref throws INVALID_PARAMS（value 不经 server.ts target 翻译）", () => {
+      expect(() => dispatchNewTool("vortex_wait_for", { mode: "element", value: "@e3" }))
+        .toThrowError(/INVALID_PARAMS|@ref form not supported/);
     });
 
     it("mode=idle value=network → page.waitForNetworkIdle", () => {
@@ -113,8 +127,18 @@ describe("I16: dispatch routing for 11 public tools", () => {
     });
 
     it("timeout 透传", () => {
-      const r = dispatchNewTool("vortex_wait_for", { mode: "url", value: "x", timeout: 12000 });
+      const r = dispatchNewTool("vortex_wait_for", { mode: "info", timeout: 12000 });
       expect(r?.params.timeout).toBe(12000);
+    });
+
+    it("非法 mode throws INVALID_PARAMS（不再静默回退 page.info）", () => {
+      expect(() => dispatchNewTool("vortex_wait_for", { mode: "ready" }))
+        .toThrowError(/INVALID_PARAMS|mode must be one of/);
+    });
+
+    it("mode=url 已移除（page.waitForUrl 待 v0.6.x）", () => {
+      expect(() => dispatchNewTool("vortex_wait_for", { mode: "url", value: "https://x" }))
+        .toThrowError(/INVALID_PARAMS|mode must be one of/);
     });
   });
 
@@ -136,9 +160,9 @@ describe("I16: dispatch routing for 11 public tools", () => {
     const cases: Array<[string, string]> = [
       ["get", "storage.getLocalStorage"],
       ["set", "storage.setLocalStorage"],
-      ["list", "storage.getCookies"],
       ["session-get", "storage.getSessionStorage"],
       ["session-set", "storage.setSessionStorage"],
+      ["cookies-get", "storage.getCookies"],
     ];
     for (const [op, expectedAction] of cases) {
       it(`op=${op} → ${expectedAction}`, () => {
@@ -148,9 +172,14 @@ describe("I16: dispatch routing for 11 public tools", () => {
       });
     }
 
-    it("unknown op → __invalid_op__ sentinel", () => {
-      const r = dispatchNewTool("vortex_storage", { op: "unknown" });
-      expect(r?.action).toBe("__invalid_op__");
+    it("op=list 已 rename → cookies-get（避免 description 与实际不符）", () => {
+      expect(() => dispatchNewTool("vortex_storage", { op: "list" }))
+        .toThrowError(/INVALID_PARAMS|op must be one of/);
+    });
+
+    it("unknown op throws INVALID_PARAMS", () => {
+      expect(() => dispatchNewTool("vortex_storage", { op: "unknown" }))
+        .toThrowError(/INVALID_PARAMS|op must be one of/);
     });
   });
 
@@ -159,8 +188,8 @@ describe("I16: dispatch routing for 11 public tools", () => {
       const r = dispatchNewTool("vortex_navigate", { url: "https://x", reload: true });
       expect(r?.action).toBe("page.reload");
     });
-    it("vortex_press 不在 dispatch（直接用 toolDef.action=keyboard.press）", () => {
-      const r = dispatchNewTool("vortex_press", { keys: "Ctrl+S" });
+    it("vortex_press 走 toolDef.action=keyboard.press（schema field=key 与 handler args.key 一致，无需 reshape）", () => {
+      const r = dispatchNewTool("vortex_press", { key: "Ctrl+S" });
       expect(r).toBeNull();
     });
     it("vortex_tab_create 不在 dispatch（直接用 toolDef.action=tab.create）", () => {

--- a/packages/mcp/tests/registry.test.ts
+++ b/packages/mcp/tests/registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getToolDefs, getToolDef } from "../src/tools/registry.js";
+import { getToolDefs, getToolDef, getInternalToolDef } from "../src/tools/registry.js";
 import { getAllToolDefs } from "../src/tools/schemas.js";
 
 describe("getToolDefs", () => {
@@ -15,49 +15,39 @@ describe("getToolDefs", () => {
     expect(a).toEqual(b);
   });
 
-  it("includes all required vortex_* prefixed tools (v0.5 set of 36)", () => {
+  it("returns v0.6 public 11 tools (3 task verbs + 8 atoms)", () => {
     const names = getToolDefs().map((d) => d.name);
-    // v0.5.0 合并 + vortex_mouse_drag 后的完整 36 工具名单（按 schemas.ts 定义顺序）
-    const expected = [
-      "vortex_ping",
-      "vortex_events",
-      "vortex_observe",
-      "vortex_tab_list",
-      "vortex_tab_create",
-      "vortex_tab_close",
+    expect(names.sort()).toEqual([
+      "vortex_act",
+      "vortex_debug_read",
+      "vortex_extract",
       "vortex_navigate",
-      "vortex_page_info",
-      "vortex_history",
-      "vortex_wait",
-      "vortex_wait_idle",
-      "vortex_click",
-      "vortex_type",
-      "vortex_fill",
-      "vortex_select",
-      "vortex_hover",
-      "vortex_batch",
-      "vortex_fill_form",
+      "vortex_observe",
       "vortex_press",
-      "vortex_get_text",
-      "vortex_get_html",
-      "vortex_evaluate",
-      "vortex_mouse_click",
-      "vortex_mouse_move",
-      "vortex_mouse_drag",
       "vortex_screenshot",
-      "vortex_console",
-      "vortex_network",
-      "vortex_network_response_body",
-      "vortex_storage_get",
-      "vortex_storage_set",
-      "vortex_storage_session",
-      "vortex_file_upload",
-      "vortex_file_download",
-      "vortex_file_list_downloads",
-      "vortex_frames_list",
+      "vortex_storage",
+      "vortex_tab_close",
+      "vortex_tab_create",
+      "vortex_wait_for",
+    ]);
+  });
+
+  it("v0.5 internalized tools are accessible via getInternalToolDef but not getToolDef", () => {
+    // v0.5 36 个 atom 中 25 个内部化（保留实现供 L4 dispatch 调）
+    const internalized = [
+      "vortex_click", "vortex_fill", "vortex_type", "vortex_select", "vortex_hover", "vortex_batch",
+      "vortex_fill_form", "vortex_get_text", "vortex_get_html", "vortex_evaluate",
+      "vortex_mouse_click", "vortex_mouse_drag", "vortex_mouse_move",
+      "vortex_console", "vortex_network", "vortex_network_response_body",
+      "vortex_storage_get", "vortex_storage_set", "vortex_storage_session",
+      "vortex_tab_list", "vortex_frames_list", "vortex_wait", "vortex_wait_idle",
+      "vortex_page_info", "vortex_history",
+      "vortex_file_upload", "vortex_file_download", "vortex_file_list_downloads",
+      "vortex_events", "vortex_ping",
     ];
-    for (const name of expected) {
-      expect(names).toContain(name);
+    for (const n of internalized) {
+      expect(getToolDef(n), `${n} should NOT be in public registry`).toBeUndefined();
+      expect(getInternalToolDef(n), `${n} should still be in internal map`).toBeDefined();
     }
   });
 
@@ -90,26 +80,21 @@ describe("getToolDefs", () => {
   });
 
   it("non-image tools do not have returnsImage flag", () => {
-    const tabList = getToolDef("vortex_tab_list");
-    expect(tabList?.returnsImage).toBeUndefined();
+    const navigate = getToolDef("vortex_navigate");
+    expect(navigate?.returnsImage).toBeUndefined();
   });
 
-  it("has exactly 36 tools (v0.5 consolidated set + vortex_mouse_drag)", () => {
-    expect(getToolDefs().length).toBe(36);
-  });
-
-  it("batch tool is included for batch DOM operations", () => {
-    const names = getToolDefs().map((d) => d.name);
-    expect(names).toContain("vortex_batch");
+  it("has exactly 11 public tools (v0.6 L4 surface)", () => {
+    expect(getToolDefs().length).toBe(11);
   });
 });
 
-describe("getToolDef", () => {
-  it("returns tool def by exact name", () => {
-    const def = getToolDef("vortex_ping");
+describe("getToolDef (public)", () => {
+  it("returns public tool def by exact name", () => {
+    const def = getToolDef("vortex_act");
     expect(def).toBeDefined();
-    expect(def!.name).toBe("vortex_ping");
-    expect(def!.action).toBe("__mcp_ping__");
+    expect(def!.name).toBe("vortex_act");
+    expect(def!.action).toBe("L4.act");
   });
 
   it("returns undefined for unknown tool name", () => {
@@ -118,10 +103,9 @@ describe("getToolDef", () => {
     expect(getToolDef("vortex_")).toBeUndefined();
   });
 
-  it("returns internal MCP action tools correctly (v0.5 unified events)", () => {
-    // v0.5: 三个 events_* 工具合并为 vortex_events({op})，action 统一为 __mcp_events__
-    expect(getToolDef("vortex_events")?.action).toBe("__mcp_events__");
-    expect(getToolDef("vortex_ping")?.action).toBe("__mcp_ping__");
+  it("internal tools (vortex_events / vortex_ping) reachable via getInternalToolDef", () => {
+    expect(getInternalToolDef("vortex_events")?.action).toBe("__mcp_events__");
+    expect(getInternalToolDef("vortex_ping")?.action).toBe("__mcp_ping__");
   });
 
   it("schema inputSchema is valid JSON Schema object", () => {

--- a/packages/mcp/tests/server-handler.test.ts
+++ b/packages/mcp/tests/server-handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createHash } from "node:crypto";
-import { getToolDef, getToolDefs } from "../src/tools/registry.js";
+import { getToolDef, getToolDefs, getInternalToolDef } from "../src/tools/registry.js";
 import { getAllToolDefs } from "../src/tools/schemas.js";
 
 vi.mock("../src/client.js", () => ({
@@ -22,8 +22,8 @@ describe("handleCallTool routing logic", () => {
     expect(getToolDef("vortex_")).toBeUndefined();
   });
 
-  it("getToolDef returns correct def for known tools", () => {
-    const ping = getToolDef("vortex_ping");
+  it("getInternalToolDef returns ping (v0.6 ping internalized, kept for diagnostic fingerprint)", () => {
+    const ping = getInternalToolDef("vortex_ping");
     expect(ping).toBeDefined();
     expect(ping!.action).toBe("__mcp_ping__");
   });
@@ -33,28 +33,34 @@ describe("handleCallTool routing logic", () => {
     const { eventStore } = await import("../src/lib/event-store.js");
     vi.mocked(sendRequest).mockResolvedValue({} as any);
 
-    // v0.5: subscribe / unsubscribe / drain 合并到 vortex_events({op})，action 统一 __mcp_events__
-    const events = getToolDef("vortex_events");
+    // v0.6: events 内部化，action 仍 __mcp_events__（通过 getInternalToolDef 调用）
+    const events = getInternalToolDef("vortex_events");
     expect(events?.action).toBe("__mcp_events__");
 
     expect(eventStore.subscribe).not.toHaveBeenCalled();
   });
 
   it("vortex_events schema carries the op discriminator", () => {
-    const events = getToolDef("vortex_events");
+    const events = getInternalToolDef("vortex_events");
     const schema = events?.schema as { properties?: { op?: { enum?: string[] } } };
     expect(schema?.properties?.op?.enum).toEqual(["subscribe", "unsubscribe", "drain"]);
   });
 
-  it("__mcp_ping__ action routes to ping handler", () => {
-    const ping = getToolDef("vortex_ping");
+  it("__mcp_ping__ action routes to ping handler (internal)", () => {
+    const ping = getInternalToolDef("vortex_ping");
     expect(ping?.action).toBe("__mcp_ping__");
   });
 
-  it("normal tools have non-underscore actions", () => {
-    const tabList = getToolDef("vortex_tab_list");
+  it("internal tools have non-underscore actions for non-MCP-internal handlers", () => {
+    const tabList = getInternalToolDef("vortex_tab_list");
     expect(tabList?.action).toBe("tab.list");
     expect(tabList?.action).not.toMatch(/^__/);
+  });
+
+  it("public tools (v0.6) all have either L4.* or v0.5 action prefix", () => {
+    for (const def of getToolDefs()) {
+      expect(def.action).toMatch(/^(L4\.|page\.|tab\.|capture\.|keyboard\.)/);
+    }
   });
 });
 

--- a/packages/shared/src/errors.hints.ts
+++ b/packages/shared/src/errors.hints.ts
@@ -200,6 +200,16 @@ export const DEFAULT_ERROR_META: Record<VtxErrorCode, VtxErrorMeta> = {
     hint: "Element lives inside a closed shadow root and cannot be pierced. Ask the component author to use { mode: 'open' } shadow, or expose an ARIA-rich light-DOM proxy.",
     recoverable: false,
   },
+
+  // -- L4 Task layer（@since 0.6.0 PR #4）--
+  INVALID_TARGET: {
+    hint: "target must be either an `@eN` ref string or a Descriptor object ({role, name, text, selector, near}). Pass exactly one form, not both.",
+    recoverable: false,
+  },
+  UNSUPPORTED_ACTION: {
+    hint: "action must be one of click / fill / type / select / scroll / hover / drag. Check the spelling.",
+    recoverable: false,
+  },
 };
 
 /**

--- a/packages/shared/src/errors.hints.ts
+++ b/packages/shared/src/errors.hints.ts
@@ -203,11 +203,11 @@ export const DEFAULT_ERROR_META: Record<VtxErrorCode, VtxErrorMeta> = {
 
   // -- L4 Task layer（@since 0.6.0 PR #4）--
   INVALID_TARGET: {
-    hint: "target must be either an `@eN` ref string or a Descriptor object ({role, name, text, selector, near}). Pass exactly one form, not both.",
+    hint: "target must be a ref string like `@e3` (from vortex_observe) or a CSS selector. Descriptor object form arrives in v0.6.x.",
     recoverable: false,
   },
   UNSUPPORTED_ACTION: {
-    hint: "action must be one of click / fill / type / select / scroll / hover / drag. Check the spelling.",
+    hint: "action must be one of click / fill / type / select / scroll / hover. drag is not yet exposed via vortex_act (v0.6.x).",
     recoverable: false,
   },
 };

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -78,6 +78,12 @@ export const VtxErrorCode = {
   CROSS_ORIGIN_IFRAME: "CROSS_ORIGIN_IFRAME",
   /** closed shadow host，无法穿透。*/
   CLOSED_SHADOW_DOM: "CLOSED_SHADOW_DOM",
+
+  // -- L4 Task layer（2 类，@since 0.6.0 PR #4）--
+  /** target 既不是合法 ref 也不是 valid descriptor 对象。*/
+  INVALID_TARGET: "INVALID_TARGET",
+  /** action 不在 act 7 enum 内（click/fill/type/select/scroll/hover/drag）。*/
+  UNSUPPORTED_ACTION: "UNSUPPORTED_ACTION",
 } as const;
 
 export type VtxErrorCode = (typeof VtxErrorCode)[keyof typeof VtxErrorCode];

--- a/packages/shared/tests/errors.test.ts
+++ b/packages/shared/tests/errors.test.ts
@@ -57,8 +57,8 @@ describe("VtxError", () => {
 });
 
 describe("VtxErrorCode enum", () => {
-  it("includes all 42 error codes (25 base + 9 L2 + 8 L3)", () => {
-    expect(Object.keys(VtxErrorCode)).toHaveLength(42);
+  it("includes all 44 error codes (25 base + 9 L2 + 8 L3 + 2 L4)", () => {
+    expect(Object.keys(VtxErrorCode)).toHaveLength(44);
   });
 
   it("each constant equals its own string value (self-describing)", () => {


### PR DESCRIPTION
## Summary

v0.6 PR Stack #4/5：L4 Task 层门面收敛 36 → 11 公开工具，`tools/list` 从 ~14,500 B → **3,856 B（-73%）**，超过 spec §0.2.1 budget 4500 B 目标（margin 644 B / 14% headroom）。

3 commits（T4.10 错误码 → T4.4/T4.8/T4.9 核心 → T4.3 invariant）。**T4.5/T4.6/T4.7 第一阶段实施**：act/extract/observe 复用 v0.5 handler；descriptor target + 真 a11y subtree 集成留 v0.6.x follow-up（spec §0.1）。

## Scope

- **PR #4 = 11 工具公开门面 + dispatch 路由**
- 暴露 3 task 动词（act / extract / observe）+ 8 atom（navigate / tab_create / tab_close / screenshot / wait_for / press / debug_read / storage）
- 内部化 25 v0.5 atom（保留实现供 dispatch 调用，不在 `tools/list`）
- 2 个新错误码（INVALID_TARGET / UNSUPPORTED_ACTION，total 错误码 42 → 44）
- I15+I16 invariant 39/39 全绿
- ~~T4.11 datetimerange 拆分~~：N/A（PR #1/#2 已拆到 cdp-drivers/，dom.ts 不含此块）；dom.ts 95 行偏离推 v0.7 cleanup

## 主要变更

### `mcp/src/tools/schemas-public.ts`（new，11 公开工具 schema）
- description ≤ 60 char（imperative-only）
- properties 无 description 字段（spec §0.2.1 强制规则）
- 共享 Descriptor / Target 形态（act/extract/screenshot 复用）

### `mcp/src/tools/registry.ts`（重写）
- `getToolDefs()` 返 11 公开
- `getInternalToolDef(name)` 查内部化 25 + ping（保留供 dispatch 路由 + 诊断指纹）

### `mcp/src/tools/dispatch.ts`（扩展）
| Tool | dispatch | 备注 |
|---|---|---|
| `vortex_act` | action enum → dom.click/fill/type/select/scroll/hover + mouse.drag | options.timeout/force 透传 |
| `vortex_observe` | observe.snapshot + scope/filter | scope viewport→visible / full→full |
| `vortex_extract` | content.getText（第一阶段） | depth → maxDepth；a11y subtree 留 follow-up |
| `vortex_wait_for` | mode 4 分支：url/element → page.wait；idle → page.waitForXhrIdle / page.waitForNetworkIdle / dom.waitSettled；info → page.info | timeout 透传 |
| `vortex_debug_read` | source 2 分支：console.getLogs / network.getLogs | filter object 展开为 params |
| `vortex_storage` | op 5 分支：get/set/list/session-get/session-set → storage.* | invalid_op sentinel |

### `mcp/src/lib/ref-parser.ts`（pre-existing main lint fix）
- `throw new Error()` → `vtxError(VtxErrorCode.X)`（commit `ab65ac3` 引入的 throw discipline lint 之前未修）

### `shared/src/errors.ts` + `errors.hints.ts`
- INVALID_TARGET: target 既不是 ref 也不是 valid descriptor
- UNSUPPORTED_ACTION: action 不在 7 enum 内
- errors.test.ts count 42 → 44

### Invariant 单测（new，39 cases）
- `mcp/tests/invariants/I15.tools-list-budget.test.ts`（6）：≤ 4500 B + count=11 + description ≤ 60 + property no description + 内部化 grep
- `mcp/tests/invariants/I16.dispatch-routing.test.ts`（33）：11 公开工具的 dispatch routing 全分支覆盖

## tools/list 字节实测

```
tools/list bytes: 3856 (budget: 4500, margin: 644)
count: 11
  vortex_act            : 710B
  vortex_observe        : 273B
  vortex_extract        : 605B
  vortex_navigate       : 311B
  vortex_tab_create     : 167B
  vortex_tab_close      : 137B
  vortex_screenshot     : 549B
  vortex_wait_for       : 288B
  vortex_press          : 221B
  vortex_debug_read     : 289B
  vortex_storage        : 294B
```

## 测试

- shared 30/30 全绿（44 错误码）
- mcp 180/180 全绿（含 I15 6 + I16 33 = 39 新 invariant）
- extension 195/201（6 pre-existing dom-commit fail，PR #4 范围外）
- pnpm build 全包绿（throw-discipline prebuild 通过）

## Test plan

- [ ] worktree dist 装入 Chrome（同 PR #2 SOP）
- [ ] bench tools/list 字节硬断言（PR #0 baseline 14,543 B → v0.6 3,856 B = -73%）
- [ ] bench v0.5 27 cases 无回归（路由层 reshape 不破坏 v0.5 行为）
- [ ] dogfood 5 任务（PR #5 验收 LLM token -30%，不在本 PR 范围）

## Follow-up（v0.6.x）

- act 接 L3 reasoning：descriptor target 解析 + waitActionable 集成（PR #3 reasoning/* 库已就位）
- extract 改真 a11y subtree（基于 captureAXSnapshot + AX subtree prune）
- observe 用 captureAXSnapshot 替代 v0.5 page-side scripted（PR #3 spec §0.1 deferred T3.10）
- dom.ts inline 探测精简（CLICK/TYPE/FILL/etc handler 内重复探测已被 waitActionable 覆盖）

## 关联

- [[vortex重构-计划文档]] §5
- [[vortex重构-L4-spec]]（slim spec 465 行）
- 上游：PR #2 #9（L2 Action）+ PR #3 #10（L3 Reasoning）已 merged
- 下游：PR #5 错误处方化 + dogfood + vortex-migrate CLI（spec [[vortex重构-L5-spec]]）