### PR TITLE
feat(bench): 自主发现引擎 #3.x — live 真站健壮性(只读 observe→act 契约探测)

### DIFF
--- a/packages/vortex-bench/.gitignore
+++ b/packages/vortex-bench/.gitignore
@@ -17,3 +17,6 @@ reports/scan/
 
 # robustness 运行产物(同 scan,transient discovery 报告,不入库)
 reports/robustness/
+
+# robustness-live 运行产物(同 scan/robustness,transient,不入库)
+reports/robustness-live/

--- a/packages/vortex-bench/live-seeds.json
+++ b/packages/vortex-bench/live-seeds.json
@@ -1,0 +1,7 @@
+{
+  "_note": "公开 JS-heavy 站点种子,bench robustness --seeds 批量探。用户可增删。",
+  "seeds": [
+    "https://web.dev/",
+    "https://material-web.dev/components/button/"
+  ]
+}

--- a/packages/vortex-bench/src/index.ts
+++ b/packages/vortex-bench/src/index.ts
@@ -19,6 +19,7 @@ import { renderScanMarkdown, rankFindings } from "./scan-report.js";
 import type { FixtureScanResult, ScanReport, SynthManifest } from "./scan-types.js";
 import { captureSnapshot } from "./runner/snapshot.js";
 import { probeFixture } from "./runner/robustness.js";
+import { probeLive, type LiveTarget } from "./runner/robustness-live.js";
 import { renderRobustnessMarkdown, rankRobustnessFindings } from "./robustness-report.js";
 import type { FixtureRobustness, RobustnessReport } from "./robustness-types.js";
 
@@ -41,6 +42,9 @@ Commands:
   snapshot <name> --url <u>  先 navigate 再冻结
   robustness --all       探全部 fixture 的 observe→act 契约,产 reports/robustness/<ts>.{md,json}
   robustness --pattern <name>  探单个 fixture
+  robustness --url <url>       live 只读探单个真站 observe→act 契约
+  robustness --current-tab     live 只读探当前已加载/已登录 tab
+  robustness --seeds [file]    live 批量探种子列表(默认 live-seeds.json)
   --help                 显示帮助
 
 Env:
@@ -56,6 +60,7 @@ const REPORTS_DIR = resolve(PKG_ROOT, "reports");
 const SYNTH_DIR = resolve(PKG_ROOT, "playground", "public", "synth");
 const SCAN_REPORTS_DIR = resolve(REPORTS_DIR, "scan");
 const ROBUSTNESS_REPORTS_DIR = resolve(REPORTS_DIR, "robustness");
+const ROBUSTNESS_LIVE_REPORTS_DIR = resolve(REPORTS_DIR, "robustness-live");
 
 function resolveMcpBin(): string {
   if (process.env.VORTEX_MCP_BIN) return resolve(process.env.VORTEX_MCP_BIN);
@@ -368,6 +373,19 @@ async function cmdSnapshot(args: string[]): Promise<number> {
 }
 
 async function cmdRobustness(args: string[]): Promise<number> {
+  // live 模式:--url / --current-tab / --seeds
+  const urlIdx = args.indexOf("--url");
+  if (urlIdx >= 0 && args[urlIdx + 1]) return cmdRobustnessLive([{ url: args[urlIdx + 1] }]);
+  if (args.includes("--current-tab")) return cmdRobustnessLive([{ currentTab: true }]);
+  const seedsIdx = args.indexOf("--seeds");
+  if (seedsIdx >= 0) {
+    const file = args[seedsIdx + 1] && !args[seedsIdx + 1].startsWith("-")
+      ? resolve(args[seedsIdx + 1])
+      : resolve(PKG_ROOT, "live-seeds.json");
+    const urls = await loadSeeds(file);
+    return cmdRobustnessLive(urls.map((url) => ({ url })));
+  }
+
   const runAll = args.includes("--all");
   let names: string[];
   if (runAll) {
@@ -420,6 +438,53 @@ async function cmdRobustness(args: string[]): Promise<number> {
   const stamp = report.generatedAt.replace(/[:.]/g, "-");
   const jsonPath = join(ROBUSTNESS_REPORTS_DIR, `${stamp}.json`);
   const mdPath = join(ROBUSTNESS_REPORTS_DIR, `${stamp}.md`);
+  await writeFile(jsonPath, JSON.stringify(report, null, 2));
+  await writeFile(mdPath, renderRobustnessMarkdown(report));
+  process.stdout.write(`\n[report] ${mdPath}\n[report] ${jsonPath}\n`);
+
+  const totalR0 = report.findings.filter((f) => f.severity === "R0").length;
+  return totalR0 === 0 ? 0 : 2;
+}
+
+async function loadSeeds(file: string): Promise<string[]> {
+  const raw = JSON.parse(await readFile(file, "utf-8")) as { seeds?: unknown };
+  if (!Array.isArray(raw.seeds)) throw new Error(`seeds 文件需含 seeds:string[](${file})`);
+  return raw.seeds.map((s) => String(s));
+}
+
+async function cmdRobustnessLive(targets: LiveTarget[]): Promise<number> {
+  const mcpBin = resolveMcpBin();
+  process.stdout.write(`[vortex-bench] robustness LIVE  mcp=${mcpBin}\n`);
+  process.stdout.write(`[vortex-bench] 只读探 ${targets.length} 个 live 目标的 observe→act 契约\n\n`);
+
+  const report: RobustnessReport = {
+    generatedAt: new Date().toISOString(), playgroundUrl: "(live)", fixtures: [], findings: [],
+  };
+  for (const t of targets) {
+    let fx: FixtureRobustness;
+    try {
+      fx = await probeLive(t, { mcpBin });
+    } catch (e) {
+      fx = {
+        fixture: t.url ?? "current-tab", path: "", totalRefs: 0, okCount: 0, okRate: 1, histogram: {},
+        findings: [], error: `探测失败: ${e instanceof Error ? e.message : String(e)}`,
+      };
+    }
+    report.fixtures.push(fx);
+    report.findings.push(...fx.findings);
+    const r0 = fx.findings.filter((f) => f.severity === "R0").length;
+    const r1 = fx.findings.filter((f) => f.severity === "R1").length;
+    process.stdout.write(
+      `${r0 === 0 ? "✓" : "✗"} ${fx.fixture.slice(0, 40).padEnd(40)} refs=${fx.totalRefs} okRate=${(fx.okRate * 100).toFixed(0)}% ` +
+      `R0=${r0} R1=${r1}${fx.error ? `  ⚠ ${fx.error}` : ""}\n`,
+    );
+  }
+  report.findings = rankRobustnessFindings(report.findings);
+
+  await mkdir(ROBUSTNESS_LIVE_REPORTS_DIR, { recursive: true });
+  const stamp = report.generatedAt.replace(/[:.]/g, "-");
+  const jsonPath = join(ROBUSTNESS_LIVE_REPORTS_DIR, `${stamp}.json`);
+  const mdPath = join(ROBUSTNESS_LIVE_REPORTS_DIR, `${stamp}.md`);
   await writeFile(jsonPath, JSON.stringify(report, null, 2));
   await writeFile(mdPath, renderRobustnessMarkdown(report));
   process.stdout.write(`\n[report] ${mdPath}\n[report] ${jsonPath}\n`);

--- a/packages/vortex-bench/src/runner/robustness-classify.ts
+++ b/packages/vortex-bench/src/runner/robustness-classify.ts
@@ -30,37 +30,7 @@ export function classifyAct(r: ActResult): ClassifiedAct {
   return { kind: "ok", code: null };
 }
 
-/** 一次 vortex_extract 探测的原始结果 */
-export interface ExtractResult {
-  text: string;
-  threw: boolean;
-  timedOut: boolean;
-}
-
-/** extract 结果中是否含 element 数据(顶层 tag 字段)= ref 解析成功 */
-function hasElementData(text: string): boolean {
-  try {
-    const parsed = JSON.parse(text) as unknown;
-    return (
-      parsed !== null &&
-      typeof parsed === "object" &&
-      typeof (parsed as { tag?: unknown }).tag === "string"
-    );
-  } catch {
-    return false; // 非 JSON(罕见)→ 视作解析失败
-  }
-}
-
-/**
- * 分类一次 vortex_extract 结果。与 classifyAct 的关键差异:extract 对解析不到的 ref
- * 静默返 null(非 Error),故 null-result(无 tag)判为 ELEMENT_NOT_FOUND 类 R0。
- * 优先级:timeout > Error[CODE] 文本 > threw(crash) > 含 tag(ok) > 其余(ELEMENT_NOT_FOUND)。
- */
-export function classifyExtract(r: ExtractResult): ClassifiedAct {
-  if (r.timedOut) return { kind: "timeout", code: null };
-  const m = r.text.match(ERROR_CODE_RE);
-  if (m) return { kind: "typed-error", code: m[1] };
-  if (r.threw) return { kind: "crash", code: null };
-  if (hasElementData(r.text)) return { kind: "ok", code: null };
-  return { kind: "typed-error", code: "ELEMENT_NOT_FOUND" };
-}
+// 注:#3.x live extract 复用 classifyAct —— vortex_extract 经 content.getText,解析不到的
+// ref 干净抛 Error[ELEMENT_NOT_FOUND](content.ts:175),成功返 {text,controls}(无 Error)。
+// 故 classifyAct 的 Error 文本解析对 extract 同样正确(not-found→typed-error,success→ok),
+// 无需 null-result 检测。(早期 classifyExtract/hasElementData 基于误读的 dom.ts 死路径,已删。)

--- a/packages/vortex-bench/src/runner/robustness-classify.ts
+++ b/packages/vortex-bench/src/runner/robustness-classify.ts
@@ -29,3 +29,38 @@ export function classifyAct(r: ActResult): ClassifiedAct {
   if (m) return { kind: "typed-error", code: m[1] };
   return { kind: "ok", code: null };
 }
+
+/** 一次 vortex_extract 探测的原始结果 */
+export interface ExtractResult {
+  text: string;
+  threw: boolean;
+  timedOut: boolean;
+}
+
+/** extract 结果中是否含 element 数据(顶层 tag 字段)= ref 解析成功 */
+function hasElementData(text: string): boolean {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      typeof (parsed as { tag?: unknown }).tag === "string"
+    );
+  } catch {
+    return false; // 非 JSON(罕见)→ 视作解析失败
+  }
+}
+
+/**
+ * 分类一次 vortex_extract 结果。与 classifyAct 的关键差异:extract 对解析不到的 ref
+ * 静默返 null(非 Error),故 null-result(无 tag)判为 ELEMENT_NOT_FOUND 类 R0。
+ * 优先级:timeout > Error[CODE] 文本 > threw(crash) > 含 tag(ok) > 其余(ELEMENT_NOT_FOUND)。
+ */
+export function classifyExtract(r: ExtractResult): ClassifiedAct {
+  if (r.timedOut) return { kind: "timeout", code: null };
+  const m = r.text.match(ERROR_CODE_RE);
+  if (m) return { kind: "typed-error", code: m[1] };
+  if (r.threw) return { kind: "crash", code: null };
+  if (hasElementData(r.text)) return { kind: "ok", code: null };
+  return { kind: "typed-error", code: "ELEMENT_NOT_FOUND" };
+}

--- a/packages/vortex-bench/src/runner/robustness-confirm.ts
+++ b/packages/vortex-bench/src/runner/robustness-confirm.ts
@@ -1,0 +1,33 @@
+// packages/vortex-bench/src/runner/robustness-confirm.ts
+// #3.x live 二次确认(纯逻辑):过滤 live 页面 mutation 抖动。
+// pass1 中契约违反的 outcome,只有在 settle+重 observe 后同身份(role+name)元素仍存在
+// 且重 extract 仍违反契约时才"确认"(真 bug);恢复(ok)/消失(S2 无同身份)判抖动丢弃。
+
+import type { RefOutcome } from "../robustness-types.js";
+import { CONTRACT_VIOLATION_CODES } from "./robustness-aggregate.js";
+
+/** 稳定身份 = role + " " + name(复用 #1 invariants 的 identity 概念) */
+export function refIdentity(role: string, name: string | null): string {
+  return `${role} ${name ?? ""}`;
+}
+
+/**
+ * @param pass1Failures pass1 中 code ∈ CONTRACT_VIOLATION_CODES 的 outcome
+ * @param pass2ByIdentity identity → 该身份在 S2 重 extract 的 outcomes(可能多个同名行)
+ * @returns 被确认的 R0 outcome 子集(其余为抖动,不返回)
+ */
+export function confirmContractViolations(
+  pass1Failures: RefOutcome[],
+  pass2ByIdentity: Map<string, RefOutcome[]>,
+): RefOutcome[] {
+  const confirmed: RefOutcome[] = [];
+  for (const f of pass1Failures) {
+    const s2 = pass2ByIdentity.get(refIdentity(f.role, f.name));
+    if (!s2 || s2.length === 0) continue; // 元素消失 → 抖动
+    const stillViolating = s2.some(
+      (out) => out.kind === "typed-error" && out.code !== null && CONTRACT_VIOLATION_CODES.has(out.code),
+    );
+    if (stillViolating) confirmed.push(f); // 持续违反 → 确认;全恢复 → 抖动丢弃
+  }
+  return confirmed;
+}

--- a/packages/vortex-bench/src/runner/robustness-live.ts
+++ b/packages/vortex-bench/src/runner/robustness-live.ts
@@ -4,7 +4,7 @@
 
 import { createMcpConnection, closeMcpConnection } from "./mcp-client.js";
 import { parseObserveSnapshot } from "./observe-parser.js";
-import { classifyExtract, type ExtractResult } from "./robustness-classify.js";
+import { classifyAct, type ActResult } from "./robustness-classify.js";
 import { aggregateFixture, CONTRACT_VIOLATION_CODES } from "./robustness-aggregate.js";
 import { confirmContractViolations, refIdentity } from "./robustness-confirm.js";
 import type { FixtureRobustness, RefOutcome } from "../robustness-types.js";
@@ -51,9 +51,19 @@ export async function probeLive(
   const outcomes: RefOutcome[] = [];
 
   const probe = async (ref: string, role: string, name: string | null): Promise<RefOutcome> => {
+    // extract 经 content.getText:解析不到 → 干净抛 Error[ELEMENT_NOT_FOUND](content.ts:175);
+    // 成功 → {text,controls}(无 Error)。故 classifyAct(解析 Error 文本)即可:not-found→typed-error
+    // ELEMENT_NOT_FOUND(R0),success→ok。无需 null-result 检测(extract 不静默返 null)。
     const raw = await runExtractProbe(call, ref);
-    const cls = classifyExtract(raw);
-    return { ref, role, name, kind: cls.kind, code: cls.code, detail: raw.text.slice(0, 120) };
+    const cls = classifyAct(raw);
+    return {
+      ref,
+      role,
+      name,
+      kind: cls.kind,
+      code: cls.code,
+      detail: raw.timedOut ? "extract 超时(>5s)" : raw.text.slice(0, 120),
+    };
   };
 
   try {
@@ -105,7 +115,7 @@ export async function probeLive(
 async function runExtractProbe(
   call: (name: string, args: Record<string, unknown>) => Promise<unknown>,
   ref: string,
-): Promise<ExtractResult> {
+): Promise<ActResult> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     const res = await Promise.race([

--- a/packages/vortex-bench/src/runner/robustness-live.ts
+++ b/packages/vortex-bench/src/runner/robustness-live.ts
@@ -1,0 +1,124 @@
+// packages/vortex-bench/src/runner/robustness-live.ts
+// #3.x live 真站健壮性探测编排(需活 MCP)。严格只读 extract + settle + 二次确认。
+// 见设计 §2/§3。无离线单测,靠 live 验收。
+
+import { createMcpConnection, closeMcpConnection } from "./mcp-client.js";
+import { parseObserveSnapshot } from "./observe-parser.js";
+import { classifyExtract, type ExtractResult } from "./robustness-classify.js";
+import { aggregateFixture, CONTRACT_VIOLATION_CODES } from "./robustness-aggregate.js";
+import { confirmContractViolations, refIdentity } from "./robustness-confirm.js";
+import type { FixtureRobustness, RefOutcome } from "../robustness-types.js";
+
+export interface LiveTarget {
+  /** navigate 到此 URL 再探;与 currentTab 二选一 */
+  url?: string;
+  /** 探当前已加载/已登录 tab(不导航) */
+  currentTab?: boolean;
+}
+
+export interface RobustnessLiveOptions {
+  mcpBin: string;
+}
+
+const EXTRACT_TIMEOUT_MS = 5000;
+
+function extractText(res: unknown): string {
+  const content = (res as { content?: unknown }).content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((i) => i && typeof i === "object" && "text" in i)
+    .map((i) => String((i as { text: unknown }).text))
+    .join("\n");
+}
+
+function isContractViolation(o: RefOutcome): boolean {
+  return o.kind === "typed-error" && o.code !== null && CONTRACT_VIOLATION_CODES.has(o.code);
+}
+
+export async function probeLive(
+  target: LiveTarget,
+  opts: RobustnessLiveOptions,
+): Promise<FixtureRobustness> {
+  const fixtureName = target.url ?? "current-tab";
+  const mcp = await createMcpConnection({
+    command: process.execPath,
+    args: [opts.mcpBin],
+    env: { ...(process.env as Record<string, string>) },
+  });
+  const call = (name: string, args: Record<string, unknown>) =>
+    mcp.client.callTool({ name, arguments: args });
+
+  const outcomes: RefOutcome[] = [];
+
+  const probe = async (ref: string, role: string, name: string | null): Promise<RefOutcome> => {
+    const raw = await runExtractProbe(call, ref);
+    const cls = classifyExtract(raw);
+    return { ref, role, name, kind: cls.kind, code: cls.code, detail: raw.text.slice(0, 120) };
+  };
+
+  try {
+    // Pass 1: navigate(可选)→ settle → observe S1 → 逐 ref extract
+    if (target.url) {
+      await call("vortex_navigate", { url: "about:blank" });
+      await call("vortex_navigate", { url: target.url });
+    }
+    await call("vortex_wait_for", { mode: "idle", value: "dom", timeout: 5000 });
+    const s1 = parseObserveSnapshot(extractText(await call("vortex_observe", {})));
+    for (const row of s1.rows) {
+      outcomes.push(await probe(row.ref, row.role, row.name));
+    }
+
+    const pass1Failures = outcomes.filter(isContractViolation);
+
+    let finalOutcomes = outcomes;
+    if (pass1Failures.length > 0) {
+      // Pass 2: settle → 重 observe S2 → 对失败身份的 S2 行重 extract → 二次确认
+      await call("vortex_wait_for", { mode: "idle", value: "dom", timeout: 5000 });
+      const s2 = parseObserveSnapshot(extractText(await call("vortex_observe", {})));
+      const failedIds = new Set(pass1Failures.map((f) => refIdentity(f.role, f.name)));
+      const pass2 = new Map<string, RefOutcome[]>();
+      for (const row of s2.rows) {
+        const id = refIdentity(row.role, row.name);
+        if (!failedIds.has(id)) continue;
+        const oc = await probe(row.ref, row.role, row.name);
+        const arr = pass2.get(id) ?? [];
+        arr.push(oc);
+        pass2.set(id, arr);
+      }
+      const confirmed = confirmContractViolations(pass1Failures, pass2);
+      const confirmedRefs = new Set(confirmed.map((c) => c.ref));
+      // 丢弃未确认的 pass1 失败(抖动);保留 ok + R1 + 确认的 R0
+      finalOutcomes = outcomes.filter((o) => !isContractViolation(o) || confirmedRefs.has(o.ref));
+    }
+
+    return aggregateFixture(fixtureName, fixtureName, finalOutcomes);
+  } catch (err) {
+    const fx = aggregateFixture(fixtureName, fixtureName, outcomes);
+    fx.error = err instanceof Error ? err.message : String(err);
+    return fx;
+  } finally {
+    await closeMcpConnection(mcp);
+  }
+}
+
+/** 跑一次只读 vortex_extract;reject→threw,超时→timedOut。 */
+async function runExtractProbe(
+  call: (name: string, args: Record<string, unknown>) => Promise<unknown>,
+  ref: string,
+): Promise<ExtractResult> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const res = await Promise.race([
+      call("vortex_extract", { target: ref, include: ["attrs"] }),
+      new Promise<never>((_, rej) => {
+        timer = setTimeout(() => rej(new Error("__extract_timeout__")), EXTRACT_TIMEOUT_MS);
+      }),
+    ]);
+    return { text: extractText(res), threw: false, timedOut: false };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { text: msg, threw: msg !== "__extract_timeout__", timedOut: msg === "__extract_timeout__" };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/packages/vortex-bench/tests/robustness-classify.test.ts
+++ b/packages/vortex-bench/tests/robustness-classify.test.ts
@@ -30,38 +30,3 @@ describe("classifyAct", () => {
     expect(classifyAct(r({ text: "result: see Error [X]: above" }))).toEqual({ kind: "ok", code: null });
   });
 });
-
-import { classifyExtract, type ExtractResult } from "../src/runner/robustness-classify.js";
-
-const ex = (over: Partial<ExtractResult>): ExtractResult => ({ text: "", threw: false, timedOut: false, ...over });
-
-describe("classifyExtract", () => {
-  it("含 tag 的元素 JSON → ok", () => {
-    expect(classifyExtract(ex({ text: '{"tag":"button","text":"保存","attributes":{}}' })))
-      .toEqual({ kind: "ok", code: null });
-  });
-  it("null-result envelope(无 tag)→ typed-error ELEMENT_NOT_FOUND", () => {
-    expect(classifyExtract(ex({ text: '{\n  "result": null\n}' })))
-      .toEqual({ kind: "typed-error", code: "ELEMENT_NOT_FOUND" });
-  });
-  it("裸 null 文本 → ELEMENT_NOT_FOUND", () => {
-    expect(classifyExtract(ex({ text: "null" })))
-      .toEqual({ kind: "typed-error", code: "ELEMENT_NOT_FOUND" });
-  });
-  it("Error [STALE_SNAPSHOT]: 文本(content error,未 throw)→ typed-error + code", () => {
-    expect(classifyExtract(ex({ text: "Error [STALE_SNAPSHOT]: page changed\nhint: ..." })))
-      .toEqual({ kind: "typed-error", code: "STALE_SNAPSHOT" });
-  });
-  it("threw 且无 Error 码 → crash", () => {
-    expect(classifyExtract(ex({ threw: true, text: "socket hang up" })))
-      .toEqual({ kind: "crash", code: null });
-  });
-  it("timedOut → timeout(优先)", () => {
-    expect(classifyExtract(ex({ timedOut: true, threw: true })))
-      .toEqual({ kind: "timeout", code: null });
-  });
-  it("空文本 → ELEMENT_NOT_FOUND(无 element 数据)", () => {
-    expect(classifyExtract(ex({ text: "" })))
-      .toEqual({ kind: "typed-error", code: "ELEMENT_NOT_FOUND" });
-  });
-});

--- a/packages/vortex-bench/tests/robustness-classify.test.ts
+++ b/packages/vortex-bench/tests/robustness-classify.test.ts
@@ -30,3 +30,38 @@ describe("classifyAct", () => {
     expect(classifyAct(r({ text: "result: see Error [X]: above" }))).toEqual({ kind: "ok", code: null });
   });
 });
+
+import { classifyExtract, type ExtractResult } from "../src/runner/robustness-classify.js";
+
+const ex = (over: Partial<ExtractResult>): ExtractResult => ({ text: "", threw: false, timedOut: false, ...over });
+
+describe("classifyExtract", () => {
+  it("含 tag 的元素 JSON → ok", () => {
+    expect(classifyExtract(ex({ text: '{"tag":"button","text":"保存","attributes":{}}' })))
+      .toEqual({ kind: "ok", code: null });
+  });
+  it("null-result envelope(无 tag)→ typed-error ELEMENT_NOT_FOUND", () => {
+    expect(classifyExtract(ex({ text: '{\n  "result": null\n}' })))
+      .toEqual({ kind: "typed-error", code: "ELEMENT_NOT_FOUND" });
+  });
+  it("裸 null 文本 → ELEMENT_NOT_FOUND", () => {
+    expect(classifyExtract(ex({ text: "null" })))
+      .toEqual({ kind: "typed-error", code: "ELEMENT_NOT_FOUND" });
+  });
+  it("Error [STALE_SNAPSHOT]: 文本(content error,未 throw)→ typed-error + code", () => {
+    expect(classifyExtract(ex({ text: "Error [STALE_SNAPSHOT]: page changed\nhint: ..." })))
+      .toEqual({ kind: "typed-error", code: "STALE_SNAPSHOT" });
+  });
+  it("threw 且无 Error 码 → crash", () => {
+    expect(classifyExtract(ex({ threw: true, text: "socket hang up" })))
+      .toEqual({ kind: "crash", code: null });
+  });
+  it("timedOut → timeout(优先)", () => {
+    expect(classifyExtract(ex({ timedOut: true, threw: true })))
+      .toEqual({ kind: "timeout", code: null });
+  });
+  it("空文本 → ELEMENT_NOT_FOUND(无 element 数据)", () => {
+    expect(classifyExtract(ex({ text: "" })))
+      .toEqual({ kind: "typed-error", code: "ELEMENT_NOT_FOUND" });
+  });
+});

--- a/packages/vortex-bench/tests/robustness-confirm.test.ts
+++ b/packages/vortex-bench/tests/robustness-confirm.test.ts
@@ -1,0 +1,72 @@
+// packages/vortex-bench/tests/robustness-confirm.test.ts
+import { describe, it, expect } from "vitest";
+import { confirmContractViolations, refIdentity } from "../src/runner/robustness-confirm.js";
+import type { RefOutcome } from "../src/robustness-types.js";
+
+const o = (over: Partial<RefOutcome>): RefOutcome => ({
+  ref: "@x", role: "button", name: "n", kind: "typed-error", code: "ELEMENT_NOT_FOUND", detail: "", ...over,
+});
+
+describe("refIdentity", () => {
+  it("role+name 组合", () => {
+    expect(refIdentity("button", "保存")).toBe("button 保存");
+    expect(refIdentity("link", null)).toBe("link ");
+  });
+});
+
+describe("confirmContractViolations", () => {
+  it("同身份在 S2 仍违反 → 确认", () => {
+    const f = o({ ref: "@a", role: "button", name: "保存" });
+    const pass2 = new Map<string, RefOutcome[]>([
+      ["button 保存", [o({ ref: "@a2", role: "button", name: "保存", code: "ELEMENT_NOT_FOUND" })]],
+    ]);
+    expect(confirmContractViolations([f], pass2)).toEqual([f]);
+  });
+
+  it("同身份在 S2 恢复(ok)→ 抖动丢弃", () => {
+    const f = o({ ref: "@a", role: "button", name: "保存" });
+    const pass2 = new Map<string, RefOutcome[]>([
+      ["button 保存", [o({ ref: "@a2", role: "button", name: "保存", kind: "ok", code: null })]],
+    ]);
+    expect(confirmContractViolations([f], pass2)).toEqual([]);
+  });
+
+  it("同身份在 S2 消失 → 抖动丢弃", () => {
+    const f = o({ ref: "@a", role: "button", name: "保存" });
+    expect(confirmContractViolations([f], new Map())).toEqual([]);
+  });
+
+  it("多同名行:任一仍违反 → 确认", () => {
+    const f = o({ ref: "@a", role: "button", name: "更多" });
+    const pass2 = new Map<string, RefOutcome[]>([
+      ["button 更多", [
+        o({ ref: "@b1", role: "button", name: "更多", kind: "ok", code: null }),
+        o({ ref: "@b2", role: "button", name: "更多", code: "ELEMENT_NOT_FOUND" }),
+      ]],
+    ]);
+    expect(confirmContractViolations([f], pass2)).toEqual([f]);
+  });
+
+  it("多同名行:全恢复 → 抖动丢弃", () => {
+    const f = o({ ref: "@a", role: "button", name: "更多" });
+    const pass2 = new Map<string, RefOutcome[]>([
+      ["button 更多", [
+        o({ ref: "@b1", role: "button", name: "更多", kind: "ok", code: null }),
+        o({ ref: "@b2", role: "button", name: "更多", kind: "ok", code: null }),
+      ]],
+    ]);
+    expect(confirmContractViolations([f], pass2)).toEqual([]);
+  });
+
+  it("pass2 中非契约码(如 OBSCURED)不算违反 → 抖动丢弃", () => {
+    const f = o({ ref: "@a", role: "button", name: "保存" });
+    const pass2 = new Map<string, RefOutcome[]>([
+      ["button 保存", [o({ ref: "@a2", role: "button", name: "保存", kind: "typed-error", code: "OBSCURED" })]],
+    ]);
+    expect(confirmContractViolations([f], pass2)).toEqual([]);
+  });
+
+  it("空 pass1 → 空", () => {
+    expect(confirmContractViolations([], new Map())).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

自主发现引擎 **#3.x**：把 #3 的 `bench robustness`（漏斗 layer-0 observe→act 契约）从冻结合成语料延伸到 **live 真站**。新增 `robustness --url <url>` / `--current-tab` / `--seeds [file]` 模式，用 `vortex_extract` **严格只读**逐 ref 探测 observe 发的 ref 能否解析，**settle + 二次确认**过滤 live mutation 抖动，产 `reports/robustness-live/<ts>.{md,json}`。发现工具非硬门。

## 设计要点

- **严格只读**：`vortex_extract`（经 content.getText）逐 ref 探，零破坏（不导航/提交/弹窗）。解析不到 → 干净 `Error [ELEMENT_NOT_FOUND]`（content.ts:175）；成功 → `{text,controls}`。直接复用 #3 `classifyAct`（Error 文本解析）即正确。
- **settle + 二次确认**：Pass1 extract 全 ref；契约违反则 Pass2 重 observe + 对失败身份(role+name)重 extract → `confirmContractViolations`：稳定元素持续违反才确认（真 bug），恢复/消失判抖动丢弃。R0=0 自校准在 live 不成立（抖动），故定位为发现工具。
- **复用浏览器会话**：`--current-tab` 探已登录 tab，#3.x 不碰凭证。
- 复用 #3 纯逻辑（aggregate/report/types），新增 `robustness-confirm.ts`（纯逻辑）+ `robustness-live.ts`（I/O）。

## Changes

- `src/runner/robustness-confirm.ts`（新，纯逻辑）— `confirmContractViolations` + `refIdentity`
- `src/runner/robustness-live.ts`（新，I/O）— `probeLive`（Pass1/Pass2/confirm）
- `src/index.ts` — `robustness` live 模式分发（--url/--current-tab/--seeds）
- `live-seeds.json`（新）+ `.gitignore`（加 `reports/robustness-live/`）
- `src/runner/robustness-classify.ts` — 仅注释（extract 复用 classifyAct 的说明）

> 注：执行中曾按误读的 dom.ts 写了 `classifyExtract`（检测 null-result），但代码核实 + 评审发现真实路径 content.getText 干净报错 + 成功返 {text,controls} 无 tag 会令其全假阳，已撤（commit 4433491），改用 classifyAct。

## 自主发现成果（live 验收）

| 目标 | refs | okRate | 确认 R0 |
|---|---|---|---|
| synth/cursor-pointer-div（受控,light-DOM） | 3 | **100%** | **0**（M1 修复确证:可解析→ok 无假阳） |
| synth/open-shadow-nested（受控,shadow） | 1 | 0% | 1（ELEMENT_NOT_FOUND） |
| web.dev | 33 | 91% | 3 |
| material-web.dev（Material Web Components） | 80 | 71% | **23** |

真站共 **26 个确认 R0，全是 `ELEMENT_NOT_FOUND`** —— observe 穿 shadow 发出的 shadow-internal ref（"外观:浅色主题"/"Language"/"Material Web" 等 web-component 元素）extract 解析不到。**triage：全是 issue #27 的 observe→act shadow gap 在真实 web-component 站的规模化体现**（非新 bug 类）→ 强化 Tier 2（让 act/extract 穿 open shadow）价值。

## Test Plan

- [x] 纯逻辑 vitest：confirm 8 用例；bench 全套 **127 passed**（119 baseline + 8），零回归
- [x] `tsc -p tsconfig.build.json` exit 0
- [x] CLI 烟测：`--help` 含 --url/--current-tab/--seeds 三行
- [x] live：--url 受控页（open-shadow R0=1 / cursor R0=0 验 M1 修复）+ --seeds 真站（web.dev/material-web.dev 26 确认 R0）
- [x] 2-pass 确认过滤抖动（确认 R0 是 settle+重 observe 后稳定仍失败的）

## 已知边界（follow-up）

- Tier 2「让 shadow act/extract 真正可用」（dom.* ~13 处 querySelector→deep）—— 本期 26 真站 R0 + #27 都归此，独立里程碑。
- live-seeds.json 是外部站，CI 不可达（手动 live 工具，非 CI）。
- CHANGELOG `[Unreleased]` 未加（main 有 WIP，留发版补）。

Refs #27