### PR TITLE
fix(extension): observe 嵌套 cursor:pointer 区分多 CTA 容器,保子项不再合并吞 (#42)

### DIFF
--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -1397,22 +1397,61 @@ async function scanOneFrame(
         const dropSet = new WeakSet<Element>();
         const normText = (el: Element): string =>
           (el.textContent ?? "").replace(/\s+/g, " ").trim();
+        // #42 多 CTA 容器修复:先按「最近 candidate 祖先」把 leaves 分组,预算多 CTA 祖先。
+        // isMultiCtaContainer 真源见 page-side/content-card.ts,inline 副本须同步。
+        const nearestCandidateAnc = (leaf: Element): Element | null => {
+          let p: Element | null = leaf.parentElement;
+          while (p) {
+            if (candidateSet.has(p)) return p;
+            p = p.parentElement;
+          }
+          return null;
+        };
+        const ancChildren = new Map<Element, Element[]>();
+        for (const leaf of survivingExtras) {
+          const anc = nearestCandidateAnc(leaf);
+          if (anc) {
+            const arr = ancChildren.get(anc);
+            if (arr) arr.push(leaf);
+            else ancChildren.set(anc, [leaf]);
+          }
+        }
+        // 多 CTA 容器:≥2 个有文本的最近 candidate 子、且自身非内容卡 → 保子、drop 容器。
+        // 不查子文本互不为子串(createBox '创建'⊂'创建空白工作表'是中文巧合,仍是独立按钮)。
+        const isMultiCtaContainer = (anc: Element, kids: Element[]): boolean => {
+          if (kids.length < 2) return false;
+          let withText = 0;
+          for (const c of kids) {
+            if ((c.textContent ?? "").trim().length > 0) withText++;
+          }
+          if (withText < 2) return false;
+          return !isClickableContentCard(anc);
+        };
+        const multiCtaAncestors = new Set<Element>();
+        for (const [anc, kids] of ancChildren) {
+          if (isMultiCtaContainer(anc, kids)) multiCtaAncestors.add(anc);
+        }
         for (const leaf of survivingExtras) {
           let p: Element | null = leaf.parentElement;
           while (p) {
             if (candidateSet.has(p)) {
-              const leafText = normText(leaf);
-              const ancText = normText(p);
-              if (ancText.length > leafText.length && ancText.includes(leafText)) {
-                // ancestor 有额外文本（主标签+leaf 子串），保留 ancestor
-                dropSet.add(leaf);
-              } else if (isClickableContentCard(p)) {
-                // 内容卡 ancestor(评价卡/商品卡)优先保留:其正文与标签子异文本
-                // 且不含标签词,旧逻辑会误 drop 容器保留标签 → 评价卡整条丢失。
-                dropSet.add(leaf);
-              } else {
-                // 文本等价（嵌套同文本 wrapper），保留 leaf
+              if (multiCtaAncestors.has(p)) {
+                // 多 CTA 容器:drop 容器、保所有子 leaf(各自独立动作,如 createBox 三按钮)。
                 dropSet.add(p);
+              } else {
+                const leafText = normText(leaf);
+                const ancText = normText(p);
+                if (ancText.length > leafText.length && ancText.includes(leafText)) {
+                  // ancestor 有额外文本（主标签+leaf 子串），保留 ancestor
+                  dropSet.add(leaf);
+                } else if (isClickableContentCard(p)) {
+                  // 内容卡 ancestor(评价卡/商品卡)优先保留:其正文与标签子异文本
+                  // 且不含标签词,旧逻辑会误 drop 容器保留标签 → 评价卡整条丢失。
+                  dropSet.add(leaf);
+                } else {
+                  // 文本等价（嵌套同文本 wrapper），保留 leaf
+                  dropSet.add(p);
+                }
               }
               break; // 链上更深 ancestor 由它们各自的 leaf 触发处理
             }

--- a/packages/extension/src/page-side/content-card.ts
+++ b/packages/extension/src/page-side/content-card.ts
@@ -49,3 +49,22 @@ export function isClickableContentCard(el: Element): boolean {
 export function isSelfClickable(el: Element): boolean {
   return getComputedStyle(el).cursor === "pointer" || hasFrameworkClickHandler(el);
 }
+
+/**
+ * 多 CTA 容器判据（#42 嵌套 cursor:pointer 去重）：
+ * ancestor 拥有 ≥2 个「最近 candidate 子」(children，由调用方按最近 candidate 祖先分组,
+ * 保证彼此非 DOM 祖裔)、其中 ≥2 个有非空文本、且 ancestor 自身不是内容卡 →
+ * 这些子是各自独立的动作（如 createBox 的"创建空白工作表/模板中心/创建"），应分别保留 ref、
+ * drop 容器。区分「单一语义标签(仅 1 个文本片段子，如 JD '全部'+span'96%好评')」。
+ * 不做"子文本互不为子串"检查——createBox 的'创建'是'创建空白工作表'子串但确为独立按钮,
+ * 子串重合是中文巧合非合并信号;分组已保证非 DOM 祖裔,计数+有文本即足够。
+ */
+export function isMultiCtaContainer(ancestor: Element, children: Element[]): boolean {
+  if (children.length < 2) return false;
+  let withText = 0;
+  for (const c of children) {
+    if ((c.textContent ?? "").trim().length > 0) withText++;
+  }
+  if (withText < 2) return false;
+  return !isClickableContentCard(ancestor);
+}

--- a/packages/extension/tests/content-card.test.ts
+++ b/packages/extension/tests/content-card.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { JSDOM } from "jsdom";
-import { hasOwnContentText, isClickableContentCard, isSelfClickable } from "../src/page-side/content-card.js";
+import { hasOwnContentText, isClickableContentCard, isSelfClickable, isMultiCtaContainer } from "../src/page-side/content-card.js";
 
 function setupDom(html: string): Document {
   const dom = new JSDOM(`<!DOCTYPE html><body>${html}</body>`);
@@ -104,5 +104,48 @@ describe("isSelfClickable — 自身独立可点", () => {
   it("cursor:auto 无 fw(普通布局 wrapper)→ false", () => {
     const doc = setupDom(`<div id="t"><button style="cursor:pointer">提交</button></div>`);
     expect(isSelfClickable(doc.getElementById("t")!)).toBe(false);
+  });
+});
+
+describe("isMultiCtaContainer — 多 CTA 容器判据(#42)", () => {
+  it("createBox 型:3 个有文本的 cursor:pointer 子 + 非内容卡 → true", () => {
+    const doc = setupDom(
+      `<div id="t" style="cursor:pointer"><div class="illust">创建工作表</div>` +
+      `<span style="cursor:pointer">创建空白工作表</span>` +
+      `<span style="cursor:pointer">模板中心</span>` +
+      `<span style="cursor:pointer">创建</span></div>`,
+    );
+    const t = doc.getElementById("t")!;
+    const kids = [...t.querySelectorAll("span")];
+    expect(isMultiCtaContainer(t, kids)).toBe(true);
+  });
+
+  it("JD 标签型:仅 1 个片段子 → false(保 ancestor)", () => {
+    const doc = setupDom(`<div id="t" style="cursor:pointer">全部<span style="cursor:pointer">96%好评</span></div>`);
+    const t = doc.getElementById("t")!;
+    const kids = [...t.querySelectorAll("span")];
+    expect(isMultiCtaContainer(t, kids)).toBe(false);
+  });
+
+  it("内容卡:≥2 子但自身有正文(content card) → false(豁免保 ancestor)", () => {
+    const doc = setupDom(
+      `<div id="t"><div class="info">这是一条很长的真实评价正文内容</div>` +
+      `<span style="cursor:pointer">拍照清晰</span>` +
+      `<span style="cursor:pointer">值得购买</span></div>`,
+    );
+    const t = doc.getElementById("t")!;
+    attachReactClick(t); // 内容卡需 framework onClick(见既有 helper)
+    const kids = [...t.querySelectorAll("span")];
+    expect(isMultiCtaContainer(t, kids)).toBe(false);
+  });
+
+  it("子项无文本(纯图标) → 有文本子<2 → false", () => {
+    const doc = setupDom(
+      `<div id="t" style="cursor:pointer"><span style="cursor:pointer"></span>` +
+      `<span style="cursor:pointer">  </span></div>`,
+    );
+    const t = doc.getElementById("t")!;
+    const kids = [...t.querySelectorAll("span")];
+    expect(isMultiCtaContainer(t, kids)).toBe(false);
   });
 });

--- a/packages/extension/tests/observe-content-card-inlined.test.ts
+++ b/packages/extension/tests/observe-content-card-inlined.test.ts
@@ -60,3 +60,20 @@ describe("observe v2:卡吸收内部 cursor:pointer 后代(源码锁)", () => {
     expect(OBSERVE_SRC).toMatch(/let survivingExtras = cursorPointerExtras;/);
   });
 });
+
+describe("observe #42:多 CTA 容器去重内联(源码锁)", () => {
+  it("inject func 含 inline isMultiCtaContainer 定义", () => {
+    expect(OBSERVE_SRC).toMatch(/const isMultiCtaContainer = \(anc: Element, kids: Element\[\]\): boolean =>/);
+  });
+  it("含 ancChildren 分组 + multiCtaAncestors 预算", () => {
+    expect(OBSERVE_SRC).toMatch(/const ancChildren = new Map<Element, Element\[\]>\(\)/);
+    expect(OBSERVE_SRC).toMatch(/const multiCtaAncestors = new Set<Element>\(\)/);
+  });
+  it("决策分支:多 CTA 祖先 drop 容器保子", () => {
+    expect(OBSERVE_SRC).toMatch(/if \(multiCtaAncestors\.has\(p\)\) \{\s*\/\/[^\n]*\n\s*dropSet\.add\(p\);/);
+  });
+  it("内联多 CTA 判据不做子串检查(只计数+有文本+非内容卡)", () => {
+    // 防回归到设计文档误写的'互不为子串'(会误排除 createBox)
+    expect(OBSERVE_SRC).toMatch(/不查子文本互不为子串/);
+  });
+});

--- a/packages/vortex-bench/playground/public/synth/multi-cta-card.html
+++ b/packages/vortex-bench/playground/public/synth/multi-cta-card.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="zh"><head><meta charset="utf-8"><title>multi cta card</title>
+<style>.box,.cta{cursor:pointer}.box{border:1px solid #888;padding:16px;width:320px}.cta{display:inline-block;padding:8px 12px;margin:4px;border:1px solid #ccc}</style>
+</head><body>
+<h1>多 CTA 卡片(嵌套 cursor:pointer 子按钮)</h1>
+<!-- #42 班牛 createBox:容器 cursor:pointer 含 3 个功能不同的 cursor:pointer 子按钮 -->
+<div class="box" data-vtx-oracle="card">
+  <div class="illust">创建工作表</div>
+  <span class="cta" data-vtx-oracle="cta-blank">创建空白工作表</span>
+  <span class="cta" data-vtx-oracle="cta-template">模板中心</span>
+  <span class="cta" data-vtx-oracle="cta-create">创建</span>
+</div>
+</body></html>

--- a/packages/vortex-bench/playground/public/synth/multi-cta-card.html
+++ b/packages/vortex-bench/playground/public/synth/multi-cta-card.html
@@ -1,10 +1,12 @@
 <!doctype html>
 <html lang="zh"><head><meta charset="utf-8"><title>multi cta card</title>
-<style>.box,.cta{cursor:pointer}.box{border:1px solid #888;padding:16px;width:320px}.cta{display:inline-block;padding:8px 12px;margin:4px;border:1px solid #ccc}</style>
+<style>.box,.cta{cursor:pointer}.box{border:1px solid #888;padding:16px;width:320px}.cta{display:inline-block;padding:8px 12px;margin:4px;border:1px solid #ccc}.illust{cursor:default}</style>
 </head><body>
 <h1>多 CTA 卡片(嵌套 cursor:pointer 子按钮)</h1>
-<!-- #42 班牛 createBox:容器 cursor:pointer 含 3 个功能不同的 cursor:pointer 子按钮 -->
-<div class="box" data-vtx-oracle="card">
+<!-- #42 班牛 createBox:容器 cursor:pointer 含 3 个功能不同的 cursor:pointer 子按钮。
+     容器本身不打 data-vtx-oracle(它不是 act 目标;且大矩形 oracle 会在几何 join 时
+     吸走子按钮 observe 行致假 recall-miss)。只断言 3 个子按钮独立暴露。 -->
+<div class="box">
   <div class="illust">创建工作表</div>
   <span class="cta" data-vtx-oracle="cta-blank">创建空白工作表</span>
   <span class="cta" data-vtx-oracle="cta-template">模板中心</span>

--- a/packages/vortex-bench/playground/public/synth/multi-cta-card.manifest.json
+++ b/packages/vortex-bench/playground/public/synth/multi-cta-card.manifest.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "multi-cta-card",
+  "path": "/synth/multi-cta-card.html",
+  "tier": "hard",
+  "frames": "main",
+  "entries": [
+    { "id": "cta-blank", "interactive": true, "expectedName": "创建空白工作表", "expectedRole": null, "pattern": "multi-cta-card", "note": "#42 多 CTA 子按钮须独立暴露" },
+    { "id": "cta-template", "interactive": true, "expectedName": "模板中心", "expectedRole": null, "pattern": "multi-cta-card" },
+    { "id": "cta-create", "interactive": true, "expectedName": "创建", "expectedRole": null, "pattern": "multi-cta-card" }
+  ]
+}

--- a/packages/vortex-bench/playground/public/synth/split-label-negative.html
+++ b/packages/vortex-bench/playground/public/synth/split-label-negative.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="zh"><head><meta charset="utf-8"><title>split label</title>
+<style>.tag{cursor:pointer;display:inline-block;padding:6px}</style>
+</head><body>
+<h1>单标签内含片段 span(不应拆分)</h1>
+<!-- JD 标签:ancestor '全部 96%好评' 含 leaf 子串 → 仍保 ancestor 一条 -->
+<div class="tag" data-vtx-oracle="filter-tag">全部<span style="cursor:pointer">96%好评</span></div>
+</body></html>

--- a/packages/vortex-bench/playground/public/synth/split-label-negative.manifest.json
+++ b/packages/vortex-bench/playground/public/synth/split-label-negative.manifest.json
@@ -4,6 +4,6 @@
   "tier": "medium",
   "frames": "main",
   "entries": [
-    { "id": "filter-tag", "interactive": true, "expectedName": "全部 96%好评", "expectedRole": null, "pattern": "split-label-negative", "note": "#42 单片段子不拆分,保 ancestor 主标签" }
+    { "id": "filter-tag", "interactive": true, "expectedName": "全部96%好评", "expectedRole": null, "pattern": "split-label-negative", "note": "#42 单片段子不拆分,保 ancestor 主标签" }
   ]
 }

--- a/packages/vortex-bench/playground/public/synth/split-label-negative.manifest.json
+++ b/packages/vortex-bench/playground/public/synth/split-label-negative.manifest.json
@@ -1,0 +1,9 @@
+{
+  "fixture": "split-label-negative",
+  "path": "/synth/split-label-negative.html",
+  "tier": "medium",
+  "frames": "main",
+  "entries": [
+    { "id": "filter-tag", "interactive": true, "expectedName": "全部 96%好评", "expectedRole": null, "pattern": "split-label-negative", "note": "#42 单片段子不拆分,保 ancestor 主标签" }
+  ]
+}


### PR DESCRIPTION
## 背景 / 根因（订正 issue-A 误诊）

班牛多 CTA 卡片（如「创建工作表」`createBox`，cursor:pointer 容器内含 `创建空白工作表 / 模板中心 / 创建` 三个 cursor:pointer 子按钮）经 `vortex_observe` 只暴露**最外层一个合并 ref**，子按钮全部丢失 → observe→act 够不到，点合并 ref 命中插图区无效。

**真根因（白盒追踪 + MAIN world 复现坐实，订正 #42 issue body 原诊断）**：不是命名逻辑 `isContainer`，而是**嵌套 cursor:pointer 去重 `observe.ts:1406`** 的 `ancText.length>leafText.length && ancText.includes(leafText) → drop leaf 保 ancestor` 分支——它无法区分「单一语义标签（JD `全部`+span`96%好评`，1 个片段子）」与「多 CTA 容器（文本=多个独立子按钮拼接）」。Refs #42（已在 issue 评论订正根因）。

## 方案（多 leaf 计数判据）

新增真源 `isMultiCtaContainer`（`content-card.ts`，纯函数可单测）：**ancestor 有 ≥2 个「最近 candidate 子」、其中 ≥2 个有非空文本、且自身非内容卡 → 多 CTA 容器 → drop 容器、保所有子 leaf**。

- observe 去重前先按「最近 candidate 祖先」分组 leaves，预算多 CTA 祖先集；per-leaf 决策里多 CTA 祖先优先 drop 容器，否则沿用原单标签/内容卡逻辑。
- **不做「子文本互不为子串」检查**——createBox 的 `创建` 是 `创建空白工作表` 子串但确为独立按钮，子串重合是中文巧合；分组已保证子项彼此非 DOM 祖裔，计数+有文本即足够。
- content-card 豁免：评价卡/商品卡（`isClickableContentCard`，自身有正文）维持保 ancestor。
- 嵌套多层自洽。inline 副本与真源同步（既有约束）。

## 变更文件

- `packages/extension/src/page-side/content-card.ts` — `isMultiCtaContainer` 真源
- `packages/extension/src/handlers/observe.ts` — 去重重构（分组 + 多 CTA 祖先集 + inline 副本）
- `packages/extension/tests/content-card.test.ts` — 真源单测（createBox 正向 / JD 标签负向 / 内容卡豁免 / 无文本子）
- `packages/extension/tests/observe-content-card-inlined.test.ts` — 4 条源码锁
- `packages/vortex-bench/playground/public/synth/multi-cta-card.{html,manifest.json}` — 正向 fixture
- `packages/vortex-bench/playground/public/synth/split-label-negative.{html,manifest.json}` — 负向 fixture

## 测试计划

- [x] 真源单测 `content-card` **16/16**（4 新多 CTA 用例）
- [x] observe 全套 **189/189** + extension 全量 **974/974**
- [x] 源码锁 4 条（inline 多 CTA 判据在场 + 不做子串检查防回归）
- [x] **真扩展 bench scan**：`multi-cta-card` **recall=3/3**（createBox 形状子按钮全召回，端到端坐实修复）；`split-label-negative` **recall=1/1**（单片段不过度拆分）
- [x] **0022 全 synth sweep 13/13 干净**（aria-cursor-dedup 2/2 同族不退化，无 TP/FP 漂移）
- [x] bench `run --all` 88 case **88/88 全过**；`bench diff` vs baseline 全部 `= unchanged`（0 行为回归）
- [x] **班牛弹出菜单 probe（Task 0，实机白盒）**：弹出菜单子项是 `el-popover role=tooltip` 内的 **cursor:auto** DIV，observe 靠 tooltip name-from-content 合并——与 #42 的 cursor:pointer 多 CTA 去重是**不同根因**，本 PR 不覆盖（→ 独立 follow-up）。createBox（cursor:pointer 多 CTA）修复由真扩展 bench fixture recall=3/3 坐实。

## 备注

- **createBox（实例1）vs 弹出菜单（实例2）是两个不同根因**：实机白盒确认弹出菜单子项 cursor:auto（非 pointer），#42 仅修 cursor:pointer 多 CTA。弹出菜单（el-popover tooltip 合并）转独立 follow-up。
- 已知 FP（文档化 + 负向 fixture 守护）：单一逻辑按钮被作者拆成 ≥2 个 cursor:pointer span 会被拆成 2 ref——非灾难（两 ref 均可点、冒泡触发同 handler，仅噪声），而 createBox bug 是灾难（0 可用 ref）。
- 设计/实施方案见知识库 `N0062/reports/vortex-prod-eval-V3/`（解决方案设计 + 实施方案-42）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
