### PR TITLE
fix(action): open-shadow 元素 act 快速失败而非 hang 5s (closes #27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 _新工作进入此段；ship 时改为版本号 + 日期。_
 
+### ✨ Added
+
+- **`wait_for(mode=info)` now surfaces sibling tabs** (`packages/extension/src/handlers/page.ts`, `packages/mcp/src/tools/dispatch.ts`). `PageActions.INFO` accepts an optional `includeAllTabs` flag; when set, the response carries a `tabs: [{tabId, windowId, url, title, active}]` array alongside the active-tab fields. The L4 dispatcher defaults `includeAllTabs=true` for `vortex_wait_for(mode=info)` so an agent's first call after attaching can see every open tab without an extra round-trip. Direct `page.info` callers (CLI, internal dispatch) are unchanged unless they opt in. **Why**: `vortex_tab_list` was demoted from the public surface in v0.6 (token-budget driven), but agents still need a way to discover sibling tabs after a session attaches — previously they had to guess or rely on `tabs_context` from the parallel `claude-in-chrome` MCP. Folding the listing into the existing `wait_for` info path keeps the public surface at 15 tools while closing the discovery gap. Discovered while driving a real Yuque-spec + prototype walkthrough where the user had a second tab pre-opened that the agent could not see.
+
 ### 🗑 Removed
 
 - **`packages/server/src/state-cache.ts`** dead code. The `StateCache` class (console / network log ring buffer, 20 LoC) was instantiated as `_stateCache` in `index.ts` but never wired to any consumer — neither `MessageRouter`, the HTTP routes, nor the WS server held a reference. Logs are actually buffered by the extension's own `console.getLogs` / `network.getLogs` handlers, so the server-side cache was vestigial. Removing the class, its import, the instantiation line, and the `state-cache.ts` entry in `packages/server/README.md` architecture map.

--- a/packages/extension/src/action/auto-wait.ts
+++ b/packages/extension/src/action/auto-wait.ts
@@ -21,6 +21,7 @@ const RETRY_INTERVAL_MS: Record<ActionabilityFailure, number> = {
   OBSCURED: 100,
   DISABLED: 200,
   NOT_EDITABLE: -1,   // do not retry — semantic error, throw immediately
+  OPEN_SHADOW: -1,    // issue #27: open-shadow element is permanently unresolvable by CSS selector — fail fast, don't retry into TIMEOUT
 };
 
 export interface WaitOptions extends CheckOptions {
@@ -93,5 +94,6 @@ function mapToVtxCode(reason: ActionabilityFailure): VtxErrorCode {
     case "OBSCURED":     return VtxErrorCode.OBSCURED;
     case "DISABLED":     return VtxErrorCode.DISABLED;
     case "NOT_EDITABLE": return VtxErrorCode.NOT_EDITABLE;
+    case "OPEN_SHADOW":  return VtxErrorCode.OPEN_SHADOW_DOM;
   }
 }

--- a/packages/extension/src/handlers/page.ts
+++ b/packages/extension/src/handlers/page.ts
@@ -134,7 +134,11 @@ export function registerPageHandlers(router: ActionRouter, debuggerMgr: Debugger
     [PageActions.INFO]: async (args, tabId) => {
       const tid = await getActiveTabId(tabId);
       const tab = await chrome.tabs.get(tid);
-      return { url: tab.url, title: tab.title, status: tab.status, tabId: tab.id, windowId: tab.windowId };
+      const base = { url: tab.url, title: tab.title, status: tab.status, tabId: tab.id, windowId: tab.windowId };
+      if (!args?.includeAllTabs) return base;
+      const all = await chrome.tabs.query({});
+      const tabs = all.map((t) => ({ tabId: t.id, windowId: t.windowId, url: t.url, title: t.title, active: t.active }));
+      return { ...base, tabs };
     },
 
     [PageActions.WAIT_FOR_NETWORK_IDLE]: async (args, tabId) => {

--- a/packages/extension/src/page-side/actionability.ts
+++ b/packages/extension/src/page-side/actionability.ts
@@ -15,7 +15,9 @@ export type ActionabilityFailure =
   | "NOT_STABLE"
   | "OBSCURED"
   | "DISABLED"
-  | "NOT_EDITABLE";
+  | "NOT_EDITABLE"
+  // issue #27: 元素在 open shadow 内,querySelector 解析不到 → 永久不可解析,快速失败。
+  | "OPEN_SHADOW";
 
 export type ActionabilityResult =
   | { ok: true; rect: { x: number; y: number; w: number; h: number } }
@@ -30,6 +32,40 @@ export type ActionabilityResult =
 
   function isAttached(el: Element): boolean {
     return el.isConnected;
+  }
+
+  // issue #27: 当 document.querySelector(selector) 落空时,探测该 selector 是否匹配
+  // 某个 open shadow root 内的元素。observe 经 querySelectorAllDeep 穿 open shadow 发出
+  // 这类 ref(且 buildSelector 在 shadow 边界断裂,常退化为裸 tag 如 "button"),但本 probe
+  // 与 act/fill 的 querySelector 不穿 shadow → 永久解析不到。命中 → 让 host 快速失败
+  // (OPEN_SHADOW 非重试)给出诊断,而非 NOT_ATTACHED 空转满 timeout(act hang >5s)。
+  // 仅在 querySelector 落空(失败路径)时调用。
+  function existsInOpenShadow(selector: string): boolean {
+    function walk(root: Document | ShadowRoot, depth: number): boolean {
+      if (depth > 10) return false;
+      let nodes: NodeListOf<Element>;
+      try {
+        nodes = root.querySelectorAll("*");
+      } catch {
+        return false;
+      }
+      for (const host of Array.from(nodes)) {
+        const sr = host.shadowRoot;
+        if (!sr) continue;
+        try {
+          if (sr.querySelector(selector)) return true;
+        } catch {
+          // selector 在该 scope 内非法 CSS — 忽略,继续
+        }
+        if (walk(sr, depth + 1)) return true;
+      }
+      return false;
+    }
+    try {
+      return walk(document, 0);
+    } catch {
+      return false;
+    }
   }
 
   // Calibration #1: vortex decision — prefer checkVisibility(), do not check opacity, do not use offsetParent.
@@ -199,7 +235,12 @@ export type ActionabilityResult =
     } catch {
       el = null;
     }
-    if (!el) return { ok: false, reason: "NOT_ATTACHED" };
+    if (!el) {
+      // querySelector 落空:可能是元素未挂载(transient,可重试),也可能在 open shadow
+      // 内(永久不可解析,issue #27)。区分二者——后者快速失败给诊断,而非空转满 timeout。
+      if (existsInOpenShadow(selector)) return { ok: false, reason: "OPEN_SHADOW" };
+      return { ok: false, reason: "NOT_ATTACHED" };
+    }
     if (!isAttached(el)) return { ok: false, reason: "NOT_ATTACHED" };
     if (!isVisible(el)) return { ok: false, reason: "NOT_VISIBLE" };
     if (!isEnabled(el)) return { ok: false, reason: "DISABLED" };

--- a/packages/extension/tests/actionability-open-shadow.test.ts
+++ b/packages/extension/tests/actionability-open-shadow.test.ts
@@ -1,0 +1,104 @@
+// Regression for issue #27: act on an open-shadow-internal element must fail FAST
+// with OPEN_SHADOW_DOM, instead of the page-side probe returning NOT_ATTACHED and
+// auto-wait retrying it into a full 5s TIMEOUT (the "act hang >5s" symptom found by
+// the autonomous discovery engine #3 robustness layer).
+//
+// Root cause: observe walks open shadow via querySelectorAllDeep and emits a ref for
+// the shadow-internal element, but buildSelector breaks at the shadow boundary
+// (parentElement is null) and returns a bare tag selector like "button". act's
+// document.querySelector("button") cannot pierce shadow → null → NOT_ATTACHED → retry.
+//
+// Fix: when querySelector finds nothing, the probe does a one-shot open-shadow deep
+// check; a match inside an open shadow root → reason OPEN_SHADOW (non-retryable in
+// auto-wait) → throws OPEN_SHADOW_DOM immediately with a diagnostic hint.
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { VtxErrorCode } from "@bytenew/vortex-shared";
+import { setupActionabilityEnv } from "./helpers/actionability-test-setup.js";
+
+vi.mock("../src/adapter/page-side-loader.js", () => ({
+  loadPageSideModule: async () => {},
+  _resetPageSideLoader: () => {},
+}));
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("actionability open-shadow fast-fail (issue #27)", () => {
+  it("act on open-shadow-internal element throws OPEN_SHADOW_DOM, not TIMEOUT", async () => {
+    vi.resetModules();
+    const dom = setupActionabilityEnv({ html: '<div id="host"></div>' });
+
+    // Attach an OPEN shadow root with a button inside. No light-DOM button exists,
+    // so document.querySelector("button") returns null (jsdom does not pierce shadow).
+    const host = dom.window.document.getElementById("host")!;
+    const sr = host.attachShadow({ mode: "open" });
+    const btn = dom.window.document.createElement("button");
+    btn.textContent = "影子按钮";
+    sr.appendChild(btn);
+
+    await import("../src/page-side/actionability.js");
+    const { waitActionable } = await import("../src/action/auto-wait.js");
+
+    // timeout is generous on purpose: the fix throws immediately (non-retryable),
+    // so this resolves fast. Before the fix it would loop the full timeout then
+    // throw TIMEOUT — the regression this test locks out.
+    let caught: any;
+    await waitActionable(1, undefined, "button", { timeout: 2000 }).catch((e) => {
+      caught = e;
+    });
+
+    expect(caught).toBeDefined();
+    expect(caught.code).toBe(VtxErrorCode.OPEN_SHADOW_DOM);
+    expect(caught.code).not.toBe(VtxErrorCode.TIMEOUT);
+  });
+
+  it("element nested two shadow levels deep is also detected (recursive walk)", async () => {
+    vi.resetModules();
+    const dom = setupActionabilityEnv({ html: '<div id="host"></div>' });
+
+    // host → open shadow → innerHost → open shadow → button. The button lives two
+    // shadow levels down, exercising existsInOpenShadow's recursive walk(sr, depth+1).
+    const host = dom.window.document.getElementById("host")!;
+    const sr1 = host.attachShadow({ mode: "open" });
+    const innerHost = dom.window.document.createElement("div");
+    sr1.appendChild(innerHost);
+    const sr2 = innerHost.attachShadow({ mode: "open" });
+    const btn = dom.window.document.createElement("button");
+    btn.textContent = "深层影子按钮";
+    sr2.appendChild(btn);
+
+    await import("../src/page-side/actionability.js");
+    const { waitActionable } = await import("../src/action/auto-wait.js");
+
+    let caught: any;
+    await waitActionable(1, undefined, "button", { timeout: 2000 }).catch((e) => {
+      caught = e;
+    });
+
+    expect(caught).toBeDefined();
+    expect(caught.code).toBe(VtxErrorCode.OPEN_SHADOW_DOM);
+  });
+
+  it("genuinely missing element (no shadow match) still reports NOT_ATTACHED → TIMEOUT", async () => {
+    vi.resetModules();
+    const dom = setupActionabilityEnv({ html: "<div id='x'></div>" });
+    void dom;
+
+    await import("../src/page-side/actionability.js");
+    const { waitActionable } = await import("../src/action/auto-wait.js");
+
+    // "button" matches nothing anywhere (no light button, no shadow) → NOT_ATTACHED
+    // remains retryable → TIMEOUT after the (short) timeout. Confirms the fast-fail
+    // is scoped to genuine open-shadow matches and does not swallow transient-attach.
+    let caught: any;
+    await waitActionable(1, undefined, "button", { timeout: 150 }).catch((e) => {
+      caught = e;
+    });
+
+    expect(caught).toBeDefined();
+    expect(caught.code).toBe(VtxErrorCode.TIMEOUT);
+  });
+});

--- a/packages/mcp/src/tools/dispatch.ts
+++ b/packages/mcp/src/tools/dispatch.ts
@@ -182,8 +182,11 @@ export function dispatchNewTool(
             : "page.waitForXhrIdle";
           return { action, params: next };
         }
-        case "info":
+        case "info": {
+          // Default to all-tabs summary so the agent sees siblings without an extra call.
+          if (next.includeAllTabs === undefined) next.includeAllTabs = true;
           return { action: "page.info", params: next };
+        }
         default:
           throw vtxError(
             VtxErrorCode.INVALID_PARAMS,

--- a/packages/mcp/tests/invariants/I16.dispatch-routing.test.ts
+++ b/packages/mcp/tests/invariants/I16.dispatch-routing.test.ts
@@ -127,6 +127,16 @@ describe("I16: dispatch routing for 11 public tools", () => {
       expect(r?.action).toBe("page.info");
     });
 
+    it("mode=info defaults includeAllTabs=true so agents see sibling tabs", () => {
+      const r = dispatchNewTool("vortex_wait_for", { mode: "info" });
+      expect(r?.params.includeAllTabs).toBe(true);
+    });
+
+    it("mode=info respects explicit includeAllTabs=false opt-out", () => {
+      const r = dispatchNewTool("vortex_wait_for", { mode: "info", includeAllTabs: false });
+      expect(r?.params.includeAllTabs).toBe(false);
+    });
+
     it("timeout 透传", () => {
       const r = dispatchNewTool("vortex_wait_for", { mode: "info", timeout: 12000 });
       expect(r?.params.timeout).toBe(12000);

--- a/packages/shared/src/errors.hints.ts
+++ b/packages/shared/src/errors.hints.ts
@@ -207,6 +207,11 @@ export const DEFAULT_ERROR_META: Record<VtxErrorCode, VtxErrorMeta> = {
     recoverable: false,
   },
 
+  OPEN_SHADOW_DOM: {
+    hint: "Element lives inside an open shadow root that vortex_observe surfaced but act cannot reach via a CSS selector. Expose a light-DOM proxy selector for the control, or have the component render the actionable element in light DOM.",
+    recoverable: false,
+  },
+
   // -- L4 Task layer（@since 0.6.0 PR #4）--
   INVALID_TARGET: {
     hint: "Use a target ref string like @e3 (returned from vortex_observe) or a CSS selector. The Descriptor object form arrives in v0.6.x once the resolver lands.",

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -61,7 +61,7 @@ export const VtxErrorCode = {
   /** Drag operation but CDP unavailable */
   DRAG_REQUIRES_CDP: "DRAG_REQUIRES_CDP",
 
-  // -- L3 Reasoning（8 类，@since 0.6.0 PR #3）--
+  // -- L3 Reasoning（9 类：8 @since 0.6.0 PR #3 + OPEN_SHADOW_DOM @issue #27）--
   /** a11y tree 不可用（CSP / sandboxed page），无法 getFullAXTree。*/
   A11Y_UNAVAILABLE: "A11Y_UNAVAILABLE",
   /** chrome.debugger.attach 失败（缺权限、tab 已关闭等）。*/
@@ -78,6 +78,10 @@ export const VtxErrorCode = {
   CROSS_ORIGIN_IFRAME: "CROSS_ORIGIN_IFRAME",
   /** closed shadow host，无法穿透。*/
   CLOSED_SHADOW_DOM: "CLOSED_SHADOW_DOM",
+  /** 元素在 open shadow root 内：observe 经 querySelectorAllDeep 穿 shadow 发出了 ref，
+   *  但 act/fill 的 CSS selector 解析不穿 shadow → 永久不可解析。快速失败给诊断，
+   *  而非 NOT_ATTACHED 重试满 timeout（issue #27）。*/
+  OPEN_SHADOW_DOM: "OPEN_SHADOW_DOM",
 
   // -- L4 Task layer（2 类，@since 0.6.0 PR #4）--
   /** target 既不是合法 ref 也不是 valid descriptor 对象。*/

--- a/packages/shared/tests/errors.test.ts
+++ b/packages/shared/tests/errors.test.ts
@@ -57,8 +57,8 @@ describe("VtxError", () => {
 });
 
 describe("VtxErrorCode enum", () => {
-  it("includes all 44 error codes (25 base + 9 L2 + 8 L3 + 2 L4)", () => {
-    expect(Object.keys(VtxErrorCode)).toHaveLength(44);
+  it("includes all 45 error codes (25 base + 9 L2 + 9 L3 + 2 L4)", () => {
+    expect(Object.keys(VtxErrorCode)).toHaveLength(45);
   });
 
   it("each constant equals its own string value (self-describing)", () => {


### PR DESCRIPTION
## Summary

修 #27（由自主发现引擎 #3 robustness 层自主发现的 bug）。act 作用于 open-shadow-internal 元素的 ref 时，从 **5s TIMEOUT hang** 改为**立即** `OPEN_SHADOW_DOM` + 诊断 hint。

## 根因

`vortex_observe` 经 `querySelectorAllDeep` 穿 open shadow 发出 shadow-internal 元素的 ref，但 `buildSelector` 在 shadow 边界断裂（`parentElement` 为 null）退化为裸 tag selector（如 `"button"`）。act 走 `waitActionable` → page-side probe `document.querySelector("button")` **不穿 shadow** → null → 返 `NOT_ATTACHED` → auto-wait `RETRY_INTERVAL_MS[NOT_ATTACHED]=0` 空转满 5000ms → 抛 `TIMEOUT`。CSS 选择器从 document 根本无法定位 shadow-internal 元素。

## 修复（Tier 1 快速失败）

- **page-side/actionability.ts**：`probe` 在 `querySelector` 落空时做一次性 open-shadow deep 探测（`existsInOpenShadow`，穿 open shadow root 递归匹配）；命中 → 新 reason `OPEN_SHADOW`。
- **auto-wait.ts**：`RETRY_INTERVAL_MS[OPEN_SHADOW]=-1`（非重试，立即抛）+ `mapToVtxCode` → 新错误码 `OPEN_SHADOW_DOM`。
- **shared/errors{,.hints}.ts**：新增 `OPEN_SHADOW_DOM` 码 + 诊断 hint（指引暴露 light-DOM proxy selector）。
- **区分**「在 open shadow 内（永久不可解析 → 快速失败诊断）」与「未挂载（transient → 照常 `NOT_ATTACHED` 重试）」——后者行为不变。

## 范围说明

这是 **Tier 1 快速失败**（消除 hang + 给诊断），不让 shadow act 真正可用。让 act 穿 open shadow 真正操作元素（dom.* + actionability 的 ~13 处 querySelector → querySelectorAllDeep + buildSelector shadow-aware locator）是 **Tier 2 follow-up**，跨切面回归面大，留独立里程碑。

## Test Plan

- [x] 行为单测 `actionability-open-shadow.test.ts`（jsdom 真跑 probe）：单层 shadow → `OPEN_SHADOW_DOM` 立抛 / 嵌套两层 shadow → 同样命中（递归分支）/ 真缺失元素 → 仍 `NOT_ATTACHED`→`TIMEOUT`（不误伤 transient）
- [x] shared 212 + extension 299 测试零回归（含 I9 auto-wait timeout / I19 hint 质量 / I20 公开工具名 / errors 计数 44→45）
- [x] 扩展构建干净（vite + page-side）
- [x] **live 直接 act**：observe open-shadow fixture 发出 `@ref` → act → 秒回 `Error [OPEN_SHADOW_DOM]` + hint（非 5s）
- [x] **live 全自校准** `bench robustness --all`：9/9 R0=0（open-shadow-nested 从 R0 timeout 转 R1 快速 `OPEN_SHADOW_DOM`），8/9 happy path 仍 100%

## 已知取舍（follow-up）

- genuine-`NOT_ATTACHED` 失败路径（`interval=0`）下每轮 probe 都重 walk 整页 shadow tree——Tier 1 可接受，大页面可后续加 selector→shadow 命中 memo 优化（v0.7.x backlog）。
- CHANGELOG `[Unreleased]` 条目未加（CHANGELOG.md 有未提交 WIP，留发版时补）。

Closes #27