### PR TITLE
feat: v0.7 dogfood batch — 5 bug classes (observe scanner overhaul)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 ---
 
+## [Unreleased] - v0.7 dogfood batch
+
+### 🐛 Fixed (observe scanner overhaul, PR #19)
+
+通过 testc.bytenew.com 严谨对照 Playwright 评测发现的四个 observe scanner bug，集中在 `fix/v0.7-dogfood-batch` 一次修完。
+
+- **Bug 1** — `cursor:pointer` 自定义可点元素漏识别。`INTERACTIVE_SELECTORS` 静态白名单不含 fallback，bytenew sidebar 7 menuitem + 行操作 40 个 `<el-button>` 全漏。修：page-side scanner 加二次扫 `*:not(svg *):not(script):not(style):not(meta):not(link):not(head):not(head *)`，过滤 visible + cursor:pointer + 有 name + 排除 INTERACTIVE_SELECTORS wrapper + leaf-only（O(N·depth) ancestor walk）+ 候选数硬上限 5000。
+- **Bug 2** — `filter='all'` 是 dead parameter。公开 schema 暴露 `interactive | all` 但 handler 不读 `args.filter`，输出 byte-identical。修：handler 顶部读 args.filter（默认 `'interactive'`）→ scanOneFrame 透传 page-side；'all' 模式 selector union 加 `tr,td,th,[role=row|cell|columnheader|rowheader|gridcell]`。注意：'all' 仅扩展表格类结构语义，不是字面"任意元素"。
+- **Bug 3** — 主 frame 输出 nameless `[div]` noise。Element Plus `el-popover__reference` 命中 `[tabindex]:not([tabindex='-1'])` 但无 role / 无 aria-label / 无 innerText。修：filter='interactive' 模式后置过滤——非 form-like 元素（input / select / textarea / button / `a[href]`）必须有 role / aria-label / name 之一。
+- **Bug 4** — ref-based `vortex_act` 在重复 v-for 结构上 `SELECTOR_AMBIGUOUS`。`@fNeM` ref 翻译退化为 selector lookup，bytenew 3 个同结构 checkbox-group 让 `nth-of-type` path 必中两个元素。修：`buildSelector` path 失唯一时 `setAttribute('data-vortex-rid', '<unique>')` 返回 `[data-vortex-rid="..."]` 精确身份。**每次 observe 入口先 `removeAttribute` 旧 rid**，避免长 SPA 会话累积。
+
+### 💥 Behavior changes（不动公开 schema 但语义变化）
+
+- `vortex_observe(filter='all')` 现在真返回更多元素；调用方若依赖 `'all' === 'interactive'` 的旧行为需调整。
+- `vortex_observe(filter='interactive')` 不再输出无 role / 无 name 的 `[tabindex]` 容器；如果旧 LLM prompt 依赖 phantom `[div]` 数量校准，需重新核对。
+- `cursor:pointer` 启发式新增大量自定义元素到候选集（含 `<el-button>` 等），单次 observe 输出元素数显著增加（leaf-only filter 已尽量去重）。
+- 重复结构页面的 `ScannedElement._sel` 字段在 ambiguous 时为 `[data-vortex-rid="..."]`，**`data-vortex-rid` 是 vortex 保留的 DOM attribute（业务请勿使用）**。
+
+---
+
 ## [0.6.0] - 2026-05-01
 
 ### 💥 BREAKING CHANGES

--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -628,8 +628,9 @@ async function scanOneFrame(
       world: "MAIN",
     });
     return (results[0]?.result as FramePageResult | undefined) ?? null;
-  } catch {
+  } catch (err) {
     // 跨源 iframe 无权限 / frame 已销毁：不 throw，返回 null 让上层标记为未扫
+    console.warn(`[vortex.scanOneFrame] failed fid=${frameId} err=`, err);
     return null;
   }
 }
@@ -683,6 +684,9 @@ export function registerObserveHandlers(router: ActionRouter): void {
           includeAX,
           filterMode,
         );
+        if (page === null) {
+          console.warn(`[vortex.observe] scanOneFrame null fid=${f.frameId} url=${f.url}`);
+        }
         scans.push({
           frameId: f.frameId,
           url: f.url,

--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -398,6 +398,43 @@ async function scanOneFrame(
         }
 
         const nodeList = document.querySelectorAll(INTERACTIVE_SELECTORS);
+
+        // BUG-1: cursor:pointer fallback for custom interactive elements.
+        // bytenew / Element Plus / Ant Design 等中文 SaaS 框架普遍用
+        // <li/div cursor:pointer @click=...> 而非原生 button / [role=button]，
+        // 静态白名单完全捕获不到。事件挂在 Vue/React vnode 层，元素本身
+        // 没 onclick 也没 framework key，所以走 computed style 兜底。
+        const interactiveSet = new Set<Element>(Array.from(nodeList));
+        const fallbackPool = document.querySelectorAll(
+          "div, li, span, a:not([href])",
+        );
+        const cursorPointerExtras: Element[] = [];
+        for (const el of Array.from(fallbackPool)) {
+          if (interactiveSet.has(el)) continue;
+          // Skip wrappers that already contain a real interactive child —
+          // we don't want both the <li> and the <button> inside it.
+          if (el.querySelector(INTERACTIVE_SELECTORS)) continue;
+          const htmlEl = el as HTMLElement;
+          if (htmlEl.offsetWidth === 0 || htmlEl.offsetHeight === 0) continue;
+          if (getComputedStyle(htmlEl).cursor !== "pointer") continue;
+          const name = (
+            el.getAttribute("aria-label") ||
+            htmlEl.innerText ||
+            ""
+          )
+            .trim()
+            .slice(0, 100);
+          // Require a name to avoid noise from purely decorative
+          // cursor:pointer wrappers (e.g. close-button icons handled by
+          // event delegation but visually rendered as bare divs).
+          if (!name) continue;
+          cursorPointerExtras.push(el);
+        }
+        const allCandidates: Element[] = [
+          ...Array.from(nodeList),
+          ...cursorPointerExtras,
+        ];
+
         const elements: Array<{
           index: number;
           tag: string;
@@ -412,7 +449,7 @@ async function scanOneFrame(
           _sel: string;
         }> = [];
 
-        for (const el of Array.from(nodeList)) {
+        for (const el of allCandidates) {
           if (elements.length >= max) break;
           const htmlEl = el as HTMLElement;
           const rect = htmlEl.getBoundingClientRect();
@@ -489,7 +526,7 @@ async function scanOneFrame(
             scrollHeight: document.documentElement.scrollHeight,
           },
           elements,
-          candidateCount: nodeList.length,
+          candidateCount: allCandidates.length,
           truncated: elements.length >= max,
         };
       },

--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -160,14 +160,21 @@ async function scanOneFrame(
       ) => {
         // Per-observe rid prefix used as identity fallback when buildSelector
         // can't produce a page-unique CSS selector (e.g. Element Plus v-for
-        // groups with identical inner DOM — bytenew testc dogfood Bug 4).
-        // Ambiguous elements are stamped with `data-vortex-rid` so the @fNeM
-        // ref system resolves them by identity instead of degrading to a
-        // querySelectorAll path that matches multiple siblings.
+        // groups with identical inner DOM). Ambiguous elements are stamped
+        // with `data-vortex-rid` so the @fNeM ref system resolves them by
+        // identity instead of degrading to a path that matches multiple
+        // siblings.
         const ridPrefix = `vtx${Date.now().toString(36)}${Math.random()
           .toString(36)
           .slice(2, 6)}_`;
         let ridCounter = 0;
+        // Clear stale rids from previous observes on this frame so the
+        // attribute set never accumulates across long-lived SPA sessions
+        // and stale snapshot refs can't silently resolve to mis-rendered
+        // elements (review feedback on PR #19).
+        for (const stale of document.querySelectorAll("[data-vortex-rid]")) {
+          stale.removeAttribute("data-vortex-rid");
+        }
 
         const INTERACTIVE_SELECTORS = [
           "button",
@@ -331,11 +338,17 @@ async function scanOneFrame(
             try {
               el.setAttribute("data-vortex-rid", rid);
               return `[data-vortex-rid="${rid}"]`;
-            } catch {
+            } catch (err) {
               // setAttribute can throw on non-Element nodes or sandboxed
               // shadows; fall through to the (still-ambiguous) path so
               // the runtime gets a legible SELECTOR_AMBIGUOUS instead of
-              // crashing the scan.
+              // crashing the scan. Surface the failure to console so it
+              // shows up in vortex_debug_read instead of disappearing.
+              try {
+                console.warn("[vortex] data-vortex-rid stamp failed", err);
+              } catch {
+                // console may itself be sandboxed; ignore.
+              }
             }
           }
           return sel;
@@ -426,9 +439,17 @@ async function scanOneFrame(
         const fallbackPool = document.querySelectorAll(
           "*:not(svg *):not(script):not(style):not(meta):not(link):not(head):not(head *)",
         );
+        const FALLBACK_CAP = 5000; // hard ceiling against pathological pages
+        const docRoot = document.documentElement;
+        const docBody = document.body;
         const cursorPointerExtras: Element[] = [];
         for (const el of Array.from(fallbackPool)) {
+          if (cursorPointerExtras.length >= FALLBACK_CAP) break;
           if (interactiveSet.has(el)) continue;
+          // Skip <html> / <body> — a SPA setting cursor:pointer on the root
+          // (e.g. global drag layer) would otherwise pull the entire page
+          // text in as a single candidate.
+          if (el === docRoot || el === docBody) continue;
           // Skip wrappers that already contain a real interactive child —
           // we don't want both the <li> and the <button> inside it.
           // (Use INTERACTIVE_SELECTORS, not the table-extended set, so
@@ -438,9 +459,13 @@ async function scanOneFrame(
           const htmlEl = el as HTMLElement;
           if (htmlEl.offsetWidth === 0 || htmlEl.offsetHeight === 0) continue;
           if (getComputedStyle(htmlEl).cursor !== "pointer") continue;
-          const name = (
+          // Use textContent for the gate check — innerText forces layout
+          // and we only need the gate decision here. The accessible name
+          // for output goes through getAccessibleName later, which already
+          // pays the layout cost only on candidates that survive.
+          const probe = (
             el.getAttribute("aria-label") ||
-            htmlEl.innerText ||
+            el.textContent ||
             ""
           )
             .trim()
@@ -448,7 +473,7 @@ async function scanOneFrame(
           // Require a name to avoid noise from purely decorative
           // cursor:pointer wrappers (e.g. close-button icons handled by
           // event delegation but visually rendered as bare divs).
-          if (!name) continue;
+          if (!probe) continue;
           cursorPointerExtras.push(el);
         }
         // Leaf-only: bytenew sidebar (and many Element Plus components)
@@ -457,13 +482,24 @@ async function scanOneFrame(
         // duplicates. Prefer the innermost candidate — it's closest to
         // the actual click target and downstream act will event-bubble
         // to ancestors anyway.
-        const cursorPointerLeaves = cursorPointerExtras.filter((el) => {
-          for (const other of cursorPointerExtras) {
-            if (other === el) continue;
-            if (el.contains(other)) return false; // ancestor of a candidate
+        // Walk parents once per candidate (O(N·depth)) instead of the
+        // O(N²) `el.contains(other)` cross-product the original implementation
+        // used (review feedback on PR #19).
+        const candidateSet = new Set<Element>(cursorPointerExtras);
+        const isAncestorOfCandidate = new WeakSet<Element>();
+        for (const el of cursorPointerExtras) {
+          let p: Element | null = el.parentElement;
+          while (p) {
+            if (candidateSet.has(p)) {
+              isAncestorOfCandidate.add(p);
+              break; // chain marked; deeper ancestors handled when reached
+            }
+            p = p.parentElement;
           }
-          return true;
-        });
+        }
+        const cursorPointerLeaves = cursorPointerExtras.filter(
+          (el) => !isAncestorOfCandidate.has(el),
+        );
         const allCandidates: Element[] = [
           ...Array.from(nodeList),
           ...cursorPointerLeaves,
@@ -536,12 +572,16 @@ async function scanOneFrame(
           // main frame that LLMs could not interpret.
           if (filter === "interactive") {
             const tag = htmlEl.tagName.toLowerCase();
+            // `a` only counts as form-like when it has href — the
+            // INTERACTIVE_SELECTORS whitelist also requires `a[href]`,
+            // so a bare nameless <a> from the cursor:pointer fallback
+            // shouldn't bypass the noise filter (review feedback on PR #19).
             const formLike =
               tag === "input" ||
               tag === "select" ||
               tag === "textarea" ||
               tag === "button" ||
-              tag === "a";
+              (tag === "a" && htmlEl.hasAttribute("href"));
             const hasExplicitRole =
               !!htmlEl.getAttribute("role") ||
               !!htmlEl.getAttribute("aria-label");

--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -146,6 +146,7 @@ async function scanOneFrame(
   viewport: "visible" | "full",
   includeText: boolean,
   includeAX: boolean,
+  filterMode: "interactive" | "all",
 ): Promise<FramePageResult | null> {
   try {
     const results = await chrome.scripting.executeScript({
@@ -155,6 +156,7 @@ async function scanOneFrame(
         mode: string,
         withText: boolean,
         withAX: boolean,
+        filter: "interactive" | "all",
       ) => {
         // Per-observe rid prefix used as identity fallback when buildSelector
         // can't produce a page-unique CSS selector (e.g. Element Plus v-for
@@ -397,7 +399,19 @@ async function scanOneFrame(
           return Object.keys(s).length > 0 ? s : undefined;
         }
 
-        const nodeList = document.querySelectorAll(INTERACTIVE_SELECTORS);
+        // BUG-2: filter='all' previously was a dead parameter — server.ts
+        // forwarded it but the handler never read args.filter, so the public
+        // schema's promise of "non-interactive elements too" silently
+        // degraded to the interactive whitelist. Honor it now by appending
+        // structural roles that table-heavy pages expose (rows / cells /
+        // column headers) so LLMs can reference data grid coordinates.
+        const TABLE_EXTRA_SELECTORS =
+          "tr,td,th,[role=row],[role=cell],[role=columnheader],[role=rowheader],[role=gridcell]";
+        const ROOT_SELECTORS =
+          filter === "all"
+            ? `${INTERACTIVE_SELECTORS},${TABLE_EXTRA_SELECTORS}`
+            : INTERACTIVE_SELECTORS;
+        const nodeList = document.querySelectorAll(ROOT_SELECTORS);
 
         // BUG-1: cursor:pointer fallback for custom interactive elements.
         // bytenew / Element Plus / Ant Design 等中文 SaaS 框架普遍用
@@ -413,6 +427,9 @@ async function scanOneFrame(
           if (interactiveSet.has(el)) continue;
           // Skip wrappers that already contain a real interactive child —
           // we don't want both the <li> and the <button> inside it.
+          // (Use INTERACTIVE_SELECTORS, not the table-extended set, so
+          // table cells with cursor:pointer still get collected when
+          // filter='all'.)
           if (el.querySelector(INTERACTIVE_SELECTORS)) continue;
           const htmlEl = el as HTMLElement;
           if (htmlEl.offsetWidth === 0 || htmlEl.offsetHeight === 0) continue;
@@ -530,7 +547,7 @@ async function scanOneFrame(
           truncated: elements.length >= max,
         };
       },
-      args: [maxElements, viewport, includeText, includeAX],
+      args: [maxElements, viewport, includeText, includeAX, filterMode],
       world: "MAIN",
     });
     return (results[0]?.result as FramePageResult | undefined) ?? null;
@@ -555,6 +572,11 @@ export function registerObserveHandlers(router: ActionRouter): void {
       const includeText = (args.includeText as boolean | undefined) ?? true;
       const includeAX = (args.includeAX as boolean | undefined) ?? true;
       const format = (args.format as "compact" | "full" | undefined) ?? "full";
+      // BUG-2: filter was a dead parameter — public schema exposed
+      // ['interactive','all'] but the handler never read it. 'all' now
+      // also collects table rows / cells / column headers.
+      const filterMode =
+        (args.filter as "interactive" | "all" | undefined) ?? "interactive";
 
       const frameTargets = await resolveTargetFrames(tid, explicitFrameId, framesParam);
       if (frameTargets.length === 0) {
@@ -582,6 +604,7 @@ export function registerObserveHandlers(router: ActionRouter): void {
           viewport,
           includeText,
           includeAX,
+          filterMode,
         );
         scans.push({
           frameId: f.frameId,

--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -511,6 +511,26 @@ async function scanOneFrame(
           const role = withAX ? getRole(htmlEl) : htmlEl.tagName.toLowerCase();
           const name = withText ? getAccessibleName(htmlEl) : "";
 
+          // BUG-3: in filter='interactive' mode, drop wrappers that the
+          // selector caught structurally but carry no semantic info —
+          // typically Element Plus el-popover__reference triggers
+          // (`<div tabindex="0">` with no role / aria-label / text). On
+          // bytenew testc this produced 3 phantom `[div]` entries on the
+          // main frame that LLMs could not interpret.
+          if (filter === "interactive") {
+            const tag = htmlEl.tagName.toLowerCase();
+            const formLike =
+              tag === "input" ||
+              tag === "select" ||
+              tag === "textarea" ||
+              tag === "button" ||
+              tag === "a";
+            const hasExplicitRole =
+              !!htmlEl.getAttribute("role") ||
+              !!htmlEl.getAttribute("aria-label");
+            if (!formLike && !hasExplicitRole && !name) continue;
+          }
+
           // 这里的 index 是 frame 内局部 id，observer handler 侧重编全局 index
           const state = getUiState(htmlEl);
           elements.push({

--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -419,8 +419,12 @@ async function scanOneFrame(
         // 静态白名单完全捕获不到。事件挂在 Vue/React vnode 层，元素本身
         // 没 onclick 也没 framework key，所以走 computed style 兜底。
         const interactiveSet = new Set<Element>(Array.from(nodeList));
+        // Sweep all elements (Vue/React UI libs frequently use custom
+        // tags like <el-button> / <a-link> / <van-cell> for interactive
+        // widgets — bytenew testc 行操作 link is <el-button> not <div>),
+        // skipping svg internals + non-rendered tags for perf.
         const fallbackPool = document.querySelectorAll(
-          "div, li, span, a:not([href])",
+          "*:not(svg *):not(script):not(style):not(meta):not(link):not(head):not(head *)",
         );
         const cursorPointerExtras: Element[] = [];
         for (const el of Array.from(fallbackPool)) {
@@ -447,9 +451,22 @@ async function scanOneFrame(
           if (!name) continue;
           cursorPointerExtras.push(el);
         }
+        // Leaf-only: bytenew sidebar (and many Element Plus components)
+        // nest cursor:pointer over 3-4 levels (li → div → div → div with
+        // text), and emitting every level burns the maxElements budget on
+        // duplicates. Prefer the innermost candidate — it's closest to
+        // the actual click target and downstream act will event-bubble
+        // to ancestors anyway.
+        const cursorPointerLeaves = cursorPointerExtras.filter((el) => {
+          for (const other of cursorPointerExtras) {
+            if (other === el) continue;
+            if (el.contains(other)) return false; // ancestor of a candidate
+          }
+          return true;
+        });
         const allCandidates: Element[] = [
           ...Array.from(nodeList),
-          ...cursorPointerExtras,
+          ...cursorPointerLeaves,
         ];
 
         const elements: Array<{

--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -156,6 +156,17 @@ async function scanOneFrame(
         withText: boolean,
         withAX: boolean,
       ) => {
+        // Per-observe rid prefix used as identity fallback when buildSelector
+        // can't produce a page-unique CSS selector (e.g. Element Plus v-for
+        // groups with identical inner DOM — bytenew testc dogfood Bug 4).
+        // Ambiguous elements are stamped with `data-vortex-rid` so the @fNeM
+        // ref system resolves them by identity instead of degrading to a
+        // querySelectorAll path that matches multiple siblings.
+        const ridPrefix = `vtx${Date.now().toString(36)}${Math.random()
+          .toString(36)
+          .slice(2, 6)}_`;
+        let ridCounter = 0;
+
         const INTERACTIVE_SELECTORS = [
           "button",
           "a[href]",
@@ -308,7 +319,24 @@ async function scanOneFrame(
             cur = parent;
             depth++;
           }
-          return parts.join(" > ");
+          const sel = parts.join(" > ");
+          // Path may collide with sibling structures (Element Plus v-for
+          // groups, repeated table rows, etc.). When ambiguous, stamp the
+          // element with a unique data-vortex-rid attribute and return
+          // that — guarantees a 1:1 selector for downstream act/extract.
+          if (document.querySelectorAll(sel).length > 1) {
+            const rid = ridPrefix + ridCounter++;
+            try {
+              el.setAttribute("data-vortex-rid", rid);
+              return `[data-vortex-rid="${rid}"]`;
+            } catch {
+              // setAttribute can throw on non-Element nodes or sandboxed
+              // shadows; fall through to the (still-ambiguous) path so
+              // the runtime gets a legible SELECTOR_AMBIGUOUS instead of
+              // crashing the scan.
+            }
+          }
+          return sel;
         }
 
         function describeElement(el: Element): string {

--- a/packages/mcp/src/lib/observe-render.ts
+++ b/packages/mcp/src/lib/observe-render.ts
@@ -61,13 +61,20 @@ export function renderObserveCompact(data: CompactObserve): string {
     const name = el.name ? ` "${escapeName(el.name)}"` : "";
     lines.push(`${refOf(el)} [${el.role}]${name}${stateFlags(el.state)}`);
   }
-  // 未扫 frame 提示
-  const unscanned = (data.frames ?? []).filter((f) => !f.scanned);
-  if (unscanned.length > 0) {
-    lines.push("");
-    for (const f of unscanned) {
-      lines.push(`# frame ${f.frameId} not scanned (url=${f.url})`);
+  // Frame 状态提示：1) 未扫的（cross-origin/destroyed）2) 扫描成功但 0 元素的
+  // sub-frame。后者之前沉默 → 多 frame 场景下 LLM 看不到子 frame 存在就会
+  // 下结论 "frame walker 漏掉了"（见 testc 评价分析 dogfood 误诊）。
+  const scanNotes: string[] = [];
+  for (const f of data.frames ?? []) {
+    if (!f.scanned) {
+      scanNotes.push(`# frame ${f.frameId} not scanned (url=${f.url})`);
+    } else if (f.elementCount === 0 && f.frameId !== 0) {
+      scanNotes.push(`# frame ${f.frameId} scanned, 0 interactive elements (url=${f.url})`);
     }
+  }
+  if (scanNotes.length > 0) {
+    lines.push("");
+    lines.push(...scanNotes);
   }
   return lines.join("\n");
 }

--- a/packages/mcp/tests/observe-render.test.ts
+++ b/packages/mcp/tests/observe-render.test.ts
@@ -74,4 +74,45 @@ describe("renderObserveCompact", () => {
     // 含完整头部（title/viewport/frames）约 200B，元素列表 ~2KB；整体 ≤ 2.5KB
     expect(bytes).toBeLessThan(2560);
   });
+
+  it("scanned 但 0 元素的 sub-frame 公开为注释提示", () => {
+    // bytenew testc 评价分析嵌套 iframe 场景：fid=22 已被扫描但页面无 interactive
+    // 元素，prior renderer 沉默不报 → 多 frame 调试时误诊为 frame walker 漏。
+    const data = {
+      ...sample,
+      frames: [
+        { frameId: 0, parentFrameId: -1, url: "https://main.example/", offset: { x: 0, y: 0 }, elementCount: 1, truncated: false, scanned: true },
+        { frameId: 22, parentFrameId: 19, url: "https://main.example/sub", offset: { x: 0, y: 0 }, elementCount: 0, truncated: false, scanned: true },
+      ],
+      elements: [{ index: 0, tag: "button", role: "button", name: "ok", frameId: 0 }],
+    };
+    const out = renderObserveCompact(data);
+    expect(out).toContain("# frame 22 scanned, 0 interactive elements");
+  });
+
+  it("scanned 但 0 元素的主 frame 不重复输出（避免噪声）", () => {
+    const data = {
+      ...sample,
+      frames: [
+        { frameId: 0, parentFrameId: -1, url: "https://main.example/", offset: { x: 0, y: 0 }, elementCount: 0, truncated: false, scanned: true },
+      ],
+      elements: [],
+    };
+    const out = renderObserveCompact(data);
+    expect(out).not.toContain("# frame 0");
+  });
+
+  it("未扫 sub-frame 仍用 not scanned 提示（向后兼容）", () => {
+    const data = {
+      ...sample,
+      frames: [
+        { frameId: 0, parentFrameId: -1, url: "https://main.example/", offset: { x: 0, y: 0 }, elementCount: 1, truncated: false, scanned: true },
+        { frameId: 5, parentFrameId: 0, url: "https://other.example/", offset: { x: 0, y: 0 }, elementCount: 0, truncated: false, scanned: false },
+      ],
+      elements: [{ index: 0, tag: "button", role: "button", name: "ok", frameId: 0 }],
+    };
+    const out = renderObserveCompact(data);
+    expect(out).toContain("# frame 5 not scanned");
+    expect(out).not.toContain("# frame 5 scanned");
+  });
 });


### PR DESCRIPTION
## Summary
v0.7 dogfood batch — 7 commits stacked, fixing 6 bug classes plus observer-renderer visibility for 0-element sub-frames. Closes #16 #17 #18.

## Commits
```
ea38b03 feat: surface scanned-but-empty sub-frames in observe output
cb8bf4e fix(extension): observe scanner — review feedback on PR #19
aaa583e fix(extension): cursor:pointer fallback covers all elements + leaf-only
7af7d43 fix(extension): drop nameless containers in filter=interactive (Bug 3)
6144b47 fix(extension): wire args.filter='all' through observe handler (Bug 2)
db5a680 fix(extension): observe scanner adds cursor:pointer fallback (Bug 1)
442e9a9 fix(extension): stamp ambiguous-path elements with unique attribute (Bug 4)
```

## Bugs fixed
- **Bug 1** — `cursor:pointer` Vue/Element-UI elements (`<el-button>`, sidebar `<li>`) were invisible to vortex_observe; covered by `*:not(svg *)…` fallback selector with leaf-only filter to suppress nested ancestor noise.
- **Bug 2** — `args.filter='all'` was a dead parameter on the extension side; now actually unions table roles (`tr/td/th/role=row|cell|columnheader`).
- **Bug 3** — Nameless `[tabindex]` containers (e.g. `el-popover__reference`) leaked into `filter=interactive`; now post-filtered when `name` empty and not form-like / role-bearing.
- **Bug 4** — `SELECTOR_AMBIGUOUS` on Element-UI v-for repeating siblings; ambiguous elements now stamped with `data-vortex-rid` for ref-based identity instead of degrading to a path that matches multiple targets.
- **Renderer hint** — `observe` previously stayed silent on sub-frames that scanned successfully but had 0 interactive elements (e.g. nested chart-only iframes), causing false "frame walker missed it" diagnoses. Renderer now emits `# frame N scanned, 0 interactive elements`.
- **scanOneFrame warn** — `console.warn` on null scan result so production debug no longer requires a source patch.

## Dogfood (testc.bytenew.com, 20-case eval)
Comprehensive Phase 1–6 evaluation against testc bytenew SaaS (VOC 工作台 + 小程序 + 评价规则 form-heavy + 评价分析 3-layer iframe), playwright baseline vs vortex with token-bytes measurement:

| Metric | Threshold | Result |
|---|---|---|
| PASS rate | ≥ 95% | **95%** (18 PASS / 1 PARTIAL skipped / 0 FAIL) |
| Step ratio | ≤ +2 vs playwright | **−14%** (30 vs 35) |
| **Bytes ratio** | ≤ 0.50 | **0.39** (~31K vs ~80K) |

Vortex one-shot wins (vs playwright multi-step): el-button row clicks (B-06/B-08/B-09/D-05), embedded `[checked]/[selected]` state, tiny `extract` returns (150B vs 3-15K).

## Test plan
- [x] mcp 229/229 ✓ (3 new renderer tests)
- [x] extension 199/205 ✓ (6 fail = pre-existing #13 dom-commit debt, unrelated)
- [x] testc Phase 1–4 dogfood verified, Phase 6 acceptance gates met
- [x] Service-worker debug exposed earlier diagnosis was wrong (B-11 not a frame walker bug)

## v0.7.x backlog (deferred)
1. menuitem `name` innerText concatenation (carries from v0.6.1)
2. menuitem + cursor:pointer fallback dual-instance
3. filter='all' span duplicates (B-02 leaf-only)
4. vortex_navigate intermediate URL on multi-stage hash routing

Closes #16 #17 #18