### PR TITLE
fix(mcp): expose frames in vortex_observe public schema (Bug F / v0.6.1)

### DIFF
--- a/packages/mcp/src/tools/schemas-public.ts
+++ b/packages/mcp/src/tools/schemas-public.ts
@@ -50,12 +50,13 @@ export const PUBLIC_TOOLS: ToolDef[] = [
   {
     name: "vortex_observe",
     action: "L4.observe",
-    description: "List interactive elements in scope.",
+    description: "List interactive elements; iframes: frames=all-permitted.",
     schema: {
       type: "object",
       properties: {
         scope: { type: "string", enum: ["viewport", "full"] },
         filter: { enum: ["interactive", "all"] },
+        frames: { enum: ["main", "all-same-origin", "all-permitted", "all"] },
         ...tabFields,
       },
     },

--- a/packages/mcp/tests/invariants/I15.tools-list-budget.test.ts
+++ b/packages/mcp/tests/invariants/I15.tools-list-budget.test.ts
@@ -100,9 +100,24 @@ describe("Bug F regression: vortex_observe surface must expose frames", () => {
     expect(props.frames).toBeDefined();
   });
 
-  it("frames enum covers main / all-same-origin / all-permitted / all", () => {
-    expect(props.frames.enum).toEqual(
-      expect.arrayContaining(["main", "all-same-origin", "all-permitted", "all"]),
-    );
+  // Strict equality (not arrayContaining) — guards against silent enum
+  // drift in either direction: subset (capability removed) or superset
+  // (untested value sneaked in). Order matches schemas.ts:111 internal enum.
+  it("frames enum equals exactly main / all-same-origin / all-permitted / all", () => {
+    expect(props.frames.enum).toEqual([
+      "main",
+      "all-same-origin",
+      "all-permitted",
+      "all",
+    ]);
+  });
+
+  // The whole point of the description change is to nudge LLMs to switch
+  // away from the implicit 'main' default when iframes are involved.
+  // If a future edit drops the hint (e.g. reverts to "List interactive
+  // elements in scope."), the schema-shape tests above still pass but
+  // discoverability silently regresses — Bug F all over again.
+  it("description hints frames usage for iframe contexts", () => {
+    expect(observe.description).toMatch(/frames/);
   });
 });

--- a/packages/mcp/tests/invariants/I15.tools-list-budget.test.ts
+++ b/packages/mcp/tests/invariants/I15.tools-list-budget.test.ts
@@ -87,3 +87,22 @@ describe("I15: tools/list budget + count + internalized grep", () => {
     }
   });
 });
+
+// Bug F (v0.6.0 dogfood): PR #4 门面化把 vortex_observe schema 砍到 scope/filter，
+// 漏掉 frames 参数。底层路由（server.ts spread rest, observe.ts:486 args.frames）
+// 全部就位，但 LLM 看到的公开 schema 不暴露 → cross-origin iframe / SPA 嵌入场景
+// 无从触发 all-permitted。本测试锁住 frames 暴露，防止门面收窄再次静默丢参数。
+describe("Bug F regression: vortex_observe surface must expose frames", () => {
+  const observe = getToolDefs().find(d => d.name === "vortex_observe")!;
+  const props = (observe.schema as { properties: Record<string, any> }).properties;
+
+  it("vortex_observe.schema.properties.frames exists", () => {
+    expect(props.frames).toBeDefined();
+  });
+
+  it("frames enum covers main / all-same-origin / all-permitted / all", () => {
+    expect(props.frames.enum).toEqual(
+      expect.arrayContaining(["main", "all-same-origin", "all-permitted", "all"]),
+    );
+  });
+});

--- a/packages/mcp/tests/observe-special-path.test.ts
+++ b/packages/mcp/tests/observe-special-path.test.ts
@@ -75,6 +75,30 @@ describe("vortex_observe special path (Bug C regression)", () => {
     expect((params as Record<string, unknown>).viewport).toBe("full");
   });
 
+  // Bug F transit-path regression: server.ts:306 currently destructures
+  // { scope, filter, tabId, timeout, ...rest } and frames falls through via
+  // `rest`. If a refactor names `frames` explicitly in the destructure and
+  // forgets to forward it into `next`, schemas-public still exposes the
+  // param (I15 passes) but the value never reaches the extension — the
+  // exact symmetric failure mode of Bug F itself.
+  it("frames param is forwarded to extension (Bug F transit-path lock)", async () => {
+    const { sendRequest } = await import("../src/client.js");
+    vi.mocked(sendRequest).mockResolvedValue({
+      result: { snapshotId: "snap_test_3", url: "", elements: [] },
+    } as any);
+
+    const { handleCallTool } = await import("../src/server.js");
+    await handleCallTool({
+      params: {
+        name: "vortex_observe",
+        arguments: { scope: "viewport", frames: "all-permitted" },
+      },
+    });
+
+    const [, params] = vi.mocked(sendRequest).mock.calls[0];
+    expect((params as Record<string, unknown>).frames).toBe("all-permitted");
+  });
+
   it("subsequent vortex_act with @eN ref reuses the activeSnapshotId set by observe (no STALE_SNAPSHOT)", async () => {
     const { sendRequest } = await import("../src/client.js");
     // observe → returns snapshotId


### PR DESCRIPTION
## Summary

- 修 v0.6.0 retrospective Bug F：PR #4 门面化漏暴露 `vortex_observe` 的 `frames` 参数（底层路由全建好，仅 `schemas-public.ts` 没暴露 surface）→ LLM 在 cross-origin iframe / SPA 嵌入场景无从触发 `all-permitted`，bytenew VOC dogfood 失败的真根因
- 加 `frames` enum 回 `schemas-public.ts`（4 值：`main` / `all-same-origin` / `all-permitted` / `all`），description 改成 57 char 引导（"List interactive elements; iframes: frames=all-permitted."）
- 加 I15 回归测试 2 条锁住 `frames` 暴露 + enum 覆盖，防门面 PR 再次静默丢参数

## 影响范围

| 指标 | 改前 | 改后 |
|---|---|---|
| `tools/list` payload | 3015 B | 3104 B（+89 B） |
| 4500 B 预算 headroom | 1485 | 1396 |
| `vortex_observe` description 长度 | 35 / 60 | 57 / 60 |
| 公开工具数 | 11 | 11（无变化） |

底层透传链未动（已就位）：`server.ts:306` rest spread → `extension/observe.ts:486 args.frames ?? "main"` → `resolveTargetFrames`。

## Test plan

- [x] mcp 全包 224/224 pass（`pnpm --filter @bytenew/vortex-mcp test`）
- [x] I15 8/8 pass（含 2 条新增回归测试 + 6 条原有不变量）
- [x] 字节预算 ≤ 4500 B（实测 3104）
- [x] description ≤ 60 char（实测 57）
- [x] no-property-description 不变量仍守
- [ ] 真实浏览器 smoke：在含 cross-origin iframe 页面跑 `vortex_observe { frames: "all-permitted" }`，验返回包含 iframe 内元素

## 关联

- v0.6.0 retrospective Bug F：[memory note](https://github.com/benbergg/vortex/issues?q=v0.6.0+retrospective)（v0.6.x backlog P0）
- 已知 unrelated test debt：#13（dom-commit.test.ts 6 失败，PR #2 mock 过时，与本 PR 无关）

## Notes

- 不带 default：handler 默认值在 `extension/observe.ts:486` `args.frames ?? "main"`，与 PR #4 §0.2.1 "no `default` fields" 规则一致
- 不带 property description：受 I15 不变量约束，iframe 引导只能在 tool 级 description（已加）