### PR TITLE
feat(bench): 自主发现引擎 #2 — 冻结快照 + 差分引导 manifest

### DIFF
--- a/packages/vortex-bench/src/index.ts
+++ b/packages/vortex-bench/src/index.ts
@@ -329,15 +329,19 @@ async function cmdScan(args: string[]): Promise<number> {
 
 async function cmdSnapshot(args: string[]): Promise<number> {
   // bench snapshot <name> [--url <url>] [--frames <main|all-same-origin|all-permitted>]
-  const name = args.find((a) => !a.startsWith("-"));
-  if (!name) {
-    process.stderr.write("[vortex-bench] snapshot 需要 <name>(产出 synth/<name>.html + .manifest.json)\n");
-    return 1;
-  }
   const urlIdx = args.indexOf("--url");
   const url = urlIdx >= 0 ? args[urlIdx + 1] : undefined;
   const framesIdx = args.indexOf("--frames");
   const frames = framesIdx >= 0 ? args[framesIdx + 1] : undefined;
+  // name = 第一个既非 flag 也非 flag 值的位置参数(防 --url <url> 在前时误选 url 为 name)
+  const consumed = new Set<number>();
+  if (urlIdx >= 0) { consumed.add(urlIdx); consumed.add(urlIdx + 1); }
+  if (framesIdx >= 0) { consumed.add(framesIdx); consumed.add(framesIdx + 1); }
+  const name = args.find((a, i) => !consumed.has(i) && !a.startsWith("-"));
+  if (!name) {
+    process.stderr.write("[vortex-bench] snapshot 需要 <name>(产出 synth/<name>.html + .manifest.json)\n");
+    return 1;
+  }
 
   const mcpBin = resolveMcpBin();
   process.stdout.write(`[vortex-bench] snapshot ${name}  mcp=${mcpBin}${url ? `  url=${url}` : "  (当前活动 tab)"}\n`);

--- a/packages/vortex-bench/src/index.ts
+++ b/packages/vortex-bench/src/index.ts
@@ -17,6 +17,7 @@ import type { BenchReport, CaseDefinition, CaseMetrics } from "./types.js";
 import { scanFixture } from "./runner/scan.js";
 import { renderScanMarkdown, rankFindings } from "./scan-report.js";
 import type { FixtureScanResult, ScanReport, SynthManifest } from "./scan-types.js";
+import { captureSnapshot } from "./runner/snapshot.js";
 
 const USAGE = `vortex-bench <command>
 
@@ -33,6 +34,8 @@ Commands:
                          median / p95 / max + reports/boxes-budget-*.json
   scan --all             扫全部合成 fixture,产 reports/scan/<ts>.{md,json}
   scan --pattern <name>  扫单个 pattern
+  snapshot <name>        冻结当前活动 tab 为 synth/<name>.html + 提议 manifest
+  snapshot <name> --url <u>  先 navigate 再冻结
   --help                 显示帮助
 
 Env:
@@ -258,6 +261,11 @@ async function loadManifest(name: string): Promise<SynthManifest> {
   return m;
 }
 
+/** #2:提议稿未确认 → scan 跳过(返回 true 表示应跳过) */
+function isProposed(m: SynthManifest): boolean {
+  return m._proposed === true;
+}
+
 async function cmdScan(args: string[]): Promise<number> {
   const runAll = args.includes("--all");
   let names: string[];
@@ -283,6 +291,10 @@ async function cmdScan(args: string[]): Promise<number> {
     let fx: FixtureScanResult;
     try {
       const manifest = await loadManifest(name);
+      if (isProposed(manifest)) {
+        process.stdout.write(`⊘ ${name.padEnd(28)} 跳过未审提议稿(_proposed:true)\n`);
+        continue;
+      }
       fx = await scanFixture(manifest, { mcpBin, playgroundUrl: url });
     } catch (e) {
       // manifest 缺失/非法等:记为该 fixture 的 error,不中断整轮扫描
@@ -315,6 +327,36 @@ async function cmdScan(args: string[]): Promise<number> {
   return totalP0 === 0 ? 0 : 2;
 }
 
+async function cmdSnapshot(args: string[]): Promise<number> {
+  // bench snapshot <name> [--url <url>] [--frames <main|all-same-origin|all-permitted>]
+  const name = args.find((a) => !a.startsWith("-"));
+  if (!name) {
+    process.stderr.write("[vortex-bench] snapshot 需要 <name>(产出 synth/<name>.html + .manifest.json)\n");
+    return 1;
+  }
+  const urlIdx = args.indexOf("--url");
+  const url = urlIdx >= 0 ? args[urlIdx + 1] : undefined;
+  const framesIdx = args.indexOf("--frames");
+  const frames = framesIdx >= 0 ? args[framesIdx + 1] : undefined;
+
+  const mcpBin = resolveMcpBin();
+  process.stdout.write(`[vortex-bench] snapshot ${name}  mcp=${mcpBin}${url ? `  url=${url}` : "  (当前活动 tab)"}\n`);
+
+  const res = await captureSnapshot({
+    mcpBin, name, synthDir: SYNTH_DIR, url,
+    frames: frames as "main" | "all-same-origin" | "all-permitted" | undefined,
+  });
+
+  process.stdout.write(
+    `✓ 冻结 ${res.observeRowCount} observe 行 / ${res.candidateCount} 候选\n` +
+    `  来源: ${res.source}\n` +
+    `  _review: observe-missed=${res.review.observeMissed} observe-extra=${res.review.observeExtra} agree=${res.review.agree}\n` +
+    `  [html] ${res.htmlPath}\n  [manifest 提议稿] ${res.manifestPath}\n` +
+    `  ⚠ 提议稿带 _proposed:true,scan 会跳过 —— 人工审定 interactive/name 后去掉 _proposed 再 scan\n`,
+  );
+  return 0;
+}
+
 async function main(): Promise<number> {
   const [, , cmd, ...rest] = process.argv;
   if (!cmd || cmd === "--help" || cmd === "-h") {
@@ -332,6 +374,8 @@ async function main(): Promise<number> {
       return cmdCompareBoxes(rest);
     case "scan":
       return cmdScan(rest);
+    case "snapshot":
+      return cmdSnapshot(rest);
     default:
       process.stderr.write(`[vortex-bench] 未知命令: ${cmd}\n\n${USAGE}`);
       return 1;

--- a/packages/vortex-bench/src/page-side/serialize-snapshot.ts
+++ b/packages/vortex-bench/src/page-side/serialize-snapshot.ts
@@ -60,6 +60,7 @@ export const SERIALIZE_SNAPSHOT_CODE = `(function(){
     for (var i=0;i<el.attributes.length;i++){
       var a = el.attributes[i];
       if (a.name === "style") continue;
+      if (a.name === "data-vtx-oracle") continue;
       attrs += " "+a.name+"=\\""+esc(a.value)+"\\"";
     }
     if (isCandidate(el)){
@@ -105,5 +106,7 @@ export const SERIALIZE_SNAPSHOT_CODE = `(function(){
   }
 
   var html = "<!doctype html>\\n" + serializeEl(document.documentElement);
-  return JSON.stringify({ html: html, candidates: candidates });
+  // 返回对象(非 JSON.stringify):vortex_evaluate 会把返回值序列化一次。
+  // 若这里再 stringify 会双重编码,bench 侧 JSON.parse 得到字符串而非对象。
+  return { html: html, candidates: candidates };
 })()`;

--- a/packages/vortex-bench/src/page-side/serialize-snapshot.ts
+++ b/packages/vortex-bench/src/page-side/serialize-snapshot.ts
@@ -1,0 +1,108 @@
+// packages/vortex-bench/src/page-side/serialize-snapshot.ts
+// page-side 脚本:序列化当前文档为自包含静态 HTML + 提议候选。
+// 经 vortex_evaluate({code: SERIALIZE_SNAPSHOT_CODE}) 注入,返回 JSON.stringify(SerializeResult)。
+// 保真度契约:烘焙 observe 关心的 computed 样式(cursor/visibility/display)为 inline style,
+// 开放 shadow → DSD,srcdoc/同源 iframe 递归,剥 script。proposer 用比 observe 更宽的启发式。
+
+export const SERIALIZE_SNAPSHOT_CODE = `(function(){
+  var oracleSeq = 0;
+  var candidates = [];
+  var INTERACTIVE_ROLES = {button:1,link:1,textbox:1,checkbox:1,radio:1,tab:1,menuitem:1,treeitem:1,option:1,"switch":1,combobox:1,slider:1,menuitemcheckbox:1,menuitemradio:1};
+  var NATIVE_TAGS = {BUTTON:1,A:1,INPUT:1,SELECT:1,TEXTAREA:1,SUMMARY:1};
+  var VOID_TAGS = {area:1,base:1,br:1,col:1,embed:1,hr:1,img:1,input:1,link:1,meta:1,param:1,source:1,track:1,wbr:1};
+
+  function esc(s){ return String(s).replace(/&/g,"&amp;").replace(/"/g,"&quot;").replace(/</g,"&lt;"); }
+  function escText(s){ return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;"); }
+
+  function isCandidate(el){
+    if (NATIVE_TAGS[el.tagName]) return true;
+    var role = el.getAttribute("role");
+    if (role && INTERACTIVE_ROLES[role]) return true;
+    var ti = el.getAttribute("tabindex");
+    if (ti !== null && ti !== "-1") return true;
+    if (el.hasAttribute("onclick")) return true;
+    if (el.tagName !== "HTML" && el.tagName !== "BODY") {
+      try { if (getComputedStyle(el).cursor === "pointer") return true; } catch(e){}
+    }
+    return false;
+  }
+  function guessName(el){
+    var al = el.getAttribute("aria-label"); if (al && al.trim()) return al.trim().slice(0,80);
+    var t = el.getAttribute("title"); if (t && t.trim()) return t.trim().slice(0,80);
+    var img = el.querySelector ? el.querySelector("img[alt]") : null;
+    if (img && img.getAttribute("alt").trim()) return img.getAttribute("alt").trim().slice(0,80);
+    var txt = (el.textContent||"").replace(/\\s+/g," ").trim();
+    return txt ? txt.slice(0,80) : null;
+  }
+  function guessPattern(el){
+    if (NATIVE_TAGS[el.tagName]) return "native";
+    var role = el.getAttribute("role"); if (role) return "role-"+role;
+    if (el.hasAttribute("onclick")) return "onclick";
+    try { if (getComputedStyle(el).cursor === "pointer") return "cursor-pointer-div"; } catch(e){}
+    if (el.getAttribute("tabindex")) return "tabindex";
+    return "other";
+  }
+  function bakeStyle(el){
+    var parts = [];
+    try {
+      var cs = getComputedStyle(el);
+      if (cs.cursor && cs.cursor !== "auto" && cs.cursor !== "default") parts.push("cursor:"+cs.cursor);
+      if (cs.visibility === "hidden") parts.push("visibility:hidden");
+      if (cs.display === "none") parts.push("display:none");
+    } catch(e){}
+    return parts.join(";");
+  }
+
+  function serializeEl(el){
+    var tag = el.tagName.toLowerCase();
+    if (tag === "script") return "";
+    var attrs = "";
+    for (var i=0;i<el.attributes.length;i++){
+      var a = el.attributes[i];
+      if (a.name === "style") continue;
+      attrs += " "+a.name+"=\\""+esc(a.value)+"\\"";
+    }
+    if (isCandidate(el)){
+      var id = "c"+(oracleSeq++);
+      attrs += " data-vtx-oracle=\\""+id+"\\"";
+      var r = el.getBoundingClientRect();
+      candidates.push({ id:id, role: el.getAttribute("role")||tag, name: guessName(el), pattern: guessPattern(el),
+        bbox: [Math.round(r.x),Math.round(r.y),Math.round(r.width),Math.round(r.height)] });
+    }
+    var baked = bakeStyle(el);
+    var existing = el.getAttribute("style");
+    var style = [existing, baked].filter(Boolean).join(";");
+    if (style) attrs += " style=\\""+esc(style)+"\\"";
+
+    if (VOID_TAGS[tag]) return "<"+tag+attrs+">";
+
+    if (tag === "iframe"){
+      try {
+        var doc = el.contentDocument;
+        if (doc && doc.documentElement) {
+          var frozen = serializeEl(doc.documentElement);
+          return "<iframe"+attrs+" srcdoc=\\""+esc(frozen)+"\\"></iframe>";
+        }
+      } catch(e){ return "<iframe"+attrs+"></iframe><!--cross-origin iframe not captured-->"; }
+    }
+
+    var inner = "";
+    if (el.shadowRoot){
+      inner += "<template shadowrootmode=\\"open\\">";
+      var sc = el.shadowRoot.childNodes;
+      for (var j=0;j<sc.length;j++) inner += serializeNode(sc[j]);
+      inner += "</template>";
+    }
+    var cn = el.childNodes;
+    for (var k=0;k<cn.length;k++) inner += serializeNode(cn[k]);
+    return "<"+tag+attrs+">"+inner+"</"+tag+">";
+  }
+  function serializeNode(node){
+    if (node.nodeType === 3) return escText(node.nodeValue);
+    if (node.nodeType === 1) return serializeEl(node);
+    return "";
+  }
+
+  var html = "<!doctype html>\\n" + serializeEl(document.documentElement);
+  return JSON.stringify({ html: html, candidates: candidates });
+})()`;

--- a/packages/vortex-bench/src/page-side/serialize-snapshot.ts
+++ b/packages/vortex-bench/src/page-side/serialize-snapshot.ts
@@ -83,6 +83,7 @@ export const SERIALIZE_SNAPSHOT_CODE = `(function(){
           var frozen = serializeEl(doc.documentElement);
           return "<iframe"+attrs+" srcdoc=\\""+esc(frozen)+"\\"></iframe>";
         }
+        return "<iframe"+attrs+"></iframe><!--iframe doc not accessible-->";
       } catch(e){ return "<iframe"+attrs+"></iframe><!--cross-origin iframe not captured-->"; }
     }
 

--- a/packages/vortex-bench/src/runner/propose-manifest.ts
+++ b/packages/vortex-bench/src/runner/propose-manifest.ts
@@ -1,0 +1,67 @@
+// packages/vortex-bench/src/runner/propose-manifest.ts
+// 候选(proposer)+ observe 行 → delta 分类 + 提议 manifest。
+// 复用 #1 的 joinByGeometry:候选当 oracles,observe 行当 rows。
+
+import { joinByGeometry } from "./geometry-join.js";
+import type { ObserveRow, OracleRect } from "../scan-types.js";
+import type { ProposedEntry, ProposedManifest, RawCandidate, ReviewTag } from "../snapshot-types.js";
+
+export interface ProposeMeta {
+  fixture: string;
+  path: string;
+  source: string;
+  capturedAt: string;
+  frames?: "main" | "all-same-origin" | "all-permitted";
+}
+
+const REVIEW_ORDER: Record<ReviewTag, number> = { "observe-missed": 0, "observe-extra": 1, agree: 2 };
+
+export function proposeManifest(
+  candidates: RawCandidate[],
+  observeRows: ObserveRow[],
+  meta: ProposeMeta,
+): ProposedManifest {
+  const oracles: OracleRect[] = candidates.map((c) => ({ id: c.id, rect: c.bbox }));
+  const { matches, unmatchedRows } = joinByGeometry(observeRows, oracles, {});
+
+  const entries: ProposedEntry[] = [];
+
+  // 候选 → agree(有 observe 命中)/ observe-missed(无)
+  for (const c of candidates) {
+    const hit = (matches.get(c.id) ?? []).length > 0;
+    entries.push({
+      id: c.id,
+      interactive: true,
+      expectedName: c.name,
+      expectedRole: c.role,
+      pattern: c.pattern,
+      _review: hit ? "agree" : "observe-missed",
+    });
+  }
+
+  // observe 行无候选命中 → observe-extra(冻结页无 data-vtx-oracle,按 name 匹配)
+  let extraSeq = 0;
+  for (const r of unmatchedRows) {
+    entries.push({
+      id: `extra-${extraSeq++}`,
+      interactive: true,
+      expectedName: r.name,
+      expectedRole: r.role,
+      pattern: "_observe-extra",
+      joinBy: "name",
+      _review: "observe-extra",
+    });
+  }
+
+  entries.sort((a, b) => REVIEW_ORDER[a._review] - REVIEW_ORDER[b._review]);
+
+  return {
+    fixture: meta.fixture,
+    path: meta.path,
+    frames: meta.frames ?? "main",
+    source: meta.source,
+    capturedAt: meta.capturedAt,
+    _proposed: true,
+    entries,
+  };
+}

--- a/packages/vortex-bench/src/runner/scan.ts
+++ b/packages/vortex-bench/src/runner/scan.ts
@@ -26,11 +26,19 @@ function extractText(res: unknown): string {
     .join("\n");
 }
 
+// 穿 open shadow 收集所有 data-vtx-oracle 元素 —— 与 observe 的 querySelectorAllDeep
+// 一致。光 document.querySelectorAll 不穿 shadow,会让 shadow 内部的 oracle 元素拿不到
+// 几何而错配(#2 快照把 oracle 标在真实交互元素上,可能落在 shadow 内)。
 const ORACLE_PROBE_CODE =
-  "Array.from(document.querySelectorAll('[data-vtx-oracle]')).map(function(el){" +
+  "(function(){var out=[];" +
+  "function visit(el){" +
+  "if(el.getAttribute&&el.getAttribute('data-vtx-oracle')!==null){" +
   "var r=el.getBoundingClientRect();" +
-  "return {id:el.getAttribute('data-vtx-oracle')," +
-  "rect:[Math.round(r.x),Math.round(r.y),Math.round(r.width),Math.round(r.height)]};})";
+  "out.push({id:el.getAttribute('data-vtx-oracle')," +
+  "rect:[Math.round(r.x),Math.round(r.y),Math.round(r.width),Math.round(r.height)]});}" +
+  "if(el.shadowRoot){var sc=el.shadowRoot.querySelectorAll('*');for(var i=0;i<sc.length;i++)visit(sc[i]);}}" +
+  "var all=document.querySelectorAll('*');for(var j=0;j<all.length;j++)visit(all[j]);" +
+  "return out;})()";
 
 export async function scanFixture(manifest: SynthManifest, opts: ScanOptions): Promise<FixtureScanResult> {
   const frames = manifest.frames ?? "main";

--- a/packages/vortex-bench/src/runner/snapshot.ts
+++ b/packages/vortex-bench/src/runner/snapshot.ts
@@ -59,7 +59,17 @@ export async function captureSnapshot(opts: SnapshotOptions): Promise<SnapshotRe
 
     // 1) 序列化 + 提议候选(一次 evaluate)
     const serRaw = extractText(await call("vortex_evaluate", { code: SERIALIZE_SNAPSHOT_CODE }));
-    const ser = JSON.parse(serRaw) as SerializeResult;
+    if (!serRaw.trim()) {
+      throw new Error("[snapshot] vortex_evaluate 返回空串,页面可能未加载完或脚本被 CSP 拦截");
+    }
+    let ser: SerializeResult;
+    try {
+      ser = JSON.parse(serRaw) as SerializeResult;
+    } catch (e) {
+      throw new Error(
+        `[snapshot] 序列化结果非合法 JSON: ${e instanceof Error ? e.message : String(e)}; 头120字: ${serRaw.slice(0, 120)}`,
+      );
+    }
 
     // 2) 当前页 observe(includeBoxes)作 delta 对照
     const obsText = extractText(await call("vortex_observe", { frames, includeBoxes: true }));

--- a/packages/vortex-bench/src/runner/snapshot.ts
+++ b/packages/vortex-bench/src/runner/snapshot.ts
@@ -1,0 +1,103 @@
+// packages/vortex-bench/src/runner/snapshot.ts
+// bench snapshot 编排:(可选 navigate)→ evaluate 注入序列化器 → observe(includeBoxes)
+// → proposeManifest 算 delta → 写 synth/<name>.html + synth/<name>.manifest.json。
+
+import { writeFile, mkdir } from "node:fs/promises";
+import { resolve } from "node:path";
+import { createMcpConnection, closeMcpConnection } from "./mcp-client.js";
+import { parseObserveSnapshot } from "./observe-parser.js";
+import { proposeManifest } from "./propose-manifest.js";
+import { SERIALIZE_SNAPSHOT_CODE } from "../page-side/serialize-snapshot.js";
+import type { SerializeResult } from "../snapshot-types.js";
+
+export interface SnapshotOptions {
+  mcpBin: string;
+  /** 目标 fixture 短名,产出 <name>.html / <name>.manifest.json */
+  name: string;
+  /** 写入目录(playground/public/synth 的绝对路径) */
+  synthDir: string;
+  /** 可选:先 navigate 到此 URL;省略则捕获当前活动 tab */
+  url?: string;
+  /** observe frames 参数,默认 "main" */
+  frames?: "main" | "all-same-origin" | "all-permitted";
+}
+
+export interface SnapshotResult {
+  htmlPath: string;
+  manifestPath: string;
+  source: string;
+  candidateCount: number;
+  observeRowCount: number;
+  /** 各 _review 计数,给 CLI 打印 */
+  review: { observeMissed: number; observeExtra: number; agree: number };
+}
+
+function extractText(res: unknown): string {
+  const content = (res as { content?: unknown }).content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((i) => i && typeof i === "object" && "text" in i)
+    .map((i) => String((i as { text: unknown }).text))
+    .join("\n");
+}
+
+export async function captureSnapshot(opts: SnapshotOptions): Promise<SnapshotResult> {
+  const frames = opts.frames ?? "main";
+  const mcp = await createMcpConnection({
+    command: process.execPath,
+    args: [opts.mcpBin],
+    env: { ...(process.env as Record<string, string>) },
+  });
+  const call = (name: string, args: Record<string, unknown>) =>
+    mcp.client.callTool({ name, arguments: args });
+
+  try {
+    if (opts.url) {
+      await call("vortex_navigate", { url: opts.url });
+      await call("vortex_wait_for", { mode: "idle", value: "dom", timeout: 5000 });
+    }
+
+    // 1) 序列化 + 提议候选(一次 evaluate)
+    const serRaw = extractText(await call("vortex_evaluate", { code: SERIALIZE_SNAPSHOT_CODE }));
+    const ser = JSON.parse(serRaw) as SerializeResult;
+
+    // 2) 当前页 observe(includeBoxes)作 delta 对照
+    const obsText = extractText(await call("vortex_observe", { frames, includeBoxes: true }));
+    const parsed = parseObserveSnapshot(obsText);
+
+    // 3) 来源 URL(observe 头部的 URL,fallback 到 opts.url)
+    const source = parsed.header.url || opts.url || "(unknown)";
+
+    // 4) 提议 manifest
+    const manifest = proposeManifest(ser.candidates, parsed.rows, {
+      fixture: opts.name,
+      path: `/synth/${opts.name}.html`,
+      source,
+      capturedAt: new Date().toISOString(),
+      frames,
+    });
+
+    // 5) 写文件
+    await mkdir(opts.synthDir, { recursive: true });
+    const htmlPath = resolve(opts.synthDir, `${opts.name}.html`);
+    const manifestPath = resolve(opts.synthDir, `${opts.name}.manifest.json`);
+    await writeFile(htmlPath, ser.html);
+    await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+    const review = { observeMissed: 0, observeExtra: 0, agree: 0 };
+    for (const e of manifest.entries) {
+      if (e._review === "observe-missed") review.observeMissed++;
+      else if (e._review === "observe-extra") review.observeExtra++;
+      else review.agree++;
+    }
+
+    return {
+      htmlPath, manifestPath, source,
+      candidateCount: ser.candidates.length,
+      observeRowCount: parsed.rows.length,
+      review,
+    };
+  } finally {
+    await closeMcpConnection(mcp);
+  }
+}

--- a/packages/vortex-bench/src/scan-types.ts
+++ b/packages/vortex-bench/src/scan-types.ts
@@ -14,6 +14,8 @@ export interface ManifestEntry {
   pattern: string;
   /** join 方式:geometry(默认,按 bbox)或 name(跨 frame fixture 用) */
   joinBy?: "geometry" | "name";
+  /** #2 提议稿的 delta 提示(scan 忽略此字段) */
+  _review?: "observe-missed" | "observe-extra" | "agree";
   note?: string;
 }
 
@@ -24,6 +26,10 @@ export interface SynthManifest {
   path: string;
   /** observe frames 参数,默认 "main" */
   frames?: "main" | "all-same-origin" | "all-permitted";
+  /** #2:捕获来源 URL(真站派生 fixture 记溯源) */
+  source?: string;
+  /** #2:提议稿未确认标记;scan 跳过 _proposed:true 的 manifest */
+  _proposed?: boolean;
   entries: ManifestEntry[];
 }
 

--- a/packages/vortex-bench/src/snapshot-types.ts
+++ b/packages/vortex-bench/src/snapshot-types.ts
@@ -1,0 +1,37 @@
+// packages/vortex-bench/src/snapshot-types.ts
+// 自主发现引擎 #2 — 快照捕获 / 提议 manifest 类型。
+
+import type { ManifestEntry, SynthManifest } from "./scan-types.js";
+
+/** page-side 提议器对一个候选元素的原始记录(序列化时产出) */
+export interface RawCandidate {
+  id: string;
+  role: string;
+  name: string | null;
+  pattern: string;
+  /** [x,y,w,h] viewport 坐标(getBoundingClientRect,已 round) */
+  bbox: [number, number, number, number];
+}
+
+/** page-side 脚本 vortex_evaluate 的返回结构 */
+export interface SerializeResult {
+  /** 自包含静态 HTML(冻结页) */
+  html: string;
+  candidates: RawCandidate[];
+}
+
+/** delta 分类:候选与 observe 是否一致 */
+export type ReviewTag = "observe-missed" | "observe-extra" | "agree";
+
+export interface ProposedEntry extends ManifestEntry {
+  _review: ReviewTag;
+}
+
+export interface ProposedManifest extends Omit<SynthManifest, "entries"> {
+  _proposed: true;
+  /** 捕获来源 URL */
+  source: string;
+  /** ISO 时间戳 */
+  capturedAt: string;
+  entries: ProposedEntry[];
+}

--- a/packages/vortex-bench/tests/propose-manifest.test.ts
+++ b/packages/vortex-bench/tests/propose-manifest.test.ts
@@ -1,0 +1,55 @@
+// packages/vortex-bench/tests/propose-manifest.test.ts
+import { describe, it, expect } from "vitest";
+import { proposeManifest } from "../src/runner/propose-manifest.js";
+import type { RawCandidate } from "../src/snapshot-types.js";
+import type { ObserveRow } from "../src/scan-types.js";
+
+const meta = { fixture: "demo", path: "/synth/demo.html", source: "https://x.com/p", capturedAt: "2026-05-26T00:00:00Z" };
+const cand = (id: string, bbox: [number, number, number, number], name = "x", pattern = "native"): RawCandidate =>
+  ({ id, role: "button", name, pattern, bbox });
+const row = (bbox: ObserveRow["bbox"], name = "x"): ObserveRow =>
+  ({ ref: "@" + name, role: "button", name, flags: [], bbox, frameId: 0 });
+
+describe("proposeManifest", () => {
+  it("候选与 observe 行几何命中 → agree", () => {
+    const m = proposeManifest([cand("c0", [10, 10, 20, 20])], [row([12, 12, 16, 16])], meta);
+    const e = m.entries.find((x) => x.id === "c0")!;
+    expect(e._review).toBe("agree");
+    expect(e.interactive).toBe(true);
+  });
+
+  it("候选无 observe 命中 → observe-missed(最高价值)", () => {
+    const m = proposeManifest([cand("c0", [10, 10, 20, 20])], [], meta);
+    const e = m.entries.find((x) => x.id === "c0")!;
+    expect(e._review).toBe("observe-missed");
+  });
+
+  it("observe 行无候选命中 → observe-extra(joinBy:name)", () => {
+    const m = proposeManifest([], [row([500, 500, 10, 10], "孤儿")], meta);
+    const e = m.entries.find((x) => x._review === "observe-extra")!;
+    expect(e).toBeDefined();
+    expect(e.joinBy).toBe("name");
+    expect(e.expectedName).toBe("孤儿");
+  });
+
+  it("排序:observe-missed → observe-extra → agree", () => {
+    const m = proposeManifest(
+      [cand("agreeC", [10, 10, 20, 20]), cand("missC", [200, 200, 20, 20])],
+      [row([12, 12, 16, 16], "x"), row([900, 900, 10, 10], "孤儿")],
+      meta,
+    );
+    const reviews = m.entries.map((e) => e._review);
+    expect(reviews[0]).toBe("observe-missed");
+    expect(reviews[reviews.length - 1]).toBe("agree");
+    expect(reviews).toContain("observe-extra");
+  });
+
+  it("manifest 元数据:_proposed/source/capturedAt", () => {
+    const m = proposeManifest([cand("c0", [10, 10, 20, 20])], [], meta);
+    expect(m._proposed).toBe(true);
+    expect(m.source).toBe("https://x.com/p");
+    expect(m.capturedAt).toBe("2026-05-26T00:00:00Z");
+    expect(m.fixture).toBe("demo");
+    expect(m.path).toBe("/synth/demo.html");
+  });
+});


### PR DESCRIPTION
## 背景

自主发现引擎 #2,建立在 #1(PR #25)的 `bench scan` 引擎之上。#1 在**手写合成对抗页面**上验证了引擎;#2 把同一引擎**延伸到真站派生 fixture**:`bench snapshot <name>` 把当前 Chrome tab 的真实页面**冻结**成自包含静态 fixture,用启发式提议器 + 一次性 observe 差分生成**待人确认**的 manifest 提议稿;人确认后该 fixture 进同一个 `bench scan`。

设计/计划见知识库 `12-Projects/0022-vortex-自主发现引擎/`(#2 文档)。

## 设计取舍

- **B2(差分一次性,非热循环)**:#1 教训是 manifest-oracle 干净、差分有噪声。故 #2 把差分降级为**捕获时一次性的标注助手**(`_review` 提示聚焦人审注意力),确认后变成确定性的 #1 式 case。否决了 roadmap 原写的"纯差分 B1"。
- **A(inline 计算样式序列化)**:关键洞察——observe 靠静态信号 + computed style(`[role]`/`[tabindex]`/`[onclick]` + computed `cursor:pointer`),**不依赖 addEventListener**。故冻结只**烘焙 observe 实际读的 computed 值**(cursor/visibility/display)为 inline style + DSD shadow + srcdoc 递归 + 剥 script,自包含可直接服务,而非保全整张 CSS。

## 改动

全部在 `packages/vortex-bench`:
- `snapshot-types.ts` + `scan-types.ts` 扩展(`source`/`_proposed`/`_review`)
- `propose-manifest.ts`(纯逻辑,**复用 #1 的 `joinByGeometry`** 算 observe delta:agree/observe-missed/observe-extra,5 单测)
- `page-side/serialize-snapshot.ts`(序列化器+提议器脚本)
- `runner/snapshot.ts`(编排:序列化→observe→提议→写文件)
- `index.ts`(`snapshot` 子命令 + scan `_proposed` skip-guard)
- `runner/scan.ts`(oracle 探针改穿 open shadow,与 observe 一致 —— 修 #1 引擎潜在 gap)

## 测试计划

- [x] vitest **100 tests 全过**(含 propose-manifest 5 新测)
- [x] tsc + throw-discipline + CLI 烟测(`--help`/空参)
- [x] **round-trip 保真自检**(捕获 #1 自己的 fixture 当试金石):
  - cursor-pointer-div 冻结副本 scan → **recall=3/3 P0=0**(inline cursor 烘焙生效)
  - open-shadow-nested DSD 冻结副本 scan → **recall=1/1 P0=0**(DSD 水合 + observe 穿透)
  - #1 全 9 fixture 回归 → 全 P0=0
- [x] code review(final reviewer)→ 修 JSON 守卫 + --url 解析 + iframe null-doc
- [x] **round-trip 揪出并修 3 个真 bug**:双重编码 / 重复 data-vtx-oracle / oracle 探针不穿 shadow

## 后续(不在本 PR)

#3 真站 seed live → #4 公开站随机 → #5 LLM-judge 塔尖。真站冒烟(验收标准 6)留作按需执行,核心保真度已由 round-trip 严格验证。