### PR TITLE
fix(extension): observe auto-fallback 纳入同源 srcdoc 子框

### DIFF
--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -934,15 +934,14 @@ export function registerObserveHandlers(router: ActionRouter): void {
               .filter((f) => {
                 if (f.frameId === 0) return false;
                 if (isFrameInPermissions(f.url)) return true;
-                // 仅对 opaque-origin 子框走 inherited same-origin 兜底:
-                // about:srcdoc 自身 url 无法匹配 host_permissions,但继承父文档源
-                // 且与父同 tree(注入权限随父)。独立 http 子框仍以 host_permissions
-                // 为准,不被同源放宽(它们需各自的注入权限)。
-                const self = safeOrigin(f.url);
-                const isOpaque = self === null || self === "null";
-                return (
-                  isOpaque && mainOrigin != null && inheritedOrigin(f, byId) === mainOrigin
-                );
+                // 仅对 srcdoc 子框走 inherited same-origin 兜底:about:srcdoc 自身 url
+                // 无法匹配 host_permissions,但继承父文档源且与父同 tree(注入权限随父)。
+                // 按 url 精确限定为 about:srcdoc,排除同为 opaque-origin 的 about:blank /
+                // data: 子框(它们不继承父源,不应被同源放宽)。独立 http 子框仍以
+                // host_permissions 为准。注:sandbox srcdoc(无 allow-same-origin)url 同为
+                // about:srcdoc 但运行时为 unique origin,会被纳入并在注入时失败兜底(非泄露)。
+                if (f.url !== "about:srcdoc") return false;
+                return mainOrigin != null && inheritedOrigin(f, byId) === mainOrigin;
               })
               .filter((f) => !scans.some((s) => s.frameId === f.frameId))
               .map((f) => ({

--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -117,6 +117,31 @@ function safeOrigin(url: string | undefined): string | null {
   }
 }
 
+/**
+ * 走 parent chain 跨过 opaque origin 找第一个具体 origin。
+ * Spec: `<iframe srcdoc>` 继承父文档 origin —— about:srcdoc 是 opaque URL
+ * (`new URL("about:srcdoc").origin` 返回字面量 "null"),srcdoc 嵌 srcdoc 时递归
+ * 继承。找不到具体 origin 返回 null。
+ * Issue #15: 据此把 srcdoc 子框归入其继承的源。
+ */
+function inheritedOrigin(
+  f: chrome.webNavigation.GetAllFrameResultDetails,
+  byId: Map<number, chrome.webNavigation.GetAllFrameResultDetails>,
+): string | null {
+  let cur: chrome.webNavigation.GetAllFrameResultDetails | undefined = f;
+  let depth = 0;
+  while (cur && depth < 16) {
+    const o = safeOrigin(cur.url);
+    // 具体 origin(非 opaque)。opaque URL 的 origin 是字面量 "null"。
+    if (o && o !== "null") return o;
+    const parentId = cur.parentFrameId;
+    if (parentId == null || parentId < 0) return null;
+    cur = byId.get(parentId);
+    depth++;
+  }
+  return null;
+}
+
 /** Exported for unit tests; production callers go through the snapshot handler. */
 export async function resolveTargetFrames(
   tabId: number,
@@ -152,31 +177,8 @@ export async function resolveTargetFrames(
     const main = all.find((f) => f.frameId === 0);
     const mainOrigin = safeOrigin(main?.url);
     if (!mainOrigin) return main ? asTargets([main]) : [];
-    // Spec: `<iframe srcdoc>` inherits its parent document's origin
-    // (about:srcdoc is an opaque URL — `new URL("about:srcdoc").origin`
-    // returns the literal string "null"). Same applies recursively for
-    // a srcdoc nested inside a srcdoc. Walk the parent chain past
-    // opaque origins to find the first concrete one, then compare.
-    // Issue #15: without this, all-same-origin silently dropped srcdoc
-    // iframes that should have been included.
     const byId = new Map(all.map((f) => [f.frameId, f]));
-    const inheritedOrigin = (
-      f: chrome.webNavigation.GetAllFrameResultDetails,
-    ): string | null => {
-      let cur: chrome.webNavigation.GetAllFrameResultDetails | undefined = f;
-      let depth = 0;
-      while (cur && depth < 16) {
-        const o = safeOrigin(cur.url);
-        // Concrete origin (non-opaque). Opaque URLs surface as "null".
-        if (o && o !== "null") return o;
-        const parentId = cur.parentFrameId;
-        if (parentId == null || parentId < 0) return null;
-        cur = byId.get(parentId);
-        depth++;
-      }
-      return null;
-    };
-    return asTargets(all.filter((f) => inheritedOrigin(f) === mainOrigin));
+    return asTargets(all.filter((f) => inheritedOrigin(f, byId) === mainOrigin));
   }
   // 默认 "main"
   const main = all.find((f) => f.frameId === 0);
@@ -922,8 +924,26 @@ export function registerObserveHandlers(router: ActionRouter): void {
           const allFrames = (await chrome.webNavigation.getAllFrames({ tabId: tid })) ?? [];
           const hasChildFrames = allFrames.some((f) => f.frameId !== 0);
           if (hasChildFrames) {
+            // 同源 srcdoc(about:srcdoc)的 url 非 http,isFrameInPermissions 会拒掉。
+            // 补一条 inherited same-origin 通道,让 auto-fallback 与 all-same-origin
+            // 模式一致地纳入 srcdoc 子框(judge iframe-srcdoc-inherit fixture 暴露:
+            // 主框近空触发 fallback 时,srcdoc 内的子按钮被静默丢弃 → observe 漏报)。
+            const byId = new Map(allFrames.map((f) => [f.frameId, f]));
+            const mainOrigin = safeOrigin(allFrames.find((f) => f.frameId === 0)?.url);
             const newTargets = allFrames
-              .filter((f) => f.frameId !== 0 && isFrameInPermissions(f.url))
+              .filter((f) => {
+                if (f.frameId === 0) return false;
+                if (isFrameInPermissions(f.url)) return true;
+                // 仅对 opaque-origin 子框走 inherited same-origin 兜底:
+                // about:srcdoc 自身 url 无法匹配 host_permissions,但继承父文档源
+                // 且与父同 tree(注入权限随父)。独立 http 子框仍以 host_permissions
+                // 为准,不被同源放宽(它们需各自的注入权限)。
+                const self = safeOrigin(f.url);
+                const isOpaque = self === null || self === "null";
+                return (
+                  isOpaque && mainOrigin != null && inheritedOrigin(f, byId) === mainOrigin
+                );
+              })
               .filter((f) => !scans.some((s) => s.frameId === f.frameId))
               .map((f) => ({
                 frameId: f.frameId,

--- a/packages/extension/tests/observe-auto-fallback.test.ts
+++ b/packages/extension/tests/observe-auto-fallback.test.ts
@@ -339,4 +339,40 @@ describe("observe auto-fallback (shell+iframe sites)", () => {
     expect(r.elements.length).toBe(2);
     expect(r.meta.autoFallback).toBe(true);
   });
+
+  it("does NOT loosen for an about:blank child (opaque but not srcdoc)", async () => {
+    // about:blank shares srcdoc's opaque origin ("null") but is NOT srcdoc — it
+    // must not be swept in via the same-origin loosening. The loosening is gated
+    // on url === "about:srcdoc" precisely to exclude about:blank / data: children.
+    const executeScript = vi.fn(
+      async ({ target, args }: { target: { frameIds?: number[] }; args?: unknown[] }) => {
+        const frameId = target.frameIds?.[0];
+        if (typeof args?.[0] === "string") return [{ result: { x: 0, y: 0 } }];
+        const pages: Record<number, ReturnType<typeof mkPage>> = { 0: mkPage(1) };
+        return [{ result: frameId != null ? pages[frameId] ?? null : null }];
+      },
+    );
+    vi.stubGlobal("chrome", {
+      tabs: { query: vi.fn().mockResolvedValue([{ id: 42 }]) },
+      webNavigation: {
+        getAllFrames: vi.fn().mockResolvedValue([
+          { frameId: 0, parentFrameId: -1, url: "https://example.com/page" },
+          { frameId: 1, parentFrameId: 0, url: "about:blank" },
+        ]),
+      },
+      scripting: { executeScript },
+      runtime: {
+        getManifest: vi.fn().mockReturnValue({ host_permissions: ["<all_urls>"] }),
+      },
+    });
+    const resp = await router.dispatch(mkReq("observe.snapshot", {}, 42));
+    const r = resp.result as {
+      frames: Array<{ frameId: number }>;
+      elements: unknown[];
+      meta: { autoFallback?: true };
+    };
+    // about:blank child must be excluded → only main frame scanned, no fallback
+    expect(r.frames.map((f) => f.frameId)).toEqual([0]);
+    expect(r.meta.autoFallback).toBeUndefined();
+  });
 });

--- a/packages/extension/tests/observe-auto-fallback.test.ts
+++ b/packages/extension/tests/observe-auto-fallback.test.ts
@@ -295,4 +295,48 @@ describe("observe auto-fallback (shell+iframe sites)", () => {
     expect(ids).toEqual([0, 190]);
     expect(r.meta.autoFallback).toBe(true);
   });
+
+  it("falls back into a same-origin srcdoc iframe (about:srcdoc child)", async () => {
+    // srcdoc inherits its parent's origin, but its frame URL is the opaque
+    // `about:srcdoc`, which isFrameInPermissions() rejects (non-http). The
+    // judge `iframe-srcdoc-inherit` fixture exposed this: auto-fallback dropped
+    // the srcdoc child, so observe never reported the child button. Same-origin
+    // srcdoc must be scanned just like resolveTargetFrames('all-same-origin').
+    const executeScript = vi.fn(
+      async ({ target, args }: { target: { frameIds?: number[] }; args?: unknown[] }) => {
+        const frameId = target.frameIds?.[0];
+        // getIframeOffset passes the child frame url (string) → return a rect
+        if (typeof args?.[0] === "string") return [{ result: { x: 0, y: 0 } }];
+        // scan call (args[0] is max:number) → page for this frame
+        const pages: Record<number, ReturnType<typeof mkPage>> = {
+          0: mkPage(1),
+          1: mkPage(1),
+        };
+        return [{ result: frameId != null ? pages[frameId] ?? null : null }];
+      },
+    );
+    vi.stubGlobal("chrome", {
+      tabs: { query: vi.fn().mockResolvedValue([{ id: 42 }]) },
+      webNavigation: {
+        getAllFrames: vi.fn().mockResolvedValue([
+          { frameId: 0, parentFrameId: -1, url: "https://example.com/page" },
+          { frameId: 1, parentFrameId: 0, url: "about:srcdoc" },
+        ]),
+      },
+      scripting: { executeScript },
+      runtime: {
+        getManifest: vi.fn().mockReturnValue({ host_permissions: ["<all_urls>"] }),
+      },
+    });
+    const resp = await router.dispatch(mkReq("observe.snapshot", {}, 42));
+    const r = resp.result as {
+      frames: Array<{ frameId: number }>;
+      elements: unknown[];
+      meta: { autoFallback?: true };
+    };
+    // srcdoc child (frameId 1) must be included via inherited same-origin
+    expect(r.frames.map((f) => f.frameId).sort()).toEqual([0, 1]);
+    expect(r.elements.length).toBe(2);
+    expect(r.meta.autoFallback).toBe(true);
+  });
 });


### PR DESCRIPTION
## 背景

`vortex_observe` 在 shell+iframe 站点(主框交互元素近空 + 有子 iframe)会触发 **auto-fallback**,自动 retry 扫描所有可注入子框。但旧的 fallback 过滤逻辑只用 `isFrameInPermissions(f.url)` 判定子框是否纳入。

`<iframe srcdoc>` 的 frame URL 是 opaque 的 `about:srcdoc`(`new URL("about:srcdoc").origin` 返回字面量 `"null"`),非 http,无法匹配 `host_permissions` → 被静默丢弃。结果:srcdoc 内的交互元素 **observe 漏报**。

这是自主发现引擎 judge 的 `iframe-srcdoc-inherit` fixture 暴露的真 observe bug(对照 `roleless-close-icon` / `icon-name-priority` 两处经 live 诊断确认为 judge 层局限,非 observe 漏报)。

## 改动

- 在 auto-fallback 子框过滤中补一条 **inherited same-origin 兜底通道**:
  - `isFrameInPermissions` 命中的子框照常纳入(独立 http 子框仍以 host_permissions 为准)。
  - 仅对 **opaque-origin** 子框(`about:srcdoc`)走 parent chain 继承源判定,与主框同源则纳入扫描。
  - 行为与 `resolveTargetFrames('all-same-origin')` 一致——srcdoc 继承父文档源,注入权限随父。
- `inheritedOrigin` 从 `resolveTargetFrames` 内联闭包提为顶层函数,两处复用。

## 测试

- 新增 `falls back into a same-origin srcdoc iframe (about:srcdoc child)` 回归测试。
- `tests/observe-auto-fallback.test.ts` 11/11 ✓
- live 验证:`vortex_observe(filter=interactive)` 对 srcdoc fixture 现正确报出子框按钮(主框按钮 + 子框按钮),修复前仅报主框。

## Test plan

- [x] 单测 observe-auto-fallback 11/11 通过
- [x] live observe 验证 srcdoc 子框现已报出
- [ ] reviewer 确认 opaque-origin 放宽不会误纳跨源 srcdoc(srcdoc 永远继承父源,无跨源风险)

Refs #15