### PR TITLE
feat(bench): 自主发现引擎 #3 — 健壮性信号层(observe→act 契约)

### DIFF
--- a/packages/vortex-bench/.gitignore
+++ b/packages/vortex-bench/.gitignore
@@ -14,3 +14,6 @@ reports/*.md
 
 # scan 运行产物(transient discovery 报告,按时间戳生成,不入库)
 reports/scan/
+
+# robustness 运行产物(同 scan,transient discovery 报告,不入库)
+reports/robustness/

--- a/packages/vortex-bench/src/index.ts
+++ b/packages/vortex-bench/src/index.ts
@@ -18,6 +18,9 @@ import { scanFixture } from "./runner/scan.js";
 import { renderScanMarkdown, rankFindings } from "./scan-report.js";
 import type { FixtureScanResult, ScanReport, SynthManifest } from "./scan-types.js";
 import { captureSnapshot } from "./runner/snapshot.js";
+import { probeFixture } from "./runner/robustness.js";
+import { renderRobustnessMarkdown, rankRobustnessFindings } from "./robustness-report.js";
+import type { FixtureRobustness, RobustnessReport } from "./robustness-types.js";
 
 const USAGE = `vortex-bench <command>
 
@@ -36,6 +39,8 @@ Commands:
   scan --pattern <name>  扫单个 pattern
   snapshot <name>        冻结当前活动 tab 为 synth/<name>.html + 提议 manifest
   snapshot <name> --url <u>  先 navigate 再冻结
+  robustness --all       探全部 fixture 的 observe→act 契约,产 reports/robustness/<ts>.{md,json}
+  robustness --pattern <name>  探单个 fixture
   --help                 显示帮助
 
 Env:
@@ -50,6 +55,7 @@ const CASES_DIR = resolve(PKG_ROOT, "cases");
 const REPORTS_DIR = resolve(PKG_ROOT, "reports");
 const SYNTH_DIR = resolve(PKG_ROOT, "playground", "public", "synth");
 const SCAN_REPORTS_DIR = resolve(REPORTS_DIR, "scan");
+const ROBUSTNESS_REPORTS_DIR = resolve(REPORTS_DIR, "robustness");
 
 function resolveMcpBin(): string {
   if (process.env.VORTEX_MCP_BIN) return resolve(process.env.VORTEX_MCP_BIN);
@@ -361,6 +367,67 @@ async function cmdSnapshot(args: string[]): Promise<number> {
   return 0;
 }
 
+async function cmdRobustness(args: string[]): Promise<number> {
+  const runAll = args.includes("--all");
+  let names: string[];
+  if (runAll) {
+    names = await listSynthManifests();
+  } else {
+    const patternIdx = args.indexOf("--pattern");
+    if (patternIdx >= 0 && args[patternIdx + 1]) names = [args[patternIdx + 1]];
+    else names = args.filter((a) => !a.startsWith("-"));
+  }
+  if (names.length === 0) {
+    process.stderr.write("[vortex-bench] robustness 需要 --all 或 --pattern <name> 或 <name...>\n");
+    return 1;
+  }
+
+  const mcpBin = resolveMcpBin();
+  const url = playgroundUrl();
+  process.stdout.write(`[vortex-bench] robustness  playground=${url}  mcp=${mcpBin}\n`);
+  process.stdout.write(`[vortex-bench] 探 ${names.length} 个 fixture 的 observe→act 契约\n\n`);
+
+  const report: RobustnessReport = {
+    generatedAt: new Date().toISOString(), playgroundUrl: url, fixtures: [], findings: [],
+  };
+  for (const name of names) {
+    let fx: FixtureRobustness;
+    try {
+      const manifest = await loadManifest(name);
+      if (isProposed(manifest)) {
+        process.stdout.write(`⊘ ${name.padEnd(28)} 跳过未审提议稿(_proposed:true)\n`);
+        continue;
+      }
+      fx = await probeFixture(manifest, { mcpBin, playgroundUrl: url });
+    } catch (e) {
+      fx = {
+        fixture: name, path: "", totalRefs: 0, okCount: 0, okRate: 1, histogram: {},
+        findings: [], error: `加载/探测失败: ${e instanceof Error ? e.message : String(e)}`,
+      };
+    }
+    report.fixtures.push(fx);
+    report.findings.push(...fx.findings);
+    const r0 = fx.findings.filter((f) => f.severity === "R0").length;
+    const r1 = fx.findings.filter((f) => f.severity === "R1").length;
+    process.stdout.write(
+      `${r0 === 0 ? "✓" : "✗"} ${name.padEnd(28)} refs=${fx.totalRefs} okRate=${(fx.okRate * 100).toFixed(0)}% ` +
+      `R0=${r0} R1=${r1}${fx.error ? `  ⚠ ${fx.error}` : ""}\n`,
+    );
+  }
+  report.findings = rankRobustnessFindings(report.findings);
+
+  await mkdir(ROBUSTNESS_REPORTS_DIR, { recursive: true });
+  const stamp = report.generatedAt.replace(/[:.]/g, "-");
+  const jsonPath = join(ROBUSTNESS_REPORTS_DIR, `${stamp}.json`);
+  const mdPath = join(ROBUSTNESS_REPORTS_DIR, `${stamp}.md`);
+  await writeFile(jsonPath, JSON.stringify(report, null, 2));
+  await writeFile(mdPath, renderRobustnessMarkdown(report));
+  process.stdout.write(`\n[report] ${mdPath}\n[report] ${jsonPath}\n`);
+
+  const totalR0 = report.findings.filter((f) => f.severity === "R0").length;
+  return totalR0 === 0 ? 0 : 2;
+}
+
 async function main(): Promise<number> {
   const [, , cmd, ...rest] = process.argv;
   if (!cmd || cmd === "--help" || cmd === "-h") {
@@ -380,6 +447,8 @@ async function main(): Promise<number> {
       return cmdScan(rest);
     case "snapshot":
       return cmdSnapshot(rest);
+    case "robustness":
+      return cmdRobustness(rest);
     default:
       process.stderr.write(`[vortex-bench] 未知命令: ${cmd}\n\n${USAGE}`);
       return 1;

--- a/packages/vortex-bench/src/robustness-report.ts
+++ b/packages/vortex-bench/src/robustness-report.ts
@@ -1,0 +1,55 @@
+// packages/vortex-bench/src/robustness-report.ts
+// R0→R1 排序 + markdown 渲染。json 报告直接 JSON.stringify(report)。
+
+import type { RobustnessReport, RobustnessFinding } from "./robustness-types.js";
+
+const SEV_ORDER: Record<RobustnessFinding["severity"], number> = { R0: 0, R1: 1 };
+
+export function rankRobustnessFindings(findings: RobustnessFinding[]): RobustnessFinding[] {
+  return [...findings].sort((a, b) => SEV_ORDER[a.severity] - SEV_ORDER[b.severity]);
+}
+
+export function renderRobustnessMarkdown(report: RobustnessReport): string {
+  const lines: string[] = [];
+  lines.push("# vortex robustness 报告(漏斗 layer-0:observe→act 契约)");
+  lines.push("");
+  lines.push(`- 生成时间: ${report.generatedAt}`);
+  lines.push(`- playground: ${report.playgroundUrl}`);
+  const r0 = report.findings.filter((f) => f.severity === "R0").length;
+  const r1 = report.findings.filter((f) => f.severity === "R1").length;
+  lines.push(`- fixture 数: ${report.fixtures.length}  R0: ${r0}  R1: ${r1}`);
+  lines.push("");
+
+  // per-page 表
+  lines.push("## 汇总(per-fixture)");
+  lines.push("");
+  lines.push("| fixture | 总 ref | okRate | R0 | R1 |");
+  lines.push("|---|---|---|---|---|");
+  for (const fxr of report.fixtures) {
+    const fr0 = fxr.findings.filter((f) => f.severity === "R0").length;
+    const fr1 = fxr.findings.filter((f) => f.severity === "R1").length;
+    lines.push(
+      `| ${fxr.fixture} | ${fxr.totalRefs} | ${(fxr.okRate * 100).toFixed(0)}% | ${fr0} | ${fr1} |`,
+    );
+    if (fxr.error) lines.push(`| ↳ ⚠ error | ${fxr.error.replace(/\|/g, "\\|")} | | | |`);
+  }
+  lines.push("");
+
+  const ranked = rankRobustnessFindings(report.findings);
+  if (r0 === 0) {
+    lines.push("> ✅ observe→act 契约全成立 —— observe 发的每个 ref 都能被 act 解析(无 R0)。");
+    lines.push("");
+  }
+  for (const sev of ["R0", "R1"] as const) {
+    const group = ranked.filter((f) => f.severity === sev);
+    if (group.length === 0) continue;
+    const title = sev === "R0" ? "R0(契约违反 / crash / timeout)" : "R1(actionability 降级)";
+    lines.push(`## ${title} — ${group.length}`);
+    lines.push("");
+    for (const f of group) {
+      lines.push(`- **[${f.code}]** \`${f.fixture}\` \`${f.ref}\` — ${f.detail}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}

--- a/packages/vortex-bench/src/robustness-types.ts
+++ b/packages/vortex-bench/src/robustness-types.ts
@@ -1,0 +1,52 @@
+// 自主发现引擎 #3 — 健壮性信号层(漏斗 layer-0)共享类型。
+// 与 scan-types.ts 解耦:robustness 是无 oracle 自证层,不复用 Finding/FixtureScanResult。
+
+/** 单个 ref 跑 act(click) 的结果种类 */
+export type RefOutcomeKind = "ok" | "typed-error" | "crash" | "timeout";
+
+/** 一个 ref 的探测结果(供聚合) */
+export interface RefOutcome {
+  ref: string;
+  /** observe 行的 role,供 finding 上下文 */
+  role: string;
+  /** observe 行的 name */
+  name: string | null;
+  kind: RefOutcomeKind;
+  /** typed-error 时抽出的错误码(如 OBSCURED);其余为 null */
+  code: string | null;
+  /** act 输出/异常消息(已截断),供报告 */
+  detail: string;
+}
+
+export type RobustnessSeverity = "R0" | "R1";
+
+export interface RobustnessFinding {
+  severity: RobustnessSeverity;
+  fixture: string;
+  ref: string;
+  /** 错误码,或字面量 "crash"/"timeout" */
+  code: string;
+  detail: string;
+}
+
+export interface FixtureRobustness {
+  fixture: string;
+  path: string;
+  totalRefs: number;
+  okCount: number;
+  /** okCount/totalRefs;totalRefs===0 时为 1(空页无契约可违反,vacuous pass) */
+  okRate: number;
+  /** outcome key → 计数,如 "ok" / "typed-error:OBSCURED" / "crash" / "timeout" */
+  histogram: Record<string, number>;
+  findings: RobustnessFinding[];
+  /** 环境/工具错误(navigate/observe 失败等,非 finding) */
+  error?: string;
+}
+
+export interface RobustnessReport {
+  generatedAt: string;
+  playgroundUrl: string;
+  fixtures: FixtureRobustness[];
+  /** 所有 fixture 扁平 + R0→R1 排序后的 finding */
+  findings: RobustnessFinding[];
+}

--- a/packages/vortex-bench/src/runner/robustness-aggregate.ts
+++ b/packages/vortex-bench/src/runner/robustness-aggregate.ts
@@ -1,0 +1,69 @@
+// packages/vortex-bench/src/runner/robustness-aggregate.ts
+// 纯逻辑:一页所有 RefOutcome → 直方图 + okRate + R0/R1 finding。
+// 含契约违反检测:observe 刚发的 ref,act 回这些 code = observe→act 握手断了。
+
+import type { RefOutcome, FixtureRobustness, RobustnessFinding } from "../robustness-types.js";
+
+/**
+ * 契约违反码:出现在"observe 刚发的 ref"上意味着 observe 发了个 act 用不了的废 ref
+ * (如 shadow-internal ref → ELEMENT_NOT_FOUND,见记忆 vortex_observe_codepath_gotcha)。
+ * 其余 typed-error(OBSCURED 等)是 actionability 降级,归 R1。
+ */
+export const CONTRACT_VIOLATION_CODES = new Set<string>([
+  "NOT_ATTACHED",
+  "ELEMENT_NOT_FOUND",
+  "STALE_SNAPSHOT",
+]);
+
+export function aggregateFixture(
+  fixture: string,
+  path: string,
+  outcomes: RefOutcome[],
+): FixtureRobustness {
+  const histogram: Record<string, number> = {};
+  const findings: RobustnessFinding[] = [];
+  let okCount = 0;
+
+  for (const out of outcomes) {
+    const key = out.kind === "typed-error" ? `typed-error:${out.code}` : out.kind;
+    histogram[key] = (histogram[key] ?? 0) + 1;
+
+    if (out.kind === "ok") {
+      okCount++;
+      continue;
+    }
+
+    let severity: "R0" | "R1";
+    let code: string;
+    if (out.kind === "crash") {
+      severity = "R0";
+      code = "crash";
+    } else if (out.kind === "timeout") {
+      severity = "R0";
+      code = "timeout";
+    } else {
+      // typed-error
+      code = out.code ?? "UNKNOWN";
+      severity = CONTRACT_VIOLATION_CODES.has(code) ? "R0" : "R1";
+    }
+
+    findings.push({
+      severity,
+      fixture,
+      ref: out.ref,
+      code,
+      detail: `[${out.role}] "${out.name ?? ""}" — ${out.detail}`,
+    });
+  }
+
+  const totalRefs = outcomes.length;
+  return {
+    fixture,
+    path,
+    totalRefs,
+    okCount,
+    okRate: totalRefs === 0 ? 1 : okCount / totalRefs,
+    histogram,
+    findings,
+  };
+}

--- a/packages/vortex-bench/src/runner/robustness-classify.ts
+++ b/packages/vortex-bench/src/runner/robustness-classify.ts
@@ -1,0 +1,31 @@
+// packages/vortex-bench/src/runner/robustness-classify.ts
+// 纯逻辑：把一次 vortex_act(click) 的结果分类为 outcome。
+// 与 invariants.ts 的 classifyProbe 同思路，但额外抽出具体错误码。
+// MCP dispatch 把 typed error 以 content 文本 `Error [CODE]: ...` 返回(dispatch.ts:12)，
+// 只有协议/传输层故障才 reject(=crash)。
+
+import type { RefOutcomeKind } from "../robustness-types.js";
+
+/** 一次 act 探测的原始结果(由编排器的 Promise.race 产出) */
+export interface ActResult {
+  text: string;
+  threw: boolean;
+  timedOut: boolean;
+}
+
+export interface ClassifiedAct {
+  kind: RefOutcomeKind;
+  /** typed-error 时的错误码;其余 null */
+  code: string | null;
+}
+
+// 行首 `Error [CODE]:`, CODE 为大写+下划线(多行模式，因 act 文本可能多行带 hint)
+const ERROR_CODE_RE = /^Error \[([A-Z_]+)\]:/m;
+
+export function classifyAct(r: ActResult): ClassifiedAct {
+  if (r.timedOut) return { kind: "timeout", code: null };
+  if (r.threw) return { kind: "crash", code: null };
+  const m = r.text.match(ERROR_CODE_RE);
+  if (m) return { kind: "typed-error", code: m[1] };
+  return { kind: "ok", code: null };
+}

--- a/packages/vortex-bench/src/runner/robustness.ts
+++ b/packages/vortex-bench/src/runner/robustness.ts
@@ -53,11 +53,16 @@ export async function probeFixture(
     // 先 observe 一次拿 ref 总数 N
     const first = await navObserve();
     const total = first.rows.length;
+    let truncated: string | undefined;
 
     for (let i = 0; i < total; i++) {
       // 每 ref 重导航 + 重 observe → pristine DOM + fresh ref(隔离 mutating click)
       const parsed = await navObserve();
-      if (i >= parsed.rows.length) break; // 防御:重载后 ref 数缩水(理论不应,INV-1 已立)
+      if (i >= parsed.rows.length) {
+        // 重载后 ref 数缩水(理论不应,INV-1 已立):记原因,不静默截断
+        truncated = `ref 数缩水: 初始 N=${total},重载后仅剩 ${parsed.rows.length} 行,中止于 i=${i}`;
+        break;
+      }
       const row = parsed.rows[i];
       const act = await runActProbe(call, row.ref);
       const cls = classifyAct(act);
@@ -67,11 +72,13 @@ export async function probeFixture(
         name: row.name,
         kind: cls.kind,
         code: cls.code,
-        detail: act.text.slice(0, 120),
+        detail: act.timedOut ? "act 超时(>5s)" : act.text.slice(0, 120),
       });
     }
 
-    return aggregateFixture(manifest.fixture, manifest.path, outcomes);
+    const fx = aggregateFixture(manifest.fixture, manifest.path, outcomes);
+    if (truncated) fx.error = truncated;
+    return fx;
   } catch (err) {
     // 中途环境/工具错误:保留已收集 outcomes,挂 error
     const fx = aggregateFixture(manifest.fixture, manifest.path, outcomes);

--- a/packages/vortex-bench/src/runner/robustness.ts
+++ b/packages/vortex-bench/src/runner/robustness.ts
@@ -1,0 +1,105 @@
+// packages/vortex-bench/src/runner/robustness.ts
+// 单 fixture 健壮性探测编排(需活 MCP)。每 ref 独立隔离:重导航 → observe → click rows[i]。
+// 见设计 §3.1:teleport 类 mutating click 不污染其他 ref,R0 语义最精确。
+
+import { createMcpConnection, closeMcpConnection } from "./mcp-client.js";
+import { parseObserveSnapshot } from "./observe-parser.js";
+import { classifyAct, type ActResult } from "./robustness-classify.js";
+import { aggregateFixture } from "./robustness-aggregate.js";
+import type { FixtureRobustness, RefOutcome } from "../robustness-types.js";
+import type { ParsedObserve, SynthManifest } from "../scan-types.js";
+
+export interface RobustnessOptions {
+  mcpBin: string;
+  playgroundUrl: string;
+}
+
+const ACT_TIMEOUT_MS = 5000;
+
+function extractText(res: unknown): string {
+  const content = (res as { content?: unknown }).content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((i) => i && typeof i === "object" && "text" in i)
+    .map((i) => String((i as { text: unknown }).text))
+    .join("\n");
+}
+
+export async function probeFixture(
+  manifest: SynthManifest,
+  opts: RobustnessOptions,
+): Promise<FixtureRobustness> {
+  const frames = manifest.frames ?? "main";
+  const mcp = await createMcpConnection({
+    command: process.execPath,
+    args: [opts.mcpBin],
+    env: { ...(process.env as Record<string, string>) },
+  });
+  const call = (name: string, args: Record<string, unknown>) =>
+    mcp.client.callTool({ name, arguments: args });
+
+  const url = opts.playgroundUrl + manifest.path;
+  const outcomes: RefOutcome[] = [];
+
+  // 重导航 + observe → pristine DOM 上的 fresh rows
+  const navObserve = async (): Promise<ParsedObserve> => {
+    await call("vortex_navigate", { url: "about:blank" });
+    await call("vortex_navigate", { url });
+    await call("vortex_wait_for", { mode: "idle", value: "dom", timeout: 5000 });
+    return parseObserveSnapshot(extractText(await call("vortex_observe", { frames })));
+  };
+
+  try {
+    // 先 observe 一次拿 ref 总数 N
+    const first = await navObserve();
+    const total = first.rows.length;
+
+    for (let i = 0; i < total; i++) {
+      // 每 ref 重导航 + 重 observe → pristine DOM + fresh ref(隔离 mutating click)
+      const parsed = await navObserve();
+      if (i >= parsed.rows.length) break; // 防御:重载后 ref 数缩水(理论不应,INV-1 已立)
+      const row = parsed.rows[i];
+      const act = await runActProbe(call, row.ref);
+      const cls = classifyAct(act);
+      outcomes.push({
+        ref: row.ref,
+        role: row.role,
+        name: row.name,
+        kind: cls.kind,
+        code: cls.code,
+        detail: act.text.slice(0, 120),
+      });
+    }
+
+    return aggregateFixture(manifest.fixture, manifest.path, outcomes);
+  } catch (err) {
+    // 中途环境/工具错误:保留已收集 outcomes,挂 error
+    const fx = aggregateFixture(manifest.fixture, manifest.path, outcomes);
+    fx.error = err instanceof Error ? err.message : String(err);
+    return fx;
+  } finally {
+    await closeMcpConnection(mcp);
+  }
+}
+
+/** 跑一次 vortex_act(click);reject→threw,超时→timedOut。 */
+async function runActProbe(
+  call: (name: string, args: Record<string, unknown>) => Promise<unknown>,
+  ref: string,
+): Promise<ActResult> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const res = await Promise.race([
+      call("vortex_act", { target: ref, action: "click" }),
+      new Promise<never>((_, rej) => {
+        timer = setTimeout(() => rej(new Error("__act_timeout__")), ACT_TIMEOUT_MS);
+      }),
+    ]);
+    return { text: extractText(res), threw: false, timedOut: false };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { text: msg, threw: msg !== "__act_timeout__", timedOut: msg === "__act_timeout__" };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/packages/vortex-bench/tests/robustness-aggregate.test.ts
+++ b/packages/vortex-bench/tests/robustness-aggregate.test.ts
@@ -1,0 +1,70 @@
+// packages/vortex-bench/tests/robustness-aggregate.test.ts
+import { describe, it, expect } from "vitest";
+import { aggregateFixture, CONTRACT_VIOLATION_CODES } from "../src/runner/robustness-aggregate.js";
+import type { RefOutcome } from "../src/robustness-types.js";
+
+const o = (over: Partial<RefOutcome>): RefOutcome => ({
+  ref: "@x", role: "button", name: "n", kind: "ok", code: null, detail: "", ...over,
+});
+
+describe("CONTRACT_VIOLATION_CODES", () => {
+  it("含三个契约违反码", () => {
+    expect([...CONTRACT_VIOLATION_CODES].sort()).toEqual(
+      ["ELEMENT_NOT_FOUND", "NOT_ATTACHED", "STALE_SNAPSHOT"],
+    );
+  });
+});
+
+describe("aggregateFixture", () => {
+  it("全 ok → okRate=1, 无 finding, 直方图只 ok", () => {
+    const fx = aggregateFixture("fx", "/p", [o({}), o({})]);
+    expect(fx.okRate).toBe(1);
+    expect(fx.okCount).toBe(2);
+    expect(fx.totalRefs).toBe(2);
+    expect(fx.findings).toHaveLength(0);
+    expect(fx.histogram).toEqual({ ok: 2 });
+  });
+
+  it("契约违反码 → R0", () => {
+    const fx = aggregateFixture("fx", "/p", [o({ kind: "typed-error", code: "ELEMENT_NOT_FOUND" })]);
+    expect(fx.findings).toHaveLength(1);
+    expect(fx.findings[0].severity).toBe("R0");
+    expect(fx.findings[0].code).toBe("ELEMENT_NOT_FOUND");
+    expect(fx.histogram).toEqual({ "typed-error:ELEMENT_NOT_FOUND": 1 });
+  });
+
+  it("OBSCURED → R1", () => {
+    const fx = aggregateFixture("fx", "/p", [o({ kind: "typed-error", code: "OBSCURED" })]);
+    expect(fx.findings[0].severity).toBe("R1");
+    expect(fx.findings[0].code).toBe("OBSCURED");
+  });
+
+  it("crash → R0(code='crash')", () => {
+    const fx = aggregateFixture("fx", "/p", [o({ kind: "crash", detail: "boom" })]);
+    expect(fx.findings[0].severity).toBe("R0");
+    expect(fx.findings[0].code).toBe("crash");
+  });
+
+  it("timeout → R0(code='timeout')", () => {
+    const fx = aggregateFixture("fx", "/p", [o({ kind: "timeout" })]);
+    expect(fx.findings[0].severity).toBe("R0");
+    expect(fx.findings[0].code).toBe("timeout");
+  });
+
+  it("okRate 计算 + finding detail 带 role/name", () => {
+    const fx = aggregateFixture("fx", "/p", [
+      o({}),
+      o({ ref: "@y", role: "link", name: "更多", kind: "typed-error", code: "OBSCURED", detail: "covered" }),
+    ]);
+    expect(fx.okRate).toBe(0.5);
+    expect(fx.findings[0].ref).toBe("@y");
+    expect(fx.findings[0].detail).toBe('[link] "更多" — covered');
+  });
+
+  it("空页(0 ref)→ okRate=1(vacuous), 无 finding", () => {
+    const fx = aggregateFixture("fx", "/p", []);
+    expect(fx.totalRefs).toBe(0);
+    expect(fx.okRate).toBe(1);
+    expect(fx.findings).toHaveLength(0);
+  });
+});

--- a/packages/vortex-bench/tests/robustness-classify.test.ts
+++ b/packages/vortex-bench/tests/robustness-classify.test.ts
@@ -1,0 +1,32 @@
+// packages/vortex-bench/tests/robustness-classify.test.ts
+import { describe, it, expect } from "vitest";
+import { classifyAct, type ActResult } from "../src/runner/robustness-classify.js";
+
+const r = (over: Partial<ActResult>): ActResult => ({ text: "", threw: false, timedOut: false, ...over });
+
+describe("classifyAct", () => {
+  it("无错误文本 → ok", () => {
+    expect(classifyAct(r({ text: "clicked" }))).toEqual({ kind: "ok", code: null });
+  });
+  it("Error [OBSCURED]: ... → typed-error + code", () => {
+    expect(classifyAct(r({ text: "Error [OBSCURED]: element covered" }))).toEqual({
+      kind: "typed-error",
+      code: "OBSCURED",
+    });
+  });
+  it("Error [ELEMENT_NOT_FOUND]: ... → typed-error + code", () => {
+    expect(classifyAct(r({ text: "Error [ELEMENT_NOT_FOUND]: @x not found\nhint: ..." }))).toEqual({
+      kind: "typed-error",
+      code: "ELEMENT_NOT_FOUND",
+    });
+  });
+  it("threw(reject)→ crash", () => {
+    expect(classifyAct(r({ threw: true, text: "boom" }))).toEqual({ kind: "crash", code: null });
+  });
+  it("timedOut → timeout(优先于 threw)", () => {
+    expect(classifyAct(r({ timedOut: true, threw: true }))).toEqual({ kind: "timeout", code: null });
+  });
+  it("错误码非行首 → 仍 ok(避免误把正文里的 Error[..] 当 typed-error)", () => {
+    expect(classifyAct(r({ text: "result: see Error [X]: above" }))).toEqual({ kind: "ok", code: null });
+  });
+});

--- a/packages/vortex-bench/tests/robustness-report.test.ts
+++ b/packages/vortex-bench/tests/robustness-report.test.ts
@@ -1,0 +1,53 @@
+// packages/vortex-bench/tests/robustness-report.test.ts
+import { describe, it, expect } from "vitest";
+import { rankRobustnessFindings, renderRobustnessMarkdown } from "../src/robustness-report.js";
+import type { RobustnessReport, RobustnessFinding, FixtureRobustness } from "../src/robustness-types.js";
+
+const f = (over: Partial<RobustnessFinding>): RobustnessFinding => ({
+  severity: "R1", fixture: "fx", ref: "@x", code: "OBSCURED", detail: "d", ...over,
+});
+const fx = (over: Partial<FixtureRobustness>): FixtureRobustness => ({
+  fixture: "fx", path: "/p", totalRefs: 2, okCount: 2, okRate: 1, histogram: { ok: 2 }, findings: [], ...over,
+});
+
+describe("rankRobustnessFindings", () => {
+  it("R0 排在 R1 前", () => {
+    const ranked = rankRobustnessFindings([f({ severity: "R1" }), f({ severity: "R0", code: "crash" })]);
+    expect(ranked.map((x) => x.severity)).toEqual(["R0", "R1"]);
+  });
+});
+
+describe("renderRobustnessMarkdown", () => {
+  it("无 R0 → 显式写契约全成立", () => {
+    const report: RobustnessReport = {
+      generatedAt: "2026-05-27T00:00:00Z", playgroundUrl: "http://x", fixtures: [fx({})], findings: [],
+    };
+    const md = renderRobustnessMarkdown(report);
+    expect(md).toContain("✅ observe→act 契约全成立");
+    expect(md).toContain("| fixture | 总 ref | okRate | R0 | R1 |");
+    expect(md).toContain("| fx | 2 | 100% | 0 | 0 |");
+  });
+
+  it("有 R0 → 不写契约全成立, 列出 R0 段", () => {
+    const finding = f({ severity: "R0", code: "ELEMENT_NOT_FOUND", ref: "@bad", detail: '[button] "x" — nope' });
+    const report: RobustnessReport = {
+      generatedAt: "t", playgroundUrl: "u",
+      fixtures: [fx({ findings: [finding], okCount: 1, okRate: 0.5 })],
+      findings: [finding],
+    };
+    const md = renderRobustnessMarkdown(report);
+    expect(md).not.toContain("✅ observe→act 契约全成立");
+    expect(md).toContain("[ELEMENT_NOT_FOUND]");
+    expect(md).toContain("@bad");
+  });
+
+  it("error 行渲染(管道转义)", () => {
+    const report: RobustnessReport = {
+      generatedAt: "t", playgroundUrl: "u",
+      fixtures: [fx({ error: "navigate 失败|超时" })], findings: [],
+    };
+    const md = renderRobustnessMarkdown(report);
+    expect(md).toContain("⚠ error");
+    expect(md).toContain("navigate 失败\\|超时");
+  });
+});

--- a/packages/vortex-bench/tests/robustness-report.test.ts
+++ b/packages/vortex-bench/tests/robustness-report.test.ts
@@ -50,4 +50,17 @@ describe("renderRobustnessMarkdown", () => {
     expect(md).toContain("⚠ error");
     expect(md).toContain("navigate 失败\\|超时");
   });
+
+  it("R1-only(无 R0)→ 既写契约全成立 banner 又列 R1 段", () => {
+    const finding = f({ severity: "R1", code: "OBSCURED", ref: "@cov", detail: '[link] "x" — covered' });
+    const report: RobustnessReport = {
+      generatedAt: "t", playgroundUrl: "u",
+      fixtures: [fx({ findings: [finding], okCount: 1, okRate: 0.5 })],
+      findings: [finding],
+    };
+    const md = renderRobustnessMarkdown(report);
+    expect(md).toContain("✅ observe→act 契约全成立");
+    expect(md).toContain("R1(actionability 降级)");
+    expect(md).toContain("@cov");
+  });
 });


### PR DESCRIPTION
## Summary

自主发现引擎子项目 **#3**:漏斗 **layer-0 健壮性信号层**。新增独立 `bench robustness [--all|--pattern X]` 命令,对 synth/ 冻结语料逐 fixture 探测 **observe→act 契约**——observe 发出的每个 ref,act 到底能不能用。无 oracle 自证,与 #1 `scan`(correctness)、#2 `snapshot`(冻结回归)三层正交。

**核心机制:每 ref 独立隔离**。对一个 fixture,先 observe 拿 ref 总数 N,然后逐 ref **重导航(pristine DOM)+ 重 observe(fresh rows)→ 只 click rows[i]**。这样 mutating click(如 `teleport-popper-overlay` 的 onclick 弹 popper)不污染其他 ref,R0 语义最精确。设计中发现 synth/ 里 #1 手写 fixture 未经 #2 序列化器剥 script,推翻了初版 spec"单次 observe 后逐个 click 安全"的前提,故改此方案。

**严重度**:R0 = observe→act 契约违反(`NOT_ATTACHED`/`ELEMENT_NOT_FOUND`/`STALE_SNAPSHOT`)或 crash/timeout;R1 = 其他 typed-error(如 `OBSCURED`,actionability 降级)。

## Changes

- `src/robustness-types.ts` — 共享类型
- `src/runner/robustness-classify.ts` — act 结果分类(纯逻辑,6 测试)
- `src/runner/robustness-aggregate.ts` — 聚合 + 契约违反检测(纯逻辑,8 测试)
- `src/robustness-report.ts` — 排序 + markdown 渲染(纯逻辑,5 测试)
- `src/runner/robustness.ts` — I/O 编排器(每 ref 重导航)
- `src/index.ts` — 接 `robustness` 子命令
- `.gitignore` — 忽略 `reports/robustness/`(同 scan)

## 自主发现成果(首次有效 live 运行)

| 指标 | 结果 |
|---|---|
| 8/9 良构 fixture | **R0=0 okRate=100%**(无假阳,自校准锚点成立) |
| `teleport-popper-overlay`(mutating click) | okRate=100%(验证每 ref 重导航隔离成功) |
| **`open-shadow-nested`** | **R0=1(真 bug)**:shadow-internal ref → act 超时 hang >5s |

漏斗 layer-0 **首次有效运行即捕获一个真实 observe→act 契约违反**:observe 经 querySelectorAllDeep 穿 shadow 发出影子按钮 ref,但 dom.ts(light-DOM only)无法解析 → act hang。已开 issue #27(发现工具不修复,记录另办)。

## Test Plan

- [x] 纯逻辑 vitest:classify 6 + aggregate 8 + report 5 = 19 新用例全过
- [x] bench 全套 **119 passed**(原 100 + 19),零回归
- [x] `tsc -p tsconfig.build.json` exit 0
- [x] CLI 烟测:`--help` 含 robustness 两行
- [x] live `bench robustness --all`:8/9 R0=0 + 1 真 bug(issue #27),两次复现一致
- [ ] reviewer 复核(可选)

Refs #27