### PR TITLE
feat(bench): 自主发现引擎 #1 MVP — bench scan 子命令

### DIFF
--- a/packages/vortex-bench/.gitignore
+++ b/packages/vortex-bench/.gitignore
@@ -11,3 +11,6 @@ reports/*.json
 !reports/archive/
 reports/*.md
 !reports/README.md
+
+# scan 运行产物(transient discovery 报告,按时间戳生成,不入库)
+reports/scan/

--- a/packages/vortex-bench/playground/public/synth/aria-cursor-dedup.html
+++ b/packages/vortex-bench/playground/public/synth/aria-cursor-dedup.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="zh"><head><meta charset="utf-8"><title>aria cursor dedup</title>
+<style>.item{cursor:pointer}</style></head><body>
+<h1>ARIA + cursor 嵌套去重</h1>
+<ul>
+  <!-- li[role=menuitem] 内层再套 cursor:pointer div:observe 应只输出 1 行,不 dual-instance -->
+  <li role="menuitem" data-vtx-oracle="home"><div class="item">首页</div></li>
+  <li role="menuitem" data-vtx-oracle="about"><div class="item">关于</div></li>
+</ul>
+</body></html>

--- a/packages/vortex-bench/playground/public/synth/aria-cursor-dedup.manifest.json
+++ b/packages/vortex-bench/playground/public/synth/aria-cursor-dedup.manifest.json
@@ -1,0 +1,9 @@
+{
+  "fixture": "aria-cursor-dedup",
+  "path": "/synth/aria-cursor-dedup.html",
+  "frames": "main",
+  "entries": [
+    { "id": "home", "interactive": true, "expectedName": "首页", "expectedRole": "menuitem", "pattern": "aria-cursor-dedup", "note": "外层 li 与内层 div 不应产生两行" },
+    { "id": "about", "interactive": true, "expectedName": "关于", "expectedRole": "menuitem", "pattern": "aria-cursor-dedup" }
+  ]
+}

--- a/packages/vortex-bench/playground/public/synth/cursor-pointer-div.html
+++ b/packages/vortex-bench/playground/public/synth/cursor-pointer-div.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="zh"><head><meta charset="utf-8"><title>cursor pointer</title>
+<style>.btn{cursor:pointer;display:inline-block;padding:8px 16px;border:1px solid #888;margin:8px}</style>
+</head><body>
+<h1>cursor:pointer div 识别</h1>
+<!-- 无 role 的可点 div,靠 cursor:pointer 启发式;observe 应识别 -->
+<div class="btn" data-vtx-oracle="save" onclick="void 0">保存</div>
+<div class="btn" data-vtx-oracle="open-menu" onclick="void 0">打开菜单</div>
+<!-- 真 button 对照组 -->
+<button data-vtx-oracle="real-btn">真按钮</button>
+</body></html>

--- a/packages/vortex-bench/playground/public/synth/cursor-pointer-div.manifest.json
+++ b/packages/vortex-bench/playground/public/synth/cursor-pointer-div.manifest.json
@@ -1,0 +1,10 @@
+{
+  "fixture": "cursor-pointer-div",
+  "path": "/synth/cursor-pointer-div.html",
+  "frames": "main",
+  "entries": [
+    { "id": "save", "interactive": true, "expectedName": "保存", "expectedRole": null, "pattern": "cursor-pointer-div", "note": "无 role 的 cursor:pointer div" },
+    { "id": "open-menu", "interactive": true, "expectedName": "打开菜单", "expectedRole": null, "pattern": "cursor-pointer-div" },
+    { "id": "real-btn", "interactive": true, "expectedName": "真按钮", "expectedRole": "button", "pattern": "cursor-pointer-div", "note": "正对照" }
+  ]
+}

--- a/packages/vortex-bench/playground/public/synth/icon-name-priority.html
+++ b/packages/vortex-bench/playground/public/synth/icon-name-priority.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="zh"><head><meta charset="utf-8"><title>icon name</title>
+<style>.icon{cursor:pointer;width:32px;height:32px;display:inline-block}</style></head><body>
+<h1>图标命名优先级</h1>
+<span class="icon el-icon-close" data-vtx-oracle="svg-title" role="button">
+  <svg width="24" height="24"><title>关闭</title><rect width="24" height="24"/></svg>
+</span>
+<span class="icon iconfont" data-vtx-oracle="img-alt" role="button">
+  <img src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" alt="搜索" width="24" height="24">
+</span>
+</body></html>

--- a/packages/vortex-bench/playground/public/synth/icon-name-priority.manifest.json
+++ b/packages/vortex-bench/playground/public/synth/icon-name-priority.manifest.json
@@ -1,0 +1,9 @@
+{
+  "fixture": "icon-name-priority",
+  "path": "/synth/icon-name-priority.html",
+  "frames": "main",
+  "entries": [
+    { "id": "svg-title", "interactive": true, "expectedName": "关闭", "expectedRole": "button", "pattern": "icon-name-priority", "note": "svg <title> 优先于 className el-icon-close" },
+    { "id": "img-alt", "interactive": true, "expectedName": "搜索", "expectedRole": "button", "pattern": "icon-name-priority", "note": "img alt 优先于 className iconfont(denylist)" }
+  ]
+}

--- a/packages/vortex-bench/playground/public/synth/iframe-srcdoc-inherit.html
+++ b/packages/vortex-bench/playground/public/synth/iframe-srcdoc-inherit.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html lang="zh"><head><meta charset="utf-8"><title>srcdoc inherit</title></head><body>
+<h1>srcdoc iframe</h1>
+<button data-vtx-oracle="main-btn">主框按钮</button>
+<iframe srcdoc='<!doctype html><button>子框按钮</button>'></iframe>
+</body></html>

--- a/packages/vortex-bench/playground/public/synth/iframe-srcdoc-inherit.manifest.json
+++ b/packages/vortex-bench/playground/public/synth/iframe-srcdoc-inherit.manifest.json
@@ -1,0 +1,9 @@
+{
+  "fixture": "iframe-srcdoc-inherit",
+  "path": "/synth/iframe-srcdoc-inherit.html",
+  "frames": "all-same-origin",
+  "entries": [
+    { "id": "main-btn", "interactive": true, "expectedName": "主框按钮", "expectedRole": "button", "pattern": "iframe-srcdoc-inherit" },
+    { "id": "child-btn", "interactive": true, "expectedName": "子框按钮", "expectedRole": "button", "pattern": "iframe-srcdoc-inherit", "joinBy": "name", "note": "srcdoc 继承父 origin,observe(all-same-origin) 应返回;跨 frame 用 name-join" }
+  ]
+}

--- a/packages/vortex-bench/playground/public/synth/nameless-div-noise.html
+++ b/packages/vortex-bench/playground/public/synth/nameless-div-noise.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="zh"><head><meta charset="utf-8"><title>nameless noise</title></head><body>
+<h1>空 div 噪声(#18)</h1>
+<!-- 3 个无 name 的 tabindex div,observe 不该输出(precision) -->
+<div tabindex="0" data-vtx-oracle="noise-1"></div>
+<div tabindex="0" data-vtx-oracle="noise-2"></div>
+<div tabindex="0" data-vtx-oracle="noise-3"></div>
+<!-- 真按钮:observe 必须保留(防「全丢」假阴) -->
+<button data-vtx-oracle="real">点我</button>
+</body></html>

--- a/packages/vortex-bench/playground/public/synth/nameless-div-noise.manifest.json
+++ b/packages/vortex-bench/playground/public/synth/nameless-div-noise.manifest.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "nameless-div-noise",
+  "path": "/synth/nameless-div-noise.html",
+  "frames": "main",
+  "entries": [
+    { "id": "noise-1", "interactive": false, "expectedName": null, "expectedRole": null, "pattern": "nameless-div-noise", "note": "空 tabindex div,应被过滤" },
+    { "id": "noise-2", "interactive": false, "expectedName": null, "expectedRole": null, "pattern": "nameless-div-noise" },
+    { "id": "noise-3", "interactive": false, "expectedName": null, "expectedRole": null, "pattern": "nameless-div-noise" },
+    { "id": "real", "interactive": true, "expectedName": "点我", "expectedRole": "button", "pattern": "nameless-div-noise", "note": "正对照" }
+  ]
+}

--- a/packages/vortex-bench/playground/public/synth/open-shadow-nested.html
+++ b/packages/vortex-bench/playground/public/synth/open-shadow-nested.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="zh"><head><meta charset="utf-8"><title>open shadow</title></head><body>
+<h1>open shadow root 内层</h1>
+<my-widget data-vtx-oracle="shadow-btn"></my-widget>
+<script>
+customElements.define("my-widget", class extends HTMLElement {
+  connectedCallback(){
+    const sr=this.attachShadow({mode:"open"});
+    const b=document.createElement("button");
+    b.textContent="影子按钮";
+    sr.appendChild(b);
+  }
+});
+</script>
+</body></html>

--- a/packages/vortex-bench/playground/public/synth/open-shadow-nested.manifest.json
+++ b/packages/vortex-bench/playground/public/synth/open-shadow-nested.manifest.json
@@ -1,0 +1,8 @@
+{
+  "fixture": "open-shadow-nested",
+  "path": "/synth/open-shadow-nested.html",
+  "frames": "main",
+  "entries": [
+    { "id": "shadow-btn", "interactive": true, "expectedName": "影子按钮", "expectedRole": "button", "pattern": "open-shadow-nested", "note": "querySelectorAllDeep 应穿 open shadow;oracle rect 取宿主元素 bbox 近似" }
+  ]
+}

--- a/packages/vortex-bench/playground/public/synth/roleless-close-icon.html
+++ b/packages/vortex-bench/playground/public/synth/roleless-close-icon.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="zh"><head><meta charset="utf-8"><title>roleless close</title>
+<style>.close{cursor:pointer;position:absolute;top:8px;right:8px}</style></head><body>
+<h1>无 role 关闭 div</h1>
+<div class="modal">
+  <div class="close" data-vtx-oracle="close-x" onclick="void 0">✕</div>
+  <p>弹窗内容</p>
+</div>
+</body></html>

--- a/packages/vortex-bench/playground/public/synth/roleless-close-icon.manifest.json
+++ b/packages/vortex-bench/playground/public/synth/roleless-close-icon.manifest.json
@@ -1,0 +1,8 @@
+{
+  "fixture": "roleless-close-icon",
+  "path": "/synth/roleless-close-icon.html",
+  "frames": "main",
+  "entries": [
+    { "id": "close-x", "interactive": true, "expectedName": null, "expectedRole": null, "pattern": "roleless-close-icon", "note": "无 role/aria-label 的 cursor:pointer 关闭图标,期望被收(name 不强校验,✕ 可能转 closeIcon)" }
+  ]
+}

--- a/packages/vortex-bench/playground/public/synth/teleport-popper-overlay.html
+++ b/packages/vortex-bench/playground/public/synth/teleport-popper-overlay.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="zh"><head><meta charset="utf-8"><title>teleport popper</title></head><body>
+<h1>teleport 弹层</h1>
+<button data-vtx-oracle="dropdown-trigger" onclick="document.getElementById('pop').style.display='block'">下拉</button>
+<div id="root"></div>
+<!-- 弹层 portal 到 body 末尾(脱离 trigger DOM 子树) -->
+<div id="pop" style="display:block;position:absolute;top:120px;left:20px">
+  <div role="menuitem" data-vtx-oracle="opt-a">选项A</div>
+  <div role="menuitem" data-vtx-oracle="opt-b">选项B</div>
+</div>
+</body></html>

--- a/packages/vortex-bench/playground/public/synth/teleport-popper-overlay.manifest.json
+++ b/packages/vortex-bench/playground/public/synth/teleport-popper-overlay.manifest.json
@@ -1,0 +1,10 @@
+{
+  "fixture": "teleport-popper-overlay",
+  "path": "/synth/teleport-popper-overlay.html",
+  "frames": "main",
+  "entries": [
+    { "id": "dropdown-trigger", "interactive": true, "expectedName": "下拉", "expectedRole": "button", "pattern": "teleport-popper-overlay" },
+    { "id": "opt-a", "interactive": true, "expectedName": "选项A", "expectedRole": "menuitem", "pattern": "teleport-popper-overlay", "note": "portal 到 body 仍应被 observe 抓到" },
+    { "id": "opt-b", "interactive": true, "expectedName": "选项B", "expectedRole": "menuitem", "pattern": "teleport-popper-overlay" }
+  ]
+}

--- a/packages/vortex-bench/playground/public/synth/visibility-hidden-megamenu.html
+++ b/packages/vortex-bench/playground/public/synth/visibility-hidden-megamenu.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="zh"><head><meta charset="utf-8"><title>hidden megamenu</title></head><body>
+<h1>visibility:hidden 菜单</h1>
+<button data-vtx-oracle="trigger">菜单</button>
+<div style="visibility:hidden">
+  <a href="#" data-vtx-oracle="hidden-link">隐藏项</a>
+</div>
+</body></html>

--- a/packages/vortex-bench/playground/public/synth/visibility-hidden-megamenu.manifest.json
+++ b/packages/vortex-bench/playground/public/synth/visibility-hidden-megamenu.manifest.json
@@ -1,0 +1,9 @@
+{
+  "fixture": "visibility-hidden-megamenu",
+  "path": "/synth/visibility-hidden-megamenu.html",
+  "frames": "main",
+  "entries": [
+    { "id": "trigger", "interactive": true, "expectedName": "菜单", "expectedRole": "button", "pattern": "visibility-hidden-megamenu" },
+    { "id": "hidden-link", "interactive": false, "expectedName": null, "expectedRole": null, "pattern": "visibility-hidden-megamenu", "note": "visibility:hidden,不该被 observe 收" }
+  ]
+}

--- a/packages/vortex-bench/src/index.ts
+++ b/packages/vortex-bench/src/index.ts
@@ -14,6 +14,9 @@ import {
   renderBoxesBudgetTable,
 } from "./runner/boxes-budget.js";
 import type { BenchReport, CaseDefinition, CaseMetrics } from "./types.js";
+import { scanFixture } from "./runner/scan.js";
+import { renderScanMarkdown, rankFindings } from "./scan-report.js";
+import type { ScanReport, SynthManifest } from "./scan-types.js";
 
 const USAGE = `vortex-bench <command>
 
@@ -28,6 +31,8 @@ Commands:
                          issue #21 token budget sweep: 跑同一组 case 两遍
                          （baseline vs includeBoxes:true），输出 ratio /
                          median / p95 / max + reports/boxes-budget-*.json
+  scan --all             扫全部合成 fixture,产 reports/scan/<ts>.{md,json}
+  scan --pattern <name>  扫单个 pattern
   --help                 显示帮助
 
 Env:
@@ -40,6 +45,8 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const PKG_ROOT = resolve(HERE, "..");
 const CASES_DIR = resolve(PKG_ROOT, "cases");
 const REPORTS_DIR = resolve(PKG_ROOT, "reports");
+const SYNTH_DIR = resolve(PKG_ROOT, "playground", "public", "synth");
+const SCAN_REPORTS_DIR = resolve(REPORTS_DIR, "scan");
 
 function resolveMcpBin(): string {
   if (process.env.VORTEX_MCP_BIN) return resolve(process.env.VORTEX_MCP_BIN);
@@ -234,6 +241,69 @@ async function cmdBaseline(): Promise<number> {
   return 0;
 }
 
+async function listSynthManifests(): Promise<string[]> {
+  const entries = await readdir(SYNTH_DIR);
+  return entries
+    .filter((e) => e.endsWith(".manifest.json"))
+    .map((e) => e.replace(/\.manifest\.json$/, ""))
+    .sort();
+}
+
+async function loadManifest(name: string): Promise<SynthManifest> {
+  const path = resolve(SYNTH_DIR, `${name}.manifest.json`);
+  const m = JSON.parse(await readFile(path, "utf-8")) as SynthManifest;
+  if (!m.fixture || !m.path || !Array.isArray(m.entries)) {
+    throw new Error(`manifest ${name} 结构非法(需 fixture/path/entries)`);
+  }
+  return m;
+}
+
+async function cmdScan(args: string[]): Promise<number> {
+  const runAll = args.includes("--all");
+  let names: string[];
+  if (runAll) {
+    names = await listSynthManifests();
+  } else {
+    const patternIdx = args.indexOf("--pattern");
+    if (patternIdx >= 0 && args[patternIdx + 1]) names = [args[patternIdx + 1]];
+    else names = args.filter((a) => !a.startsWith("-"));
+  }
+  if (names.length === 0) {
+    process.stderr.write("[vortex-bench] scan 需要 --all 或 --pattern <name> 或 <name...>\n");
+    return 1;
+  }
+
+  const mcpBin = resolveMcpBin();
+  const url = playgroundUrl();
+  process.stdout.write(`[vortex-bench] scan  playground=${url}  mcp=${mcpBin}\n`);
+  process.stdout.write(`[vortex-bench] 扫 ${names.length} 个合成 fixture\n\n`);
+
+  const report: ScanReport = { generatedAt: new Date().toISOString(), playgroundUrl: url, fixtures: [], findings: [] };
+  for (const name of names) {
+    const manifest = await loadManifest(name);
+    const fx = await scanFixture(manifest, { mcpBin, playgroundUrl: url });
+    report.fixtures.push(fx);
+    report.findings.push(...fx.findings);
+    const p0 = fx.findings.filter((f) => f.severity === "P0").length;
+    process.stdout.write(
+      `${p0 === 0 ? "✓" : "✗"} ${name.padEnd(28)} recall=${fx.recall.matched}/${fx.recall.expected} ` +
+      `P0=${p0} findings=${fx.findings.length}${fx.error ? `  ⚠ ${fx.error}` : ""}\n`,
+    );
+  }
+  report.findings = rankFindings(report.findings);
+
+  await mkdir(SCAN_REPORTS_DIR, { recursive: true });
+  const stamp = report.generatedAt.replace(/[:.]/g, "-");
+  const jsonPath = join(SCAN_REPORTS_DIR, `${stamp}.json`);
+  const mdPath = join(SCAN_REPORTS_DIR, `${stamp}.md`);
+  await writeFile(jsonPath, JSON.stringify(report, null, 2));
+  await writeFile(mdPath, renderScanMarkdown(report));
+  process.stdout.write(`\n[report] ${mdPath}\n[report] ${jsonPath}\n`);
+
+  const totalP0 = report.findings.filter((f) => f.severity === "P0").length;
+  return totalP0 === 0 ? 0 : 2;
+}
+
 async function main(): Promise<number> {
   const [, , cmd, ...rest] = process.argv;
   if (!cmd || cmd === "--help" || cmd === "-h") {
@@ -249,6 +319,8 @@ async function main(): Promise<number> {
       return cmdBaseline();
     case "compare-boxes":
       return cmdCompareBoxes(rest);
+    case "scan":
+      return cmdScan(rest);
     default:
       process.stderr.write(`[vortex-bench] 未知命令: ${cmd}\n\n${USAGE}`);
       return 1;

--- a/packages/vortex-bench/src/index.ts
+++ b/packages/vortex-bench/src/index.ts
@@ -16,7 +16,7 @@ import {
 import type { BenchReport, CaseDefinition, CaseMetrics } from "./types.js";
 import { scanFixture } from "./runner/scan.js";
 import { renderScanMarkdown, rankFindings } from "./scan-report.js";
-import type { ScanReport, SynthManifest } from "./scan-types.js";
+import type { FixtureScanResult, ScanReport, SynthManifest } from "./scan-types.js";
 
 const USAGE = `vortex-bench <command>
 
@@ -280,8 +280,19 @@ async function cmdScan(args: string[]): Promise<number> {
 
   const report: ScanReport = { generatedAt: new Date().toISOString(), playgroundUrl: url, fixtures: [], findings: [] };
   for (const name of names) {
-    const manifest = await loadManifest(name);
-    const fx = await scanFixture(manifest, { mcpBin, playgroundUrl: url });
+    let fx: FixtureScanResult;
+    try {
+      const manifest = await loadManifest(name);
+      fx = await scanFixture(manifest, { mcpBin, playgroundUrl: url });
+    } catch (e) {
+      // manifest 缺失/非法等:记为该 fixture 的 error,不中断整轮扫描
+      fx = {
+        fixture: name, pattern: name, path: "",
+        recall: { matched: 0, expected: 0 }, precision: { matchedNoise: 0, emitted: 0 },
+        invariants: { inv1: false, inv2: false, inv3: false, inv4: false },
+        findings: [], error: `加载/扫描失败: ${e instanceof Error ? e.message : String(e)}`,
+      };
+    }
     report.fixtures.push(fx);
     report.findings.push(...fx.findings);
     const p0 = fx.findings.filter((f) => f.severity === "P0").length;

--- a/packages/vortex-bench/src/runner/geometry-join.ts
+++ b/packages/vortex-bench/src/runner/geometry-join.ts
@@ -1,0 +1,41 @@
+// packages/vortex-bench/src/runner/geometry-join.ts
+// observe 行 ↔ oracle rect 几何 join。主 frame bbox 即视口坐标;
+// 子 frame bbox 是 frame-local,需加 frameOffsets 复合到 top-page 坐标。
+
+import type { ObserveRow, OracleRect } from "../scan-types.js";
+
+type Box = [number, number, number, number];
+
+/** bbox 中心是否落在 rect 内(含边界) */
+export function centerInside(bbox: Box, rect: Box): boolean {
+  const cx = bbox[0] + bbox[2] / 2;
+  const cy = bbox[1] + bbox[3] / 2;
+  return cx >= rect[0] && cx <= rect[0] + rect[2] && cy >= rect[1] && cy <= rect[1] + rect[3];
+}
+
+export interface JoinResult {
+  /** oracleId → 命中它的 observe 行(可能多个 → INV-3 去重会另行处理) */
+  matches: Map<string, ObserveRow[]>;
+  /** 有 bbox 但没命中任何 oracle 的行(precision 候选) */
+  unmatchedRows: ObserveRow[];
+}
+
+export function joinByGeometry(
+  rows: ObserveRow[],
+  oracles: OracleRect[],
+  frameOffsets: Record<number, [number, number]>,
+): JoinResult {
+  const matches = new Map<string, ObserveRow[]>();
+  for (const o of oracles) matches.set(o.id, []);
+  const unmatchedRows: ObserveRow[] = [];
+
+  for (const r of rows) {
+    if (r.bbox === null) continue; // 无 bbox 不参与几何 join
+    const [dx, dy] = frameOffsets[r.frameId] ?? [0, 0];
+    const topBox: Box = [r.bbox[0] + dx, r.bbox[1] + dy, r.bbox[2], r.bbox[3]];
+    const hit = oracles.find((o) => centerInside(topBox, o.rect));
+    if (hit) matches.get(hit.id)!.push(r);
+    else unmatchedRows.push(r);
+  }
+  return { matches, unmatchedRows };
+}

--- a/packages/vortex-bench/src/runner/invariants.ts
+++ b/packages/vortex-bench/src/runner/invariants.ts
@@ -39,7 +39,7 @@ export function checkStability(a: ParsedObserve, b: ParsedObserve, fixture: stri
   for (const k of keys) {
     const na = ca.get(k) ?? 0;
     const nb = cb.get(k) ?? 0;
-    if (na !== nb) diffs.push(`${k.replace(" ", " ")}: ${na}→${nb}`);
+    if (na !== nb) diffs.push(`${k.replace(" ", "/")}: ${na}→${nb}`);
   }
   if (diffs.length === 0) return [];
   return [{ fixture, pattern, severity: "P1", kind: "inv1-instability",
@@ -82,7 +82,9 @@ export function checkBboxSanity(parsed: ParsedObserve, fixture: string, pattern:
     const bad: string[] = [];
     if (w <= 0 || h <= 0) bad.push(`退化尺寸 ${w}x${h}`);
     if (x < 0 || y < 0) bad.push(`负坐标 (${x},${y})`);
-    if (vp) {
+    // 视口越界类只对主 frame 判定:子 frame 元素坐标是 frame-local,
+    // 拿主 frame viewport 比会假阳。退化尺寸/负坐标对所有 frame 都查。
+    if (vp && r.frameId === 0) {
       if (w > vp.width * 2) bad.push(`宽 ${w} 超视口 2 倍(${vp.width})`);
       if (y > vp.scrollHeight + 50) bad.push(`y=${y} 超文档高 ${vp.scrollHeight}`);
     }

--- a/packages/vortex-bench/src/runner/invariants.ts
+++ b/packages/vortex-bench/src/runner/invariants.ts
@@ -1,0 +1,95 @@
+// packages/vortex-bench/src/runner/invariants.ts
+// C 不变量的纯逻辑部分。INV-2 的探针「执行」在 scan.ts(需活 MCP),
+// 这里只做结果「分类」(classifyProbe),保持本文件 100% 离线可测。
+
+import type { Finding, ObserveRow, ParsedObserve } from "../scan-types.js";
+
+type Box = [number, number, number, number];
+
+/** 两个 box 的 IoU(交并比) */
+export function iou(a: Box, b: Box): number {
+  const ix = Math.max(a[0], b[0]);
+  const iy = Math.max(a[1], b[1]);
+  const ix2 = Math.min(a[0] + a[2], b[0] + b[2]);
+  const iy2 = Math.min(a[1] + a[3], b[1] + b[3]);
+  const iw = Math.max(0, ix2 - ix);
+  const ih = Math.max(0, iy2 - iy);
+  const inter = iw * ih;
+  if (inter === 0) return 0;
+  const union = a[2] * a[3] + b[2] * b[3] - inter;
+  return union === 0 ? 0 : inter / union;
+}
+
+/** 元素的稳定性身份:role + name(bbox 抖动不计入身份,只看语义集合) */
+function identity(r: ObserveRow): string {
+  return `${r.role} ${r.name ?? ""}`;
+}
+
+/** INV-1:无 mutation 连跑两次 observe,可交互集合(role+name 计数)必须一致 */
+export function checkStability(a: ParsedObserve, b: ParsedObserve, fixture: string, pattern: string): Finding[] {
+  const count = (rows: ObserveRow[]): Map<string, number> => {
+    const m = new Map<string, number>();
+    for (const r of rows) m.set(identity(r), (m.get(identity(r)) ?? 0) + 1);
+    return m;
+  };
+  const ca = count(a.rows);
+  const cb = count(b.rows);
+  const keys = new Set([...ca.keys(), ...cb.keys()]);
+  const diffs: string[] = [];
+  for (const k of keys) {
+    const na = ca.get(k) ?? 0;
+    const nb = cb.get(k) ?? 0;
+    if (na !== nb) diffs.push(`${k.replace(" ", " ")}: ${na}→${nb}`);
+  }
+  if (diffs.length === 0) return [];
+  return [{ fixture, pattern, severity: "P1", kind: "inv1-instability",
+    detail: `两次 observe 集合不一致: ${diffs.join("; ")}` }];
+}
+
+export interface ProbeResult { text: string; threw: boolean; timedOut: boolean; }
+
+/** INV-2:把一次 ref 探针的结果分类。typed-error / ok 都算 PASS,crash 是 FAIL。 */
+export function classifyProbe(p: ProbeResult): "ok" | "typed-error" | "crash" {
+  if (p.threw || p.timedOut) return "crash";
+  if (/^Error \[[A-Z_]+\]:/m.test(p.text)) return "typed-error";
+  return "ok";
+}
+
+/** INV-3:同 role+name 且 bbox IoU>0.5 的两行视为重复 */
+export function checkDuplicates(rows: ObserveRow[], fixture: string, pattern: string): Finding[] {
+  const findings: Finding[] = [];
+  for (let i = 0; i < rows.length; i++) {
+    for (let j = i + 1; j < rows.length; j++) {
+      const a = rows[i], b = rows[j];
+      if (identity(a) !== identity(b)) continue;
+      if (a.bbox === null || b.bbox === null) continue;
+      if (iou(a.bbox, b.bbox) > 0.5) {
+        findings.push({ fixture, pattern, severity: "P2", kind: "inv3-duplicate", ref: b.ref,
+          detail: `重复行 ${a.ref} 与 ${b.ref}: [${a.role}] "${a.name ?? ""}"` });
+      }
+    }
+  }
+  return findings;
+}
+
+/** INV-4:bbox 合法性。需要 viewport 求边界;无 viewport 时跳过越界类检查。 */
+export function checkBboxSanity(parsed: ParsedObserve, fixture: string, pattern: string): Finding[] {
+  const findings: Finding[] = [];
+  const vp = parsed.header.viewport;
+  for (const r of parsed.rows) {
+    if (r.bbox === null) continue;
+    const [x, y, w, h] = r.bbox;
+    const bad: string[] = [];
+    if (w <= 0 || h <= 0) bad.push(`退化尺寸 ${w}x${h}`);
+    if (x < 0 || y < 0) bad.push(`负坐标 (${x},${y})`);
+    if (vp) {
+      if (w > vp.width * 2) bad.push(`宽 ${w} 超视口 2 倍(${vp.width})`);
+      if (y > vp.scrollHeight + 50) bad.push(`y=${y} 超文档高 ${vp.scrollHeight}`);
+    }
+    if (bad.length) {
+      findings.push({ fixture, pattern, severity: "P2", kind: "inv4-bbox", ref: r.ref,
+        detail: `bbox 异常 [${r.bbox.join(",")}]: ${bad.join(", ")}` });
+    }
+  }
+  return findings;
+}

--- a/packages/vortex-bench/src/runner/manifest-check.ts
+++ b/packages/vortex-bench/src/runner/manifest-check.ts
@@ -1,0 +1,62 @@
+// packages/vortex-bench/src/runner/manifest-check.ts
+// observe 输出 vs manifest ground truth → recall/precision/name/role finding。
+
+import type { Finding, OracleRect, ParsedObserve, SynthManifest } from "../scan-types.js";
+import { joinByGeometry } from "./geometry-join.js";
+
+export function checkManifest(
+  parsed: ParsedObserve,
+  oracles: OracleRect[],
+  manifest: SynthManifest,
+): Finding[] {
+  const findings: Finding[] = [];
+  const { matches, unmatchedRows } = joinByGeometry(parsed.rows, oracles, parsed.frameOffsets);
+
+  for (const entry of manifest.entries) {
+    const base = { fixture: manifest.fixture, pattern: entry.pattern, oracleId: entry.id };
+
+    // name-join 分支(跨 frame fixture):按 expectedName 在 observe 行里找
+    if (entry.joinBy === "name") {
+      const hit = parsed.rows.find((r) => r.name !== null && r.name === entry.expectedName);
+      if (entry.interactive && !hit) {
+        findings.push({ ...base, severity: "P0", kind: "recall-miss",
+          detail: `name-join: observe 未输出 name="${entry.expectedName}" 的可交互元素` });
+      }
+      continue;
+    }
+
+    const hits = matches.get(entry.id) ?? [];
+    if (entry.interactive) {
+      if (hits.length === 0) {
+        findings.push({ ...base, severity: "P0", kind: "recall-miss",
+          detail: `interactive 元素 #${entry.id} 未被任何 observe 行命中(漏识别)` });
+        continue;
+      }
+      // 命中:校验首个命中行的 name/role
+      const row = hits[0];
+      if (entry.expectedName !== null && row.name !== entry.expectedName) {
+        findings.push({ ...base, severity: "P1", kind: "name-mismatch", ref: row.ref,
+          detail: `#${entry.id} 期望 name="${entry.expectedName}",实际 "${row.name ?? ""}"` });
+      }
+      if (entry.expectedRole !== null && row.role !== entry.expectedRole) {
+        findings.push({ ...base, severity: "P1", kind: "role-mismatch", ref: row.ref,
+          detail: `#${entry.id} 期望 role=${entry.expectedRole},实际 ${row.role}` });
+      }
+    } else {
+      // interactive:false 却被命中 → 噪声
+      if (hits.length > 0) {
+        findings.push({ ...base, severity: "P2", kind: "precision-miss", ref: hits[0].ref,
+          detail: `#${entry.id} 标注为非交互,却被 observe 输出(噪声)` });
+      }
+    }
+  }
+
+  // 命中不到任何 oracle 的 observe 行:记为 P2 噪声(fixture 应标全;未标元素从轻)
+  for (const row of unmatchedRows) {
+    findings.push({ fixture: manifest.fixture, pattern: "_unannotated", severity: "P2",
+      kind: "precision-miss", ref: row.ref,
+      detail: `observe 行 ${row.ref} [${row.role}] "${row.name ?? ""}" 未匹配任何 oracle 标注` });
+  }
+
+  return findings;
+}

--- a/packages/vortex-bench/src/runner/manifest-check.ts
+++ b/packages/vortex-bench/src/runner/manifest-check.ts
@@ -51,8 +51,18 @@ export function checkManifest(
     }
   }
 
+  // joinBy:name 的 entry 靠 name 认领 observe 行(跨 frame 无 geometry oracle),
+  // 这些行必然落在 geometry 的 unmatchedRows 里。下面噪声扫描要排除它们,
+  // 否则被正确识别的跨 frame 元素会被误报成 _unannotated 噪声(自校准实测假阳)。
+  const nameClaimed = new Set(
+    manifest.entries
+      .filter((e) => e.joinBy === "name" && e.expectedName !== null)
+      .map((e) => e.expectedName as string),
+  );
+
   // 命中不到任何 oracle 的 observe 行:记为 P2 噪声(fixture 应标全;未标元素从轻)
   for (const row of unmatchedRows) {
+    if (row.name !== null && nameClaimed.has(row.name)) continue; // 已被 name-join 认领
     findings.push({ fixture: manifest.fixture, pattern: "_unannotated", severity: "P2",
       kind: "precision-miss", ref: row.ref,
       detail: `observe 行 ${row.ref} [${row.role}] "${row.name ?? ""}" 未匹配任何 oracle 标注` });

--- a/packages/vortex-bench/src/runner/observe-parser.ts
+++ b/packages/vortex-bench/src/runner/observe-parser.ts
@@ -1,0 +1,75 @@
+// packages/vortex-bench/src/runner/observe-parser.ts
+// observe compact 文本 → 结构化。契约见 observe-render.ts:57-121。
+
+import type { ObserveRow, ObserveHeader, ParsedObserve } from "../scan-types.js";
+
+// 元素行:@<ref> [<role>] "<name>"? (<flags>)* (bbox=[..])?
+// ref=@[\w:]+,role=[^\]]+,name 含转义 \" 与非 " 字符。
+const ROW_RE =
+  /^(@[\w:]+)\s+\[([^\]]+)\](?:\s+"((?:\\.|[^"\\])*)")?((?:\s+\[[a-z]+\])*)(?:\s+bbox=\[(\d+),(\d+),(\d+),(\d+)\])?\s*$/;
+const FLAG_RE = /\[([a-z]+)\]/g;
+const OFFSET_RE = /^#\s+frame\s+(\d+)\s+offset=\[(\d+),(\d+)\]/;
+const VIEWPORT_RE = /^Viewport:\s+(\d+)x(\d+),\s+scrollY=(\d+)\/(\d+)/;
+
+/** 从 ref 提取 frameId:@h:f<N>e<M> → N;无 fN 段 → 0 */
+function frameIdOf(ref: string): number {
+  const m = ref.match(/f(\d+)e\d+$/);
+  return m ? Number.parseInt(m[1], 10) : 0;
+}
+
+export function parseObserveSnapshot(text: string): ParsedObserve {
+  const header: ObserveHeader = { snapshotId: "", url: "" };
+  const rows: ObserveRow[] = [];
+  const frameOffsets: Record<number, [number, number]> = {};
+
+  for (const raw of text.split("\n")) {
+    const line = raw.trimEnd();
+    if (line.startsWith("SnapshotId:")) {
+      header.snapshotId = line.slice("SnapshotId:".length).trim();
+      continue;
+    }
+    if (line.startsWith("URL:")) {
+      header.url = line.slice("URL:".length).trim();
+      continue;
+    }
+    if (line.startsWith("Title:")) {
+      header.title = line.slice("Title:".length).trim();
+      continue;
+    }
+    const vp = line.match(VIEWPORT_RE);
+    if (vp) {
+      header.viewport = {
+        width: Number.parseInt(vp[1], 10),
+        height: Number.parseInt(vp[2], 10),
+        scrollY: Number.parseInt(vp[3], 10),
+        scrollHeight: Number.parseInt(vp[4], 10),
+      };
+      continue;
+    }
+    const off = line.match(OFFSET_RE);
+    if (off) {
+      frameOffsets[Number.parseInt(off[1], 10)] = [
+        Number.parseInt(off[2], 10),
+        Number.parseInt(off[3], 10),
+      ];
+      continue;
+    }
+    const m = line.match(ROW_RE);
+    if (m) {
+      const flags = m[4] ? [...m[4].matchAll(FLAG_RE)].map((f) => f[1]) : [];
+      const bbox: ObserveRow["bbox"] =
+        m[5] !== undefined
+          ? [Number.parseInt(m[5], 10), Number.parseInt(m[6], 10), Number.parseInt(m[7], 10), Number.parseInt(m[8], 10)]
+          : null;
+      rows.push({
+        ref: m[1],
+        role: m[2],
+        name: m[3] !== undefined ? m[3].replace(/\\"/g, '"') : null,
+        flags,
+        bbox,
+        frameId: frameIdOf(m[1]),
+      });
+    }
+  }
+  return { header, rows, frameOffsets };
+}

--- a/packages/vortex-bench/src/runner/scan.ts
+++ b/packages/vortex-bench/src/runner/scan.ts
@@ -40,7 +40,7 @@ export async function scanFixture(manifest: SynthManifest, opts: ScanOptions): P
     path: manifest.path,
     recall: { matched: 0, expected: 0 },
     precision: { matchedNoise: 0, emitted: 0 },
-    invariants: { inv1: true, inv2: true, inv3: true, inv4: true },
+    invariants: { inv1: false, inv2: false, inv3: false, inv4: false },
     findings: [],
   };
 
@@ -64,20 +64,27 @@ export async function scanFixture(manifest: SynthManifest, opts: ScanOptions): P
 
     // 2) oracle rect 探针(仅主 frame;跨 frame entry 走 joinBy:name)
     let oracles: OracleRect[] = [];
+    let oracleProbeFailed = false;
     try {
       oracles = JSON.parse(extractText(await call("vortex_evaluate", { code: ORACLE_PROBE_CODE }))) as OracleRect[];
     } catch (e) {
+      oracleProbeFailed = true;
       result.error = `oracle 探针失败: ${e instanceof Error ? e.message : String(e)}`;
     }
 
-    // manifest 裁决
-    const manifestFindings = checkManifest(parsed1, oracles, manifest);
-    result.findings.push(...manifestFindings);
-    result.recall.expected = manifest.entries.filter((e) => e.interactive).length;
-    result.recall.matched =
-      result.recall.expected - manifestFindings.filter((f) => f.kind === "recall-miss").length;
-    result.precision.emitted = parsed1.rows.length;
-    result.precision.matchedNoise = manifestFindings.filter((f) => f.kind === "precision-miss").length;
+    // manifest 裁决 —— 仅在 oracle 探针成功时跑。否则空 oracles 会让所有
+    // interactive 条目都 join 不上 → 一堆假 P0 recall-miss,把环境/工具故障
+    // 伪装成 vortex 真 bug,破坏 P0=0 自校准承诺。探针失败时跳过 recall/
+    // precision;但下面 4 条不变量只依赖 observe 输出,仍照常跑。
+    if (!oracleProbeFailed) {
+      const manifestFindings = checkManifest(parsed1, oracles, manifest);
+      result.findings.push(...manifestFindings);
+      result.recall.expected = manifest.entries.filter((e) => e.interactive).length;
+      result.recall.matched =
+        result.recall.expected - manifestFindings.filter((f) => f.kind === "recall-miss").length;
+      result.precision.emitted = parsed1.rows.length;
+      result.precision.matchedNoise = manifestFindings.filter((f) => f.kind === "precision-miss").length;
+    }
 
     // INV-3 / INV-4(基于 observe #1)
     const dup = checkDuplicates(parsed1.rows, manifest.fixture, result.pattern);
@@ -87,16 +94,19 @@ export async function scanFixture(manifest: SynthManifest, opts: ScanOptions): P
     result.invariants.inv4 = bbox.length === 0;
 
     // 3) INV-2 — 探 observe #1 每个 ref(此时仍是 active snapshot)
+    let inv2Crashed = false;
     for (const row of parsed1.rows) {
       const probe = await runProbe(call, row.ref);
       const verdict = classifyProbe(probe);
       if (verdict === "crash") {
-        result.invariants.inv2 = false;
+        inv2Crashed = true;
         result.findings.push({ fixture: manifest.fixture, pattern: result.pattern, severity: "P0",
           kind: "inv2-unresolvable", ref: row.ref,
           detail: `ref ${row.ref} 探针 ${probe.timedOut ? "超时" : "崩溃"}: ${probe.text.slice(0, 120)}` });
       }
     }
+    // 跑完所有 ref 无 crash 才置 INV-2 通过(init false = 未验证)
+    result.invariants.inv2 = !inv2Crashed;
 
     // 4) observe #2 → INV-1 稳定性(此处才让 observe #1 的 ref 失效)
     const parsed2 = parseObserveSnapshot(extractText(await call("vortex_observe", { frames, includeBoxes: true })));

--- a/packages/vortex-bench/src/runner/scan.ts
+++ b/packages/vortex-bench/src/runner/scan.ts
@@ -1,0 +1,133 @@
+// packages/vortex-bench/src/runner/scan.ts
+// 单 fixture 扫描编排:navigate → observe1(includeBoxes) → evaluate oracle rects
+// → INV-2 探每个 ref → observe2 → 跑 manifest-check + 4 不变量 → FixtureScanResult。
+// 探测顺序固定以规避 STALE_SNAPSHOT(observe2 会让 observe1 的 ref 失效)。
+
+import { createMcpConnection, closeMcpConnection } from "./mcp-client.js";
+import { parseObserveSnapshot } from "./observe-parser.js";
+import { checkManifest } from "./manifest-check.js";
+import { checkStability, classifyProbe, checkDuplicates, checkBboxSanity, type ProbeResult } from "./invariants.js";
+import { joinByGeometry } from "./geometry-join.js";
+import type { Finding, FixtureScanResult, OracleRect, SynthManifest } from "../scan-types.js";
+
+export interface ScanOptions {
+  mcpBin: string;
+  playgroundUrl: string;
+}
+
+const PROBE_TIMEOUT_MS = 5000;
+
+function extractText(res: unknown): string {
+  const content = (res as { content?: unknown }).content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((i) => i && typeof i === "object" && "text" in i)
+    .map((i) => String((i as { text: unknown }).text))
+    .join("\n");
+}
+
+const ORACLE_PROBE_CODE =
+  "Array.from(document.querySelectorAll('[data-vtx-oracle]')).map(function(el){" +
+  "var r=el.getBoundingClientRect();" +
+  "return {id:el.getAttribute('data-vtx-oracle')," +
+  "rect:[Math.round(r.x),Math.round(r.y),Math.round(r.width),Math.round(r.height)]};})";
+
+export async function scanFixture(manifest: SynthManifest, opts: ScanOptions): Promise<FixtureScanResult> {
+  const frames = manifest.frames ?? "main";
+  const result: FixtureScanResult = {
+    fixture: manifest.fixture,
+    pattern: manifest.entries[0]?.pattern ?? manifest.fixture,
+    path: manifest.path,
+    recall: { matched: 0, expected: 0 },
+    precision: { matchedNoise: 0, emitted: 0 },
+    invariants: { inv1: true, inv2: true, inv3: true, inv4: true },
+    findings: [],
+  };
+
+  const mcp = await createMcpConnection({
+    command: process.execPath,
+    args: [opts.mcpBin],
+    env: { ...(process.env as Record<string, string>) },
+  });
+
+  const call = (name: string, args: Record<string, unknown>) =>
+    mcp.client.callTool({ name, arguments: args });
+
+  try {
+    await call("vortex_navigate", { url: "about:blank" });
+    await call("vortex_navigate", { url: opts.playgroundUrl + manifest.path });
+    await call("vortex_wait_for", { mode: "idle", value: "dom", timeout: 5000 });
+
+    // 1) observe #1 (includeBoxes) — manifest-check / INV-3 / INV-4 的数据源
+    const obs1Text = extractText(await call("vortex_observe", { frames, includeBoxes: true }));
+    const parsed1 = parseObserveSnapshot(obs1Text);
+
+    // 2) oracle rect 探针(仅主 frame;跨 frame entry 走 joinBy:name)
+    let oracles: OracleRect[] = [];
+    try {
+      oracles = JSON.parse(extractText(await call("vortex_evaluate", { code: ORACLE_PROBE_CODE }))) as OracleRect[];
+    } catch (e) {
+      result.error = `oracle 探针失败: ${e instanceof Error ? e.message : String(e)}`;
+    }
+
+    // manifest 裁决
+    const manifestFindings = checkManifest(parsed1, oracles, manifest);
+    result.findings.push(...manifestFindings);
+    result.recall.expected = manifest.entries.filter((e) => e.interactive).length;
+    result.recall.matched =
+      result.recall.expected - manifestFindings.filter((f) => f.kind === "recall-miss").length;
+    result.precision.emitted = parsed1.rows.length;
+    result.precision.matchedNoise = manifestFindings.filter((f) => f.kind === "precision-miss").length;
+
+    // INV-3 / INV-4(基于 observe #1)
+    const dup = checkDuplicates(parsed1.rows, manifest.fixture, result.pattern);
+    const bbox = checkBboxSanity(parsed1, manifest.fixture, result.pattern);
+    result.findings.push(...dup, ...bbox);
+    result.invariants.inv3 = dup.length === 0;
+    result.invariants.inv4 = bbox.length === 0;
+
+    // 3) INV-2 — 探 observe #1 每个 ref(此时仍是 active snapshot)
+    for (const row of parsed1.rows) {
+      const probe = await runProbe(call, row.ref);
+      const verdict = classifyProbe(probe);
+      if (verdict === "crash") {
+        result.invariants.inv2 = false;
+        result.findings.push({ fixture: manifest.fixture, pattern: result.pattern, severity: "P0",
+          kind: "inv2-unresolvable", ref: row.ref,
+          detail: `ref ${row.ref} 探针 ${probe.timedOut ? "超时" : "崩溃"}: ${probe.text.slice(0, 120)}` });
+      }
+    }
+
+    // 4) observe #2 → INV-1 稳定性(此处才让 observe #1 的 ref 失效)
+    const parsed2 = parseObserveSnapshot(extractText(await call("vortex_observe", { frames, includeBoxes: true })));
+    const inv1 = checkStability(parsed1, parsed2, manifest.fixture, result.pattern);
+    result.findings.push(...inv1);
+    result.invariants.inv1 = inv1.length === 0;
+  } catch (err) {
+    result.error = err instanceof Error ? err.message : String(err);
+  } finally {
+    await closeMcpConnection(mcp);
+  }
+
+  return result;
+}
+
+/** 跑一次只读 ref 探针:vortex_extract(target=@ref)。reject/超时 → crash 信号。 */
+async function runProbe(
+  call: (name: string, args: Record<string, unknown>) => Promise<unknown>,
+  ref: string,
+): Promise<ProbeResult> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const res = await Promise.race([
+      call("vortex_extract", { target: ref, include: ["attrs"] }),
+      new Promise<never>((_, rej) => { timer = setTimeout(() => rej(new Error("__probe_timeout__")), PROBE_TIMEOUT_MS); }),
+    ]);
+    return { text: extractText(res), threw: false, timedOut: false };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { text: msg, threw: msg !== "__probe_timeout__", timedOut: msg === "__probe_timeout__" };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/packages/vortex-bench/src/scan-report.ts
+++ b/packages/vortex-bench/src/scan-report.ts
@@ -1,0 +1,57 @@
+// packages/vortex-bench/src/scan-report.ts
+// finding 排序 + markdown 报告渲染。json 报告直接 JSON.stringify(report)。
+
+import type { Finding, ScanReport } from "./scan-types.js";
+
+const SEV_ORDER: Record<Finding["severity"], number> = { P0: 0, P1: 1, P2: 2 };
+
+export function rankFindings(findings: Finding[]): Finding[] {
+  return [...findings].sort((a, b) => SEV_ORDER[a.severity] - SEV_ORDER[b.severity]);
+}
+
+export function renderScanMarkdown(report: ScanReport): string {
+  const lines: string[] = [];
+  lines.push("# vortex scan 报告");
+  lines.push("");
+  lines.push(`- 生成时间: ${report.generatedAt}`);
+  lines.push(`- playground: ${report.playgroundUrl}`);
+  lines.push(`- fixture 数: ${report.fixtures.length}  候选 finding 数: ${report.findings.length}`);
+  lines.push("");
+
+  // 汇总表
+  lines.push("## 汇总(per-fixture)");
+  lines.push("");
+  lines.push("| fixture | pattern | recall | precision(noise/emit) | INV1 | INV2 | INV3 | INV4 |");
+  lines.push("|---|---|---|---|---|---|---|---|");
+  for (const fx of report.fixtures) {
+    const inv = (b: boolean) => (b ? "✓" : "✗");
+    lines.push(
+      `| ${fx.fixture} | ${fx.pattern} | ${fx.recall.matched}/${fx.recall.expected} | ` +
+      `${fx.precision.matchedNoise}/${fx.precision.emitted} | ${inv(fx.invariants.inv1)} | ` +
+      `${inv(fx.invariants.inv2)} | ${inv(fx.invariants.inv3)} | ${inv(fx.invariants.inv4)} |`,
+    );
+    if (fx.error) lines.push(`| ↳ ⚠ error | ${fx.error} | | | | | | |`);
+  }
+  lines.push("");
+
+  // 按严重度分组的 finding
+  const ranked = rankFindings(report.findings);
+  if (ranked.length === 0) {
+    lines.push("## 候选 finding");
+    lines.push("");
+    lines.push("> ✅ 未发现候选 —— 当前 vortex 在合成语料上 P0/P1/P2 全清。");
+    return lines.join("\n");
+  }
+  for (const sev of ["P0", "P1", "P2"] as const) {
+    const group = ranked.filter((f) => f.severity === sev);
+    if (group.length === 0) continue;
+    lines.push(`## ${sev}(${group.length})`);
+    lines.push("");
+    for (const f of group) {
+      const ref = f.ref ? ` \`${f.ref}\`` : "";
+      lines.push(`- **[${f.kind}]** \`${f.fixture}\`/${f.pattern}${ref} — ${f.detail}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}

--- a/packages/vortex-bench/src/scan-report.ts
+++ b/packages/vortex-bench/src/scan-report.ts
@@ -30,7 +30,7 @@ export function renderScanMarkdown(report: ScanReport): string {
       `${fx.precision.matchedNoise}/${fx.precision.emitted} | ${inv(fx.invariants.inv1)} | ` +
       `${inv(fx.invariants.inv2)} | ${inv(fx.invariants.inv3)} | ${inv(fx.invariants.inv4)} |`,
     );
-    if (fx.error) lines.push(`| ↳ ⚠ error | ${fx.error} | | | | | | |`);
+    if (fx.error) lines.push(`| ↳ ⚠ error | ${fx.error.replace(/\|/g, "\\|")} | | | | | | |`);
   }
   lines.push("");
 

--- a/packages/vortex-bench/src/scan-types.ts
+++ b/packages/vortex-bench/src/scan-types.ts
@@ -1,0 +1,101 @@
+// packages/vortex-bench/src/scan-types.ts
+// 自主发现引擎 #1 MVP — scan 子系统共享类型。与 bench 的 types.ts 解耦。
+
+/** manifest 单条:键 id 对应 fixture HTML 上的 data-vtx-oracle="<id>" */
+export interface ManifestEntry {
+  id: string;
+  /** 该元素该不该被 observe 识别为可交互(true=应出现在 observe 输出) */
+  interactive: boolean;
+  /** 期望 accessibleName;null=不校验该字段 */
+  expectedName: string | null;
+  /** 期望 role;null=不校验 */
+  expectedRole: string | null;
+  /** 对抗模式标签,用于分组统计 */
+  pattern: string;
+  /** join 方式:geometry(默认,按 bbox)或 name(跨 frame fixture 用) */
+  joinBy?: "geometry" | "name";
+  note?: string;
+}
+
+export interface SynthManifest {
+  /** fixture 短名,等于文件名去扩展,如 "cursor-pointer-div" */
+  fixture: string;
+  /** vite 服务路径,如 "/synth/cursor-pointer-div.html" */
+  path: string;
+  /** observe frames 参数,默认 "main" */
+  frames?: "main" | "all-same-origin" | "all-permitted";
+  entries: ManifestEntry[];
+}
+
+/** evaluate 探针返回的 oracle 元素几何 */
+export interface OracleRect {
+  id: string;
+  /** [x,y,w,h] viewport 坐标(getBoundingClientRect,已 round) */
+  rect: [number, number, number, number];
+}
+
+export interface ObserveRow {
+  ref: string;
+  role: string;
+  name: string | null;
+  flags: string[];
+  /** [x,y,w,h] frame-local 视口坐标;无 includeBoxes 或离屏时 null */
+  bbox: [number, number, number, number] | null;
+  frameId: number;
+}
+
+export interface ObserveHeader {
+  snapshotId: string;
+  url: string;
+  title?: string;
+  viewport?: { width: number; height: number; scrollY: number; scrollHeight: number };
+}
+
+export interface ParsedObserve {
+  header: ObserveHeader;
+  rows: ObserveRow[];
+  /** frameId → [offsetX, offsetY],来自 "# frame N offset=[x,y]" 行 */
+  frameOffsets: Record<number, [number, number]>;
+}
+
+export type FindingSeverity = "P0" | "P1" | "P2";
+
+export type FindingKind =
+  | "recall-miss"
+  | "precision-miss"
+  | "name-mismatch"
+  | "role-mismatch"
+  | "inv1-instability"
+  | "inv2-unresolvable"
+  | "inv3-duplicate"
+  | "inv4-bbox";
+
+export interface Finding {
+  severity: FindingSeverity;
+  kind: FindingKind;
+  fixture: string;
+  pattern: string;
+  detail: string;
+  oracleId?: string;
+  ref?: string;
+}
+
+export interface FixtureScanResult {
+  fixture: string;
+  pattern: string;
+  path: string;
+  recall: { matched: number; expected: number };
+  precision: { matchedNoise: number; emitted: number };
+  invariants: { inv1: boolean; inv2: boolean; inv3: boolean; inv4: boolean };
+  findings: Finding[];
+  /** 扫描中途的环境/工具错误(非 finding),如 navigate 失败 */
+  error?: string;
+}
+
+export interface ScanReport {
+  generatedAt: string;
+  playgroundUrl: string;
+  fixtures: FixtureScanResult[];
+  /** 所有 fixture 扁平化 + 排序后的 finding */
+  findings: Finding[];
+}

--- a/packages/vortex-bench/tests/geometry-join.test.ts
+++ b/packages/vortex-bench/tests/geometry-join.test.ts
@@ -1,0 +1,51 @@
+// packages/vortex-bench/tests/geometry-join.test.ts
+import { describe, it, expect } from "vitest";
+import { centerInside, joinByGeometry } from "../src/runner/geometry-join.js";
+import type { ObserveRow, OracleRect } from "../src/scan-types.js";
+
+function row(ref: string, bbox: ObserveRow["bbox"]): ObserveRow {
+  return { ref, role: "button", name: "x", flags: [], bbox, frameId: 0 };
+}
+
+describe("centerInside", () => {
+  it("bbox 中心落在 rect 内 → true", () => {
+    expect(centerInside([10, 10, 20, 20], [0, 0, 100, 100])).toBe(true); // center 20,20
+  });
+  it("bbox 中心在 rect 外 → false", () => {
+    expect(centerInside([200, 200, 20, 20], [0, 0, 100, 100])).toBe(false);
+  });
+});
+
+describe("joinByGeometry", () => {
+  it("行中心落在 oracle rect → 配对", () => {
+    const rows = [row("@e0", [10, 10, 20, 20])];
+    const oracles: OracleRect[] = [{ id: "a", rect: [0, 0, 100, 100] }];
+    const { matches, unmatchedRows } = joinByGeometry(rows, oracles, {});
+    expect(matches.get("a")?.[0].ref).toBe("@e0");
+    expect(unmatchedRows).toHaveLength(0);
+  });
+
+  it("无 oracle 命中 → unmatchedRows", () => {
+    const rows = [row("@e0", [500, 500, 10, 10])];
+    const oracles: OracleRect[] = [{ id: "a", rect: [0, 0, 100, 100] }];
+    const { matches, unmatchedRows } = joinByGeometry(rows, oracles, {});
+    expect(matches.get("a") ?? []).toHaveLength(0);
+    expect(unmatchedRows).toHaveLength(1);
+  });
+
+  it("子 frame 行加 offset 后再判定", () => {
+    // 行 frame-local bbox 中心 (10,10);frame 1 offset [40,400] → top-page (50,410)
+    const rows: ObserveRow[] = [{ ref: "@f1e0", role: "link", name: "x", flags: [], bbox: [5, 5, 10, 10], frameId: 1 }];
+    const oracles: OracleRect[] = [{ id: "if", rect: [40, 400, 100, 100] }];
+    const { matches } = joinByGeometry(rows, oracles, { 1: [40, 400] });
+    expect(matches.get("if")?.[0].ref).toBe("@f1e0");
+  });
+
+  it("无 bbox 的行被跳过(不参与几何 join)", () => {
+    const rows = [row("@e0", null)];
+    const oracles: OracleRect[] = [{ id: "a", rect: [0, 0, 100, 100] }];
+    const { matches, unmatchedRows } = joinByGeometry(rows, oracles, {});
+    expect(matches.get("a") ?? []).toHaveLength(0);
+    expect(unmatchedRows).toHaveLength(0); // 无 bbox 不算 noise,交给 INV-4
+  });
+});

--- a/packages/vortex-bench/tests/invariants.test.ts
+++ b/packages/vortex-bench/tests/invariants.test.ts
@@ -1,0 +1,80 @@
+// packages/vortex-bench/tests/invariants.test.ts
+import { describe, it, expect } from "vitest";
+import { checkStability, classifyProbe, checkDuplicates, checkBboxSanity, iou } from "../src/runner/invariants.js";
+import type { ParsedObserve, ObserveRow } from "../src/scan-types.js";
+
+function parsed(rows: ObserveRow[], scrollHeight = 2000): ParsedObserve {
+  return { header: { snapshotId: "s", url: "u", viewport: { width: 1280, height: 720, scrollY: 0, scrollHeight } }, rows, frameOffsets: {} };
+}
+const r = (role: string, name: string | null, bbox: ObserveRow["bbox"]): ObserveRow =>
+  ({ ref: "@x", role, name, flags: [], bbox, frameId: 0 });
+
+describe("checkStability (INV-1)", () => {
+  it("两次 observe 集合一致 → 无 finding", () => {
+    const a = parsed([r("button", "保存", [0, 0, 10, 10])]);
+    const b = parsed([r("button", "保存", [1, 0, 10, 10])]); // 1px 抖动容忍
+    expect(checkStability(a, b, "t", "p")).toHaveLength(0);
+  });
+  it("第二次少了一个元素 → P1 inv1-instability", () => {
+    const a = parsed([r("button", "保存", [0, 0, 10, 10]), r("link", "更多", [0, 50, 10, 10])]);
+    const b = parsed([r("button", "保存", [0, 0, 10, 10])]);
+    const f = checkStability(a, b, "t", "p");
+    expect(f).toHaveLength(1);
+    expect(f[0].kind).toBe("inv1-instability");
+    expect(f[0].severity).toBe("P1");
+  });
+});
+
+describe("classifyProbe (INV-2)", () => {
+  it("返回正常文本 → ok", () => {
+    expect(classifyProbe({ text: '{"attrs":{}}', threw: false, timedOut: false })).toBe("ok");
+  });
+  it("typed error 文本 → typed-error", () => {
+    expect(classifyProbe({ text: "Error [STALE_SNAPSHOT]: ...", threw: false, timedOut: false })).toBe("typed-error");
+  });
+  it("promise reject → crash", () => {
+    expect(classifyProbe({ text: "", threw: true, timedOut: false })).toBe("crash");
+  });
+  it("超时 → crash", () => {
+    expect(classifyProbe({ text: "", threw: false, timedOut: true })).toBe("crash");
+  });
+});
+
+describe("checkDuplicates (INV-3)", () => {
+  it("同 name+role 且 bbox 高度重叠 → P2 inv3-duplicate", () => {
+    const rows = [r("menuitem", "首页", [0, 0, 100, 30]), r("menuitem", "首页", [2, 1, 100, 30])];
+    const f = checkDuplicates(rows, "t", "p");
+    expect(f).toHaveLength(1);
+    expect(f[0].kind).toBe("inv3-duplicate");
+  });
+  it("同 name 但 bbox 不重叠 → 无 finding", () => {
+    const rows = [r("menuitem", "首页", [0, 0, 100, 30]), r("menuitem", "首页", [0, 500, 100, 30])];
+    expect(checkDuplicates(rows, "t", "p")).toHaveLength(0);
+  });
+});
+
+describe("checkBboxSanity (INV-4)", () => {
+  it("正常 bbox → 无 finding", () => {
+    expect(checkBboxSanity(parsed([r("button", "x", [10, 10, 50, 20])]), "t", "p")).toHaveLength(0);
+  });
+  it("宽或高 ≤0 → P2 inv4-bbox", () => {
+    const f = checkBboxSanity(parsed([r("button", "x", [10, 10, 0, 20])]), "t", "p");
+    expect(f).toHaveLength(1);
+    expect(f[0].kind).toBe("inv4-bbox");
+  });
+  it("x 负坐标越界 → P2 inv4-bbox", () => {
+    expect(checkBboxSanity(parsed([r("button", "x", [-5, 10, 50, 20])]), "t", "p")).toHaveLength(1);
+  });
+  it("宽度超视口 2 倍 → P2 inv4-bbox", () => {
+    expect(checkBboxSanity(parsed([r("button", "x", [0, 10, 3000, 20])]), "t", "p")).toHaveLength(1);
+  });
+});
+
+describe("iou", () => {
+  it("完全重叠 = 1", () => {
+    expect(iou([0, 0, 10, 10], [0, 0, 10, 10])).toBeCloseTo(1);
+  });
+  it("不相交 = 0", () => {
+    expect(iou([0, 0, 10, 10], [100, 100, 10, 10])).toBe(0);
+  });
+});

--- a/packages/vortex-bench/tests/manifest-check.test.ts
+++ b/packages/vortex-bench/tests/manifest-check.test.ts
@@ -62,4 +62,13 @@ describe("checkManifest", () => {
     const m = manifest([{ id: "x", interactive: true, expectedName: "子框按钮", expectedRole: null, pattern: "iframe-srcdoc-inherit", joinBy: "name" }]);
     expect(checkManifest(p, oracles, m)).toHaveLength(0); // name 命中 → 无 recall-miss
   });
+
+  it("name-join 认领的行(有 bbox 但几何 join 不上)不被误报为 _unannotated 噪声", () => {
+    // 自校准实测:srcdoc 子按钮在 iframe 内有 bbox,主 frame 探针拿不到它的 oracle rect,
+    // 故落入 geometry unmatchedRows;但它已被 joinBy:name 的 entry 认领,不该算噪声。
+    const p = parsed([{ ref: "@f49e1", role: "button", name: "子框按钮", flags: [], bbox: [5, 5, 60, 20], frameId: 49 }]);
+    const oracles: OracleRect[] = [];
+    const m = manifest([{ id: "child", interactive: true, expectedName: "子框按钮", expectedRole: null, pattern: "iframe-srcdoc-inherit", joinBy: "name" }]);
+    expect(checkManifest(p, oracles, m)).toHaveLength(0); // 既不 recall-miss 也不 precision-miss
+  });
 });

--- a/packages/vortex-bench/tests/manifest-check.test.ts
+++ b/packages/vortex-bench/tests/manifest-check.test.ts
@@ -1,0 +1,65 @@
+// packages/vortex-bench/tests/manifest-check.test.ts
+import { describe, it, expect } from "vitest";
+import { checkManifest } from "../src/runner/manifest-check.js";
+import type { ParsedObserve, OracleRect, SynthManifest } from "../src/scan-types.js";
+
+function parsed(rows: ParsedObserve["rows"]): ParsedObserve {
+  return { header: { snapshotId: "s", url: "u" }, rows, frameOffsets: {} };
+}
+const manifest = (entries: SynthManifest["entries"]): SynthManifest => ({
+  fixture: "t", path: "/synth/t.html", entries,
+});
+
+describe("checkManifest", () => {
+  it("interactive 元素无 observe 行命中 → P0 recall-miss", () => {
+    const p = parsed([]); // observe 啥都没出
+    const oracles: OracleRect[] = [{ id: "btn", rect: [0, 0, 100, 50] }];
+    const m = manifest([{ id: "btn", interactive: true, expectedName: "保存", expectedRole: "button", pattern: "cursor-pointer-div" }]);
+    const findings = checkManifest(p, oracles, m);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].kind).toBe("recall-miss");
+    expect(findings[0].severity).toBe("P0");
+    expect(findings[0].oracleId).toBe("btn");
+  });
+
+  it("interactive 命中且 name/role 一致 → 无 finding", () => {
+    const p = parsed([{ ref: "@e0", role: "button", name: "保存", flags: [], bbox: [10, 10, 50, 20], frameId: 0 }]);
+    const oracles: OracleRect[] = [{ id: "btn", rect: [0, 0, 100, 50] }];
+    const m = manifest([{ id: "btn", interactive: true, expectedName: "保存", expectedRole: "button", pattern: "p" }]);
+    expect(checkManifest(p, oracles, m)).toHaveLength(0);
+  });
+
+  it("命中但 name 不符 → P1 name-mismatch", () => {
+    const p = parsed([{ ref: "@e0", role: "button", name: "确定", flags: [], bbox: [10, 10, 50, 20], frameId: 0 }]);
+    const oracles: OracleRect[] = [{ id: "btn", rect: [0, 0, 100, 50] }];
+    const m = manifest([{ id: "btn", interactive: true, expectedName: "保存", expectedRole: null, pattern: "p" }]);
+    const findings = checkManifest(p, oracles, m);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].kind).toBe("name-mismatch");
+    expect(findings[0].severity).toBe("P1");
+  });
+
+  it("observe 行命中 interactive:false 的 oracle → P2 precision-miss", () => {
+    const p = parsed([{ ref: "@e0", role: "div", name: null, flags: [], bbox: [10, 10, 50, 20], frameId: 0 }]);
+    const oracles: OracleRect[] = [{ id: "noise", rect: [0, 0, 100, 50] }];
+    const m = manifest([{ id: "noise", interactive: false, expectedName: null, expectedRole: null, pattern: "nameless-div-noise" }]);
+    const findings = checkManifest(p, oracles, m);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].kind).toBe("precision-miss");
+    expect(findings[0].severity).toBe("P2");
+  });
+
+  it("expectedName=null 不校验 name", () => {
+    const p = parsed([{ ref: "@e0", role: "button", name: "随便", flags: [], bbox: [10, 10, 50, 20], frameId: 0 }]);
+    const oracles: OracleRect[] = [{ id: "btn", rect: [0, 0, 100, 50] }];
+    const m = manifest([{ id: "btn", interactive: true, expectedName: null, expectedRole: null, pattern: "p" }]);
+    expect(checkManifest(p, oracles, m)).toHaveLength(0);
+  });
+
+  it("joinBy=name:按 expectedName 匹配 observe 行,不靠 bbox", () => {
+    const p = parsed([{ ref: "@f1e0", role: "button", name: "子框按钮", flags: [], bbox: null, frameId: 1 }]);
+    const oracles: OracleRect[] = []; // 跨 frame oracle rect 拿不到
+    const m = manifest([{ id: "x", interactive: true, expectedName: "子框按钮", expectedRole: null, pattern: "iframe-srcdoc-inherit", joinBy: "name" }]);
+    expect(checkManifest(p, oracles, m)).toHaveLength(0); // name 命中 → 无 recall-miss
+  });
+});

--- a/packages/vortex-bench/tests/observe-parser.test.ts
+++ b/packages/vortex-bench/tests/observe-parser.test.ts
@@ -1,0 +1,63 @@
+// packages/vortex-bench/tests/observe-parser.test.ts
+import { describe, it, expect } from "vitest";
+import { parseObserveSnapshot } from "../src/runner/observe-parser.js";
+
+const SAMPLE = `SnapshotId: snap-abc
+URL: http://localhost:5173/synth/cursor-pointer-div.html
+Title: cursor pointer
+Viewport: 1280x720, scrollY=0/2000
+
+@h1:e0 [button] "保存" bbox=[10,20,80,30]
+@h1:e1 [div] "打开菜单" [active] bbox=[100,200,120,40]
+@h1:e2 [div] bbox=[300,400,50,50]
+@h1:f1e0 [link] "子框按钮" bbox=[5,5,60,20]
+
+# frame 1 scanned, 0 interactive elements (url=about:srcdoc)
+# frame 1 offset=[40,400]`;
+
+describe("parseObserveSnapshot", () => {
+  it("解析头部 snapshotId / url / viewport", () => {
+    const p = parseObserveSnapshot(SAMPLE);
+    expect(p.header.snapshotId).toBe("snap-abc");
+    expect(p.header.url).toContain("cursor-pointer-div.html");
+    expect(p.header.viewport).toEqual({ width: 1280, height: 720, scrollY: 0, scrollHeight: 2000 });
+  });
+
+  it("解析带 name 的元素行", () => {
+    const p = parseObserveSnapshot(SAMPLE);
+    const r0 = p.rows[0];
+    expect(r0.ref).toBe("@h1:e0");
+    expect(r0.role).toBe("button");
+    expect(r0.name).toBe("保存");
+    expect(r0.bbox).toEqual([10, 20, 80, 30]);
+    expect(r0.frameId).toBe(0);
+  });
+
+  it("解析 state flags", () => {
+    const p = parseObserveSnapshot(SAMPLE);
+    expect(p.rows[1].flags).toEqual(["active"]);
+    expect(p.rows[1].name).toBe("打开菜单");
+  });
+
+  it("无 name 的行 name=null", () => {
+    const p = parseObserveSnapshot(SAMPLE);
+    expect(p.rows[2].name).toBeNull();
+    expect(p.rows[2].role).toBe("div");
+  });
+
+  it("子 frame 行解析出 frameId", () => {
+    const p = parseObserveSnapshot(SAMPLE);
+    expect(p.rows[3].ref).toBe("@h1:f1e0");
+    expect(p.rows[3].frameId).toBe(1);
+  });
+
+  it("解析 frame offset 行", () => {
+    const p = parseObserveSnapshot(SAMPLE);
+    expect(p.frameOffsets[1]).toEqual([40, 400]);
+  });
+
+  it("无 bbox 的行 bbox=null(无 includeBoxes 场景)", () => {
+    const p = parseObserveSnapshot("SnapshotId: s\nURL: u\n\n@e0 [button] \"x\"");
+    expect(p.rows[0].bbox).toBeNull();
+  });
+});

--- a/packages/vortex-bench/tests/scan-report.test.ts
+++ b/packages/vortex-bench/tests/scan-report.test.ts
@@ -1,0 +1,41 @@
+// packages/vortex-bench/tests/scan-report.test.ts
+import { describe, it, expect } from "vitest";
+import { rankFindings, renderScanMarkdown } from "../src/scan-report.js";
+import type { Finding, ScanReport } from "../src/scan-types.js";
+
+const f = (severity: Finding["severity"], kind: Finding["kind"]): Finding =>
+  ({ severity, kind, fixture: "t", pattern: "p", detail: "d" });
+
+describe("rankFindings", () => {
+  it("P0 排在 P1 前,P1 排在 P2 前", () => {
+    const sorted = rankFindings([f("P2", "inv3-duplicate"), f("P0", "recall-miss"), f("P1", "name-mismatch")]);
+    expect(sorted.map((x) => x.severity)).toEqual(["P0", "P1", "P2"]);
+  });
+});
+
+describe("renderScanMarkdown", () => {
+  it("含汇总表 + 按严重度分组的 finding", () => {
+    const report: ScanReport = {
+      generatedAt: "2026-05-26T00:00:00Z",
+      playgroundUrl: "http://localhost:5173",
+      fixtures: [{
+        fixture: "cursor-pointer-div", pattern: "cursor-pointer-div", path: "/synth/cursor-pointer-div.html",
+        recall: { matched: 1, expected: 2 }, precision: { matchedNoise: 0, emitted: 3 },
+        invariants: { inv1: true, inv2: true, inv3: true, inv4: true },
+        findings: [f("P0", "recall-miss")],
+      }],
+      findings: [f("P0", "recall-miss")],
+    };
+    const md = renderScanMarkdown(report);
+    expect(md).toContain("# vortex scan 报告");
+    expect(md).toContain("cursor-pointer-div");
+    expect(md).toContain("1/2"); // recall
+    expect(md).toContain("P0");
+    expect(md).toContain("recall-miss");
+  });
+
+  it("零 finding 时显式写「未发现候选」", () => {
+    const report: ScanReport = { generatedAt: "t", playgroundUrl: "u", fixtures: [], findings: [] };
+    expect(renderScanMarkdown(report)).toContain("未发现候选");
+  });
+});

--- a/packages/vortex-bench/tests/scan-report.test.ts
+++ b/packages/vortex-bench/tests/scan-report.test.ts
@@ -38,4 +38,20 @@ describe("renderScanMarkdown", () => {
     const report: ScanReport = { generatedAt: "t", playgroundUrl: "u", fixtures: [], findings: [] };
     expect(renderScanMarkdown(report)).toContain("未发现候选");
   });
+
+  it("fixture.error 含 | 时转义,不破坏表格", () => {
+    const report: ScanReport = {
+      generatedAt: "t", playgroundUrl: "u",
+      fixtures: [{
+        fixture: "x", pattern: "p", path: "/x",
+        recall: { matched: 0, expected: 0 }, precision: { matchedNoise: 0, emitted: 0 },
+        invariants: { inv1: false, inv2: false, inv3: false, inv4: false },
+        findings: [], error: "boom a|b|c",
+      }],
+      findings: [],
+    };
+    const md = renderScanMarkdown(report);
+    expect(md).toContain("boom a\\|b\\|c");
+    expect(md).not.toContain("boom a|b|c");
+  });
 });


### PR DESCRIPTION
## 背景

把 vortex 当前"手动访问网站发现问题再优化"的 dogfood 发现环,升级为**手动触发、机器扫描、排序产报告**的半自主发现引擎。本 PR 是该平台的 **#1 MVP**:在合成对抗页面上,用页面自带 manifest 作完美 oracle + 4 条无 oracle 不变量,产出按可疑度排序的候选 bug 报告。

设计/计划文档见知识库 `12-Projects/0022-vortex-自主发现引擎/`。

## 改动

全部落在 `packages/vortex-bench`,与现有 `bench run/diff/baseline` **零耦合**:

- **纯逻辑核**(vitest 离线可测):`observe-parser`(observe 文本→结构化)、`geometry-join`(observe 行↔oracle rect 几何配对)、`manifest-check`(recall/precision/name/role 裁决)、`invariants`(INV-1 稳定性 / INV-2 ref 可解析 / INV-3 dedup / INV-4 bbox)、`scan-report`(排序+markdown)、`scan-types`
- **scan 编排器** `scan.ts`:navigate→observe1(includeBoxes)→evaluate oracle→INV-2 探 ref→observe2,固定顺序规避 STALE_SNAPSHOT;INV-2 探针用只读 `vortex_extract(target=@ref)`
- **CLI**:`bench scan --all` / `--pattern <name>`,产 `reports/scan/<ts>.{md,json}`
- **9 个合成对抗 fixture**:复刻历史 bug 类(cursor:pointer div #16 / nameless div #18 / aria-cursor dedup / icon 命名优先级 / visibility:hidden / open shadow / 无 role 关闭图标 / teleport 弹层 / srcdoc 继承 #15)

### 设计要点

- **为何 manifest-oracle 而非差分**:合成页面我们自己生成→掌握 ground truth,manifest 即完美 oracle,比任何差分都强。差分(外部参照)推迟到 #2(快照/真站,无 manifest 时)。
- **否决内部 a11y 差分**:`reasoning/ax-snapshot.ts` 是孤立 prep 代码无 MCP 入口;且 a11y tree 是子集(不含无 role 的 cursor:pointer div),与 observe 超集差分会在最关键 bug 类上疯狂误报。

## 测试计划

- [x] vitest **95 tests 全过**(8 文件:parser/join/manifest/invariants/report + 既有 aggregate/boxes/classify)
- [x] tsc `--noEmit` 无错误
- [x] throw-discipline lint 通过
- [x] CLI 烟测:`--help` 含 scan、空参报错退出 1
- [x] **live 自校准**:`bench scan --all` 对活栈(Chrome+扩展+ws:6800+playground)实跑 → **9/9 fixture P0=0 findings=0**,4 不变量全 ✓,observe 满 recall
- [x] code review(final reviewer)抓修 H1(oracle 探针失败产假 P0)+ H2(scan 出错不变量假阴)+ M1-M4
- [x] 自校准抓修 1 个引擎假阳(name-join 认领行被误判 _unannotated 噪声)

## 后续(不在本 PR)

#1.5 fuzzing → #2 冻结快照+差分 → #3 真站 seed → #4 公开站随机 → #5 LLM-judge 塔尖。