### PR TITLE
fix(extension): observeEffect 自适应网络空闲窗口替换固定 windowMs 钳制 (#43)

### DIFF
--- a/packages/extension/src/page-side/click-effect.ts
+++ b/packages/extension/src/page-side/click-effect.ts
@@ -58,7 +58,9 @@ interface PendingEntry {
 }
 
 (function () {
-  if ((window as unknown as { __vortexClickEffect?: { version?: number } }).__vortexClickEffect?.version === 1) {
+  // version 2（#43 自适应窗口）：bump 自 1，使旧 v1 模块在已加载页被新注入覆盖——
+  // 否则扩展 reload 后未硬刷新的页面仍跑旧固定钳制逻辑（活验证 2026-06-11 实测踩到）。
+  if ((window as unknown as { __vortexClickEffect?: { version?: number } }).__vortexClickEffect?.version === 2) {
     return;
   }
 
@@ -151,7 +153,7 @@ interface PendingEntry {
   };
 
   (window as unknown as { __vortexClickEffect: unknown }).__vortexClickEffect = {
-    version: 1,
+    version: 2,
 
     /** 派发前调用：snapshot（url/activeElement/target aria）+ 启动 document 根 observer。返回 token。 */
     begin(sel: string, windowMs: number): string {

--- a/packages/extension/src/page-side/click-effect.ts
+++ b/packages/extension/src/page-side/click-effect.ts
@@ -34,8 +34,10 @@ export interface ClickEffect {
   networkSample: string[];
   /** 采集是否成功完成（false=document 被导航替换 / token 已超时清理，信号不可信）。 */
   observed: boolean;
-  /** 实际等待窗口（ms）。 */
+  /** 实际等待耗时（ms）。自适应窗口下 = 网络静默早返或到达 ceiling 的实际时长，非请求值。 */
   windowMs: number;
+  /** 请求的 windowMs 超过硬上限 WINDOW_MAX_MS 被钳制时为 true（调用方传值被改写的显式提示）。 */
+  clamped: boolean;
 }
 
 interface PendingEntry {
@@ -48,7 +50,10 @@ interface PendingEntry {
   // Resource Timing 起点：end 只统计 startTime >= perfStart 的请求（即 click 之后发起的）。
   // NaN 表示 performance API 不可用（采集降级，networkRequests 留 0）。
   perfStart: number;
-  windowMs: number;
+  /** 调用方请求的原始 windowMs（未钳制），用于回报 clamped。 */
+  requestedWindowMs: number;
+  /** 钳制后的等待上限（ceiling），end() 自适应轮询以此为硬上限。 */
+  ceilingMs: number;
   timer: ReturnType<typeof setTimeout>;
 }
 
@@ -62,8 +67,12 @@ interface PendingEntry {
 
   // begin 后无 end（异常 / 调用方崩）则强制 disconnect，防 observer 悬挂泄漏。
   const PENDING_TTL_MS = 5000;
-  const WINDOW_MAX_MS = 1000;
+  // 硬上限：自适应窗口最长等待（#43 慢站提交后置 POST 常在 1000~2500ms，1000 太短）。
+  const WINDOW_MAX_MS = 3000;
   const WINDOW_DEFAULT_MS = 300;
+  // 自适应轮询间隔与网络静默判定阈值。
+  const POLL_MS = 150;
+  const IDLE_QUIET_MS = 400;
 
   const ariaFingerprint = (el: Element | null): string => {
     if (!el) return "";
@@ -165,7 +174,8 @@ interface PendingEntry {
             return NaN;
           }
         })(),
-        windowMs: clampWindow(windowMs),
+        requestedWindowMs: typeof windowMs === "number" ? windowMs : NaN,
+        ceilingMs: clampWindow(windowMs),
         timer: setTimeout(() => {
           try {
             entry.observer.disconnect();
@@ -189,7 +199,8 @@ interface PendingEntry {
       return token;
     },
 
-    /** 派发后调用：await windowMs → diff snapshot + 读 observer 计数 + disconnect。返回 ClickEffect。 */
+    /** 派发后调用：自适应轮询网络（仅 sawNetwork 后静默 IDLE_QUIET_MS 早返，否则到 ceiling）
+     *  → diff snapshot + 读 observer 计数 + disconnect。返回 ClickEffect。 */
     end(token: string): Promise<ClickEffect> {
       const entry = PENDING[token];
       if (!entry) {
@@ -203,11 +214,27 @@ interface PendingEntry {
           networkSample: [],
           observed: false,
           windowMs: 0,
+          clamped: false,
         });
       }
+      // 取消 begin 的 TTL 看门狗；下面用本地 pollTimer 自管。
+      clearTimeout(entry.timer);
+      const ceiling = entry.ceilingMs;
+      const clamped =
+        typeof entry.requestedWindowMs === "number" &&
+        isFinite(entry.requestedWindowMs) &&
+        entry.requestedWindowMs > WINDOW_MAX_MS;
       return new Promise<ClickEffect>((resolve) => {
-        setTimeout(() => {
-          clearTimeout(entry.timer);
+        let elapsed = 0;
+        let quietFor = 0;
+        // perfStart 标记在 click 派发前；collectNetwork(perfStart) 计的是 click 之后的请求。
+        // sawNetwork = 自 perfStart 以来有过任何请求（curNet>0）——覆盖"快点击 POST 已落地"
+        // （基线已含）与"晚到 POST"（轮询中新增）两种。quietFor 仅在请求**增量**时归零。
+        let lastNet = collectNetwork(entry.perfStart).networkRequests;
+        let sawNetwork = lastNet > 0;
+        let pollTimer: ReturnType<typeof setTimeout>;
+        const finish = (): void => {
+          clearTimeout(pollTimer);
           try {
             entry.observer.disconnect();
           } catch {
@@ -237,9 +264,30 @@ interface PendingEntry {
             networkRequests: net.networkRequests,
             networkSample: net.networkSample,
             observed,
-            windowMs: entry.windowMs,
+            windowMs: elapsed,
+            clamped,
           });
-        }, entry.windowMs);
+        };
+        const step = (): void => {
+          const curNet = collectNetwork(entry.perfStart).networkRequests;
+          if (curNet > lastNet) {
+            lastNet = curNet;
+            quietFor = 0;
+          }
+          if (curNet > 0) sawNetwork = true;
+          if (elapsed >= ceiling) return finish();
+          // 仅在「观察到过网络 + 网络静默达阈值」时早返；静默失败/DOM-only 不早返，等到 ceiling。
+          if (sawNetwork && quietFor >= IDLE_QUIET_MS) return finish();
+          const dt = Math.min(POLL_MS, ceiling - elapsed);
+          elapsed += dt;
+          quietFor += dt;
+          pollTimer = setTimeout(step, dt);
+        };
+        if (ceiling <= 0) return finish();
+        const dt0 = Math.min(POLL_MS, ceiling);
+        elapsed += dt0;
+        quietFor += dt0;
+        pollTimer = setTimeout(step, dt0);
       });
     },
   };

--- a/packages/extension/tests/click-effect.helper.test.ts
+++ b/packages/extension/tests/click-effect.helper.test.ts
@@ -30,9 +30,9 @@ describe("click-effect page-side module (__vortexClickEffect)", () => {
     };
   }
 
-  it("挂载 __vortexClickEffect(version=1, begin/end 函数)", async () => {
+  it("挂载 __vortexClickEffect(version=2, begin/end 函数)", async () => {
     const ns = await load();
-    expect(ns.version).toBe(1);
+    expect(ns.version).toBe(2);
     expect(typeof ns.begin).toBe("function");
     expect(typeof ns.end).toBe("function");
   });

--- a/packages/extension/tests/click-effect.helper.test.ts
+++ b/packages/extension/tests/click-effect.helper.test.ts
@@ -25,6 +25,7 @@ describe("click-effect page-side module (__vortexClickEffect)", () => {
       end(t: string): Promise<{
         domMutations: number; urlChanged: boolean; focusChanged: boolean;
         ariaChanged: boolean; observed: boolean; windowMs: number;
+        networkRequests: number; networkSample: string[]; clamped: boolean;
       }>;
     };
   }
@@ -184,20 +185,89 @@ describe("click-effect page-side module (__vortexClickEffect)", () => {
     }
   });
 
-  it("windowMs 钳制:超 1000 截到 1000, 负数/非法回退 300", async () => {
+  it("windowMs 语义=实际耗时：超 3000 钳到 3000 且 clamped=true；非法回退 300", async () => {
     const ns = await load();
     vi.useFakeTimers();
     try {
       const t1 = ns.begin("#b", 99999);
       const p1 = ns.end(t1);
-      await vi.advanceTimersByTimeAsync(1000);
-      expect((await p1).windowMs).toBe(1000);
+      await vi.advanceTimersByTimeAsync(3000); // 无网络活动 → 等到 ceiling
+      const e1 = await p1;
+      expect(e1.windowMs).toBe(3000);
+      expect(e1.clamped).toBe(true);
 
       const t2 = ns.begin("#b", -5 as unknown as number);
       const p2 = ns.end(t2);
-      await vi.advanceTimersByTimeAsync(300);
-      expect((await p2).windowMs).toBe(300);
+      await vi.advanceTimersByTimeAsync(300); // 非法 → 默认 300 ceiling
+      const e2 = await p2;
+      expect(e2.windowMs).toBe(300);
+      expect(e2.clamped).toBe(false);
     } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("晚到 POST（>1000ms）被自适应窗口捕获（#43 核心：旧固定 1000ms 会漏报 networkRequests:0）", async () => {
+    const ns = await load();
+    vi.useFakeTimers();
+    // 受控 Resource Timing：POST 在 1500ms 才出现。perfStart=0。
+    const entries: { name: string; initiatorType: string; startTime: number }[] = [];
+    let clock = 0;
+    vi.stubGlobal("performance", {
+      now: () => clock,
+      getEntriesByType: () => entries.slice(),
+    });
+    try {
+      const t = ns.begin("#b", 3000); // ceiling 3000
+      const p = ns.end(t);
+      // 0~1450ms 无网络
+      await vi.advanceTimersByTimeAsync(1450);
+      clock = 1500;
+      entries.push({ name: "https://api.bytenew.com/work/submit", initiatorType: "xmlhttprequest", startTime: 1500 });
+      // 推进到 POST 后静默早返（1500 + IDLE_QUIET 400 + 轮询粒度）
+      await vi.advanceTimersByTimeAsync(800);
+      const eff = await p;
+      expect(eff.networkRequests).toBe(1);
+      expect(eff.networkSample).toEqual(["api.bytenew.com/work/submit"]);
+      expect(eff.windowMs).toBeLessThan(3000); // 静默早返，未拖满 ceiling
+      expect(eff.windowMs).toBeGreaterThanOrEqual(1500);
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  });
+
+  it("网络活动后静默 IDLE_QUIET → 早返，不拖满 ceiling", async () => {
+    const ns = await load();
+    vi.useFakeTimers();
+    const entries = [{ name: "https://api.bytenew.com/x", initiatorType: "fetch", startTime: 0 }];
+    vi.stubGlobal("performance", { now: () => 0, getEntriesByType: () => entries.slice() });
+    try {
+      const t = ns.begin("#b", 3000);
+      const p = ns.end(t);
+      await vi.advanceTimersByTimeAsync(700); // 首 step 即见 1 个请求 → 之后静默 400 早返
+      const eff = await p;
+      expect(eff.networkRequests).toBe(1);
+      expect(eff.windowMs).toBeLessThan(1000);
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  });
+
+  it("全程无网络（静默失败 / isTrusted 拦截）→ 不早返，等到 ceiling，networkRequests:0 仍成立", async () => {
+    const ns = await load();
+    vi.useFakeTimers();
+    vi.stubGlobal("performance", { now: () => 0, getEntriesByType: () => [] });
+    try {
+      const t = ns.begin("#b", 2000);
+      const p = ns.end(t);
+      await vi.advanceTimersByTimeAsync(2000);
+      const eff = await p;
+      expect(eff.networkRequests).toBe(0);
+      expect(eff.windowMs).toBe(2000); // 等到 ceiling，未提前
+    } finally {
+      vi.unstubAllGlobals();
       vi.useRealTimers();
     }
   });

--- a/packages/mcp/src/tools/schemas-public.ts
+++ b/packages/mcp/src/tools/schemas-public.ts
@@ -43,8 +43,8 @@ export const PUBLIC_TOOLS: ToolDef[] = [
     name: "vortex_act",
     action: "L4.act",
     description:
-      "Write to a UI element. scroll: value={container?,position}. " +
-      "click options.observeEffect:true→effect signals (0=no-op).",
+      "Write to a UI element. scroll:value={container?,position}. " +
+      "click observeEffect→effect signals; windowMs上限3000,慢站0网络≠失败.",
     schema: {
       type: "object",
       properties: {


### PR DESCRIPTION
## 背景 / 根因

`vortex_act click` 的 `options.observeEffect` 效果信号中，`windowMs` 被硬钳在 **1000ms**（`click-effect.ts` `WINDOW_MAX_MS=1000` + `Math.min`）。在**提交后置**的重型 SPA（debounce/异步校验 → POST 在 click 后 >1000ms 才发）上，成功操作在 1000ms 窗口内测不到网络 → effect 报 `networkRequests:0`，把"慢成功"误判成 silent fail（假阴性）。这削弱了 GAP-G 这一 P0 功能在真实 B 端的可靠性。

发现来源：N0062 vortex 生产能力评测 V3（班牛预发深度复测）。Refs #43。

## 方案（自适应网络空闲窗口，对齐 Playwright "networkidle 劝退 → 等可见就绪" 经验）

- `WINDOW_MAX_MS` 1000→**3000**；`windowMs` 语义从"固定等待时长"改为"等待上限 ceiling"（默认 300，可传至 3000）。
- `end()` 改为**轮询 Resource Timing**：仅当**观察到过网络请求**（自 perfStart）且**网络静默 `IDLE_QUIET_MS`(400ms)** 后早返；否则等到 ceiling。
  - 早返门**只看网络、不看 DOM**——否则 SPA 噪声 mutation 会在"提交后置 POST 还没发"时提前 resolve、漏掉 POST。
  - 静默失败 / 纯 DOM 点击（`sawNetwork=false`）**从不早返**，等到 ceiling，确保"0 网络"判读可靠（含淘宝/京东 isTrusted 拦截场景）。
  - `sawNetwork = 自 perfStart 有过任何请求`，覆盖"快点击 POST 已落地"与"晚到 POST"两种。
- `ClickEffect` 新增 `clamped: boolean`（请求值 > 上限被钳时显式标注）；`windowMs` 返回**实际耗时**。
- **version 守卫 1→2**：使新模块在已加载页被注入时覆盖旧 v1 驻留（否则扩展 reload 后未硬刷新的页面仍跑旧固定钳制——活验证实测踩到的重载族陷阱）。
- 工具描述补判读边界（windowMs 上限 3000，慢站 0 网络≠失败），保持 I15 description ≤120 char。

边界澄清：淘宝/京东 isTrusted 静默拦截根本不发请求，1000ms 仍足够，GAP-G 原结论不变；本 PR 影响的是"无法在慢站 positively 确认成功"与"0 网络≠失败"判读。

## 变更文件

- `packages/extension/src/page-side/click-effect.ts` — 自适应窗口 + clamped + version 2
- `packages/extension/tests/click-effect.helper.test.ts` — clamp 语义更新 + 晚到 POST/静默早返/无网络等满 ceiling 回归
- `packages/mcp/src/tools/schemas-public.ts` — vortex_act 描述补判读边界

## 测试计划

- [x] 单测 click-effect 全套 **21/21**（含晚到 POST 捕获、静默早返、无网络等满 ceiling、clamped 标注）
- [x] extension 全量 **969/969** + mcp 全量 **409/409**
- [x] I15 不变量（description ≤120 char + tools/list 字节预算）通过
- [x] **班牛预发主帧 live 验证**：`windowMs:99999` → `clamped:true` + `windowMs:3000`（旧版必为 1000）；`windowMs:2000` → `windowMs:2000`，证明 cap 1000→3000 生效
- [x] bench **click-effect-signal** case 端到端通过（7 calls / 0 fallback / 0 missed）
- [x] bench `run --all` 88 case 全量回归：运行中，已过 41/88 全绿、0 失败/0 missed（完成后更新）

## 备注

- 班牛工单表刷新/排序的 `networkRequests:0` 系其走客户端重渲染/websocket/子帧（既有 collectNetwork 捕获范围，非本变更），故未用真提交（避免造测试数据）；"晚到 POST 捕获"由单测精确覆盖。
- 设计/实施方案见知识库 `N0062/reports/vortex-prod-eval-V3/`（解决方案设计 + 实施方案-43）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)