### PR TITLE
fix: N0063 评测核实出的 5 个 vortex 工具缺陷修复(P0×3 + P1×2)

### DIFF
--- a/packages/extension/src/handlers/dom.ts
+++ b/packages/extension/src/handlers/dom.ts
@@ -418,7 +418,13 @@ export function registerDomHandlers(
             return { error: err instanceof Error ? err.message : String(err) };
           }
         },
-        args: [selector, cdpAvailable, observeEffect, windowMs],
+        // BUG-001 (N0063): windowMs 缺省时为 undefined,chrome.scripting.executeScript 的
+        // args 走 structured clone 拒 undefined(报 "unserializable at index 3"),非 trusted
+        // 合成路径默认 click 100% 崩。默认 300 对齐 page-side click-effect.ts 的 `windowMs ?? 300`
+        // ——observeEffect=false 时该值不被使用(begin 不调),observeEffect=true 且未传时给回正确
+        // 的 300ms 窗口(用 ?? 0 会因 0 非 nullish 把窗口塌成 0ms,故不可用 0)。observeEffect
+        // 恒为 boolean(args.observeEffect === true),无需兜底。
+        args: [selector, cdpAvailable, observeEffect, windowMs ?? 300],
         world: "MAIN",
       });
       return results[0]?.result as {
@@ -849,7 +855,18 @@ export function registerDomHandlers(
                 extras: { attempted: String(val), type: (el as HTMLInputElement).type },
               };
             }
-            return { result: { success: true } };
+            // DESIGN-002 (N0063): fill 成功后显式 focus,让后续 vortex_press/Enter 落在 input 上。
+            // 原生 value setter 不触发 focus,React 受控组件 click→fill 链路常使 activeElement
+            // 停在 BODY(实测 bytenew 搜索框 fill 后 activeElement=BODY → 搜索+回车整类失效)。
+            // preventScroll 避免 sticky 容器 fill 后视口跳变;不支持该选项的环境兜底裸 focus。
+            if (typeof el.focus === "function") {
+              try { el.focus({ preventScroll: true }); } catch { try { el.focus(); } catch { /* focus 非所有元素可用 */ } }
+            }
+            // focused 反映真实结果(focus 在 disabled/hidden 上不抛错但静默 no-op,review N0063):
+            // 取 el 所在 root(穿 shadow)的 activeElement 是否就是 el,而非硬编码 true。
+            const __root = (el.getRootNode?.() ?? el.ownerDocument) as Document | ShadowRoot;
+            const focused = __root?.activeElement === el;
+            return { result: { success: true, focused } };
           } catch (err) {
             return { error: err instanceof Error ? err.message : String(err) };
           }

--- a/packages/extension/src/handlers/file.ts
+++ b/packages/extension/src/handlers/file.ts
@@ -4,13 +4,9 @@ import { FileActions, VtxErrorCode, vtxError, VtxEventType } from "@vortex-brows
 import type { ActionRouter } from "../lib/router.js";
 import type { NativeMessagingClient } from "../lib/native-messaging.js";
 import type { EventDispatcher } from "../events/dispatcher.js";
-
-async function getActiveTabId(tabId?: number): Promise<number> {
-  if (tabId) return tabId;
-  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  if (!tab?.id) throw vtxError(VtxErrorCode.TAB_NOT_FOUND, "No active tab found");
-  return tab.id;
-}
+import { resolveTarget } from "../lib/resolve-target.js";
+import { getActiveTabId, buildExecuteTarget, ensureFrameAttached } from "../lib/tab-utils.js";
+import { loadPageSideModule } from "../adapter/page-side-loader.js";
 
 export function registerFileHandlers(
   router: ActionRouter,
@@ -35,20 +31,29 @@ export function registerFileHandlers(
 
   router.registerAll({
     [FileActions.UPLOAD]: async (args, tabId) => {
-      const selector = args.selector as string;
+      // DESIGN-001 (N0063): 经 resolveTarget 支持 @ref/index+snapshotId(server.ts 翻译后)
+      // 与裸 selector,和其它 14 工具一致;原仅认 args.selector,@ref 必报 Missing。
+      const __t = resolveTarget(args);
+      const selector = __t.selector;
       const fileName = args.fileName as string;
       const fileContent = args.fileContent as string; // base64
       const mimeType = (args.mimeType as string) ?? "application/octet-stream";
       if (!selector || !fileName || !fileContent) {
-        throw vtxError(VtxErrorCode.INVALID_PARAMS, "Missing required params: selector, fileName, fileContent (base64)");
+        throw vtxError(VtxErrorCode.INVALID_PARAMS, "Missing required params: target (@ref/CSS) or selector, fileName, fileContent (base64)");
       }
-      const tid = await getActiveTabId((args.tabId as number | undefined) ?? tabId);
+      const tid = await getActiveTabId(__t.boundTabId ?? (args.tabId as number | undefined) ?? tabId);
+      const frameId = __t.boundFrameId ?? (args.frameId as number | undefined);
+      if (frameId != null) await ensureFrameAttached(tid, frameId);
+      // dom-resolve 让 page-side func 经 queryAllDeep 穿 open shadow + 走 @ref 一致路径,
+      // 取代旧的 document.querySelector(光 DOM)+ target:{tabId}(无 frameId,iframe 内 file input 漏)。
+      await loadPageSideModule(tid, frameId, "dom-resolve");
 
       const results = await chrome.scripting.executeScript({
-        target: { tabId: tid },
+        target: buildExecuteTarget(tid, frameId),
         func: (sel: string, name: string, b64: string, mime: string) => {
           try {
-            const input = document.querySelector(sel) as HTMLInputElement | null;
+            const els = (window as unknown as { __vortexDomResolve: { queryAllDeep(s: string): Element[] } }).__vortexDomResolve.queryAllDeep(sel);
+            const input = els[0] as HTMLInputElement | undefined;
             if (!input) return { error: `Element not found: ${sel}` };
             if (input.type !== "file") return { error: "Element is not a file input" };
 

--- a/packages/extension/src/handlers/network.ts
+++ b/packages/extension/src/handlers/network.ts
@@ -85,6 +85,71 @@ function addLog(tabId: number, entry: NetworkEntry): void {
   }
 }
 
+function mapInitiatorType(it: string): string {
+  if (it === "xmlhttprequest") return "XHR";
+  if (it === "fetch") return "Fetch";
+  return it ? it.charAt(0).toUpperCase() + it.slice(1) : "Other";
+}
+
+/**
+ * BUG-003 (N0063): 读 page-side Resource Timing 历史。CDP Network 只捕获 enable 之后的请求,
+ * 首次 debug_read 之前已发生的全丢(实测 bytenew CDP 0 vs Resource Timing 250)。
+ * performance.getEntriesByType('resource') 总能拿到已完成请求的 url/initiator/duration
+ * (无 method/status/headers,这是 Resource Timing 的固有限制)。startTime 用 timeOrigin
+ * 对齐成 epoch ms,与 CDP 条目(Date.now())可同轴排序。缺 chrome.scripting / performance
+ * 时优雅降级返回 []。
+ */
+async function readResourceTimingEntries(tabId: number): Promise<NetworkEntry[]> {
+  try {
+    const results = await chrome.scripting.executeScript({
+      target: { tabId },
+      func: () => {
+        try {
+          if (
+            typeof performance === "undefined" ||
+            typeof performance.getEntriesByType !== "function"
+          ) {
+            return [];
+          }
+          const origin = typeof performance.timeOrigin === "number" ? performance.timeOrigin : 0;
+          return (performance.getEntriesByType("resource") as PerformanceResourceTiming[]).map(
+            (e) => ({
+              url: e.name,
+              initiatorType: e.initiatorType,
+              startTime: Math.round(origin + e.startTime),
+              duration: Math.round(e.duration),
+            }),
+          );
+        } catch {
+          return [];
+        }
+      },
+    });
+    const raw = (results[0]?.result ?? []) as Array<{
+      url: string;
+      initiatorType: string;
+      startTime: number;
+      duration: number;
+    }>;
+    return raw.map((r) => ({
+      requestId: `rt:${r.url}:${r.startTime}`,
+      url: r.url,
+      method: "",
+      type: mapInitiatorType(r.initiatorType),
+      startTime: r.startTime,
+      duration: r.duration,
+    }));
+  } catch (err) {
+    // 不静默吞:executeScript 真失败(frame detached / chrome:// 受限页 / CSP / 导航中)
+    // 会让历史回填退回空,与"确无历史"无法区分。至少 warn 出信号,便于诊断(review N0063)。
+    console.warn(
+      "[vortex] Resource Timing 历史回填失败,network 历史可能不完整:",
+      err instanceof Error ? err.message : String(err),
+    );
+    return [];
+  }
+}
+
 export function registerNetworkHandlers(
   router: ActionRouter,
   debuggerMgr: DebuggerManager,
@@ -277,10 +342,21 @@ export function registerNetworkHandlers(
       );
       await ensureSubscribed(debuggerMgr, tid);
       const includeResources = args.includeResources as boolean | undefined;
+      const pattern = (args.pattern ?? args.url) as string | undefined;
       const apis = apiLogs.get(tid) ?? [];
-      if (!includeResources) return apis;
-      const resources = resourceLogs.get(tid) ?? [];
-      return [...apis, ...resources].sort((a, b) => a.startTime - b.startTime);
+      const cdpResources = includeResources ? (resourceLogs.get(tid) ?? []) : [];
+      // BUG-003 (N0063): 回填 Resource Timing 历史 —— CDP 漏 enable 前的请求(首次 debug_read
+      // 之前的全丢)。dedup by URL 对 apis + cdpResources 都做,CDP 条目(有 method/status/
+      // headers)优先于 RT 摘要,避免 includeResources 时静态资源 CDP+RT 双现(review N0063)。
+      const rt = await readResourceTimingEntries(tid);
+      const seenUrls = new Set([...apis, ...cdpResources].map((a) => a.url));
+      const rtFresh = rt.filter((e) => !seenUrls.has(e.url));
+      let merged: NetworkEntry[] = [...apis, ...cdpResources, ...rtFresh];
+      // 默认只留 API 类(XHR/Fetch),滤掉静态资源噪声;includeResources 时全保留。
+      if (!includeResources) merged = merged.filter((e) => API_TYPES.has(e.type ?? ""));
+      // pattern 过滤(debug_read 必带 pattern;缺省则不滤)。
+      if (pattern) merged = merged.filter((e) => e.url.includes(pattern));
+      return merged.sort((a, b) => a.startTime - b.startTime);
     },
 
     [NetworkActions.GET_ERRORS]: async (args, tabId) => {

--- a/packages/extension/src/handlers/page.ts
+++ b/packages/extension/src/handlers/page.ts
@@ -2,6 +2,7 @@ import { PageActions, VtxErrorCode, vtxError } from "@vortex-browser/shared";
 import type { ActionRouter } from "../lib/router.js";
 import type { DebuggerManager } from "../lib/debugger-manager.js";
 import { buildExecuteTarget, ensureFrameAttached } from "../lib/tab-utils.js";
+import { resolveTargetOptional } from "../lib/resolve-target.js";
 
 async function getActiveTabId(tabId?: number): Promise<number> {
   if (tabId) return tabId;
@@ -279,12 +280,19 @@ export function registerPageHandlers(router: ActionRouter, debuggerMgr: Debugger
     },
 
     [PageActions.WAIT]: async (args, tabId) => {
-      const tid = await getActiveTabId(tabId);
-      const selector = args.selector as string | undefined;
+      // BUG-002 (N0063): 支持 @ref —— server.ts 把 @ref 翻成 index+snapshotId,这里经
+      // resolveTargetOptional 反查 selector(与 dom.* handler 同源,含 STALE_SNAPSHOT 防御);
+      // 纯 CSS selector 直接返回;两者都缺时返回 undefined,走下方无目标 plain-wait。
+      // 空串 selector 规范化为无目标:历史上 `if (selector)` 视其为 falsy 落 plain-wait,
+      // resolveTargetOptional 对 "" 非 null 会进 resolveTarget 抛 INVALID_PARAMS(review N0063)。
+      const targetArgs = args.selector === "" ? { ...args, selector: undefined } : args;
+      const __t = resolveTargetOptional(targetArgs);
+      const selector = __t?.selector;
+      const tid = await getActiveTabId(__t?.boundTabId ?? tabId);
       const timeout = (args.timeout as number) ?? 10_000;
 
       if (selector) {
-        const frameId = args.frameId as number | undefined;
+        const frameId = __t?.boundFrameId ?? (args.frameId as number | undefined);
         if (frameId != null) await ensureFrameAttached(tid, frameId);
         const result = await chrome.scripting.executeScript({
           target: buildExecuteTarget(tid, frameId),

--- a/packages/extension/tests/click-effect-synthetic.test.ts
+++ b/packages/extension/tests/click-effect-synthetic.test.ts
@@ -121,4 +121,25 @@ describe("合成 click 效果信号(GAP-G observeEffect)", () => {
     await router.dispatch(mkReq({ selector: "#btn", observeEffect: true }));
     expect(beginCalls).toEqual([["#btn", 300]]);
   });
+
+  // BUG-001 (N0063): 缺省 click(无 windowMs/observeEffect)走合成路径时,executeScript 的
+  // args 第 4 位 windowMs=undefined → 真 Chrome structured clone 拒 "Value is unserializable
+  // at index 3"(非 trusted 模式 100% 崩;trusted 走 CDP 不经此路径故掩盖)。Node 测 mock 不
+  // 校验序列化,故显式断言 args 无 undefined,锁住 structured-clone 安全契约。
+  it("BUG-001: 缺省 click 的 executeScript args 无 undefined(structured-clone 安全)", async () => {
+    let capturedArgs: unknown[] | undefined;
+    (globalThis as unknown as { chrome: { scripting: { executeScript: unknown } } }).chrome.scripting.executeScript =
+      async (opts: { func?: (...a: unknown[]) => unknown; args?: unknown[] }) => {
+        capturedArgs = opts.args;
+        if (typeof opts.func !== "function") return [{}];
+        const stripped = new Function(`return (${String(opts.func)})`)() as (...a: unknown[]) => unknown;
+        return [{ result: await Promise.resolve(stripped(...(opts.args ?? []))) }];
+      };
+    const resp = await router.dispatch(mkReq({ selector: "#btn" }));
+    expect(resp.error).toBeUndefined();
+    expect(capturedArgs).toBeDefined();
+    expect(capturedArgs!.some((a) => a === undefined)).toBe(false);
+    // args = [selector, cdpAvailable, observeEffect, windowMs];第 4 位须为 number(默认),非 undefined
+    expect(typeof capturedArgs![3]).toBe("number");
+  });
 });

--- a/packages/extension/tests/dom-fill-refocus.test.ts
+++ b/packages/extension/tests/dom-fill-refocus.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Author: qingwa
+ * Description: DESIGN-002 (N0063) FILL 后回焦契约。
+ *   fill 走原生 value setter 不触发 focus,React 受控组件 click→fill 链路常使
+ *   activeElement 停在 BODY(实测 bytenew 搜索框 fill 后 activeElement=BODY),
+ *   后续 vortex_press Enter 落不到 input → 搜索+回车整类失效。FILL 成功后须显式
+ *   focus 目标,让后续 press 命中。
+ *   复刻注入语义:mock pageQuery 用 new Function 剥离模块闭包真执行 inline func。
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { JSDOM } from "jsdom";
+import { DomActions } from "@vortex-browser/shared";
+import { ActionRouter } from "../src/lib/router.js";
+import { registerDomHandlers } from "../src/handlers/dom.js";
+import type { NmRequest } from "@vortex-browser/shared";
+
+vi.mock("../src/action/wait-actionable-auto-force.js", () => ({
+  waitActionableAutoForce: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../src/adapter/page-side-loader.js", () => ({
+  loadPageSideModule: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../src/lib/tab-utils.js", () => ({
+  getActiveTabId: vi.fn().mockResolvedValue(1),
+  buildExecuteTarget: vi.fn().mockReturnValue({ tabId: 1 }),
+  ensureFrameAttached: vi.fn().mockResolvedValue(undefined),
+}));
+// pageQuery 真执行 inline func(剥离模块闭包),操作下方 JSDOM 全局 document。
+vi.mock("../src/adapter/native.js", () => ({
+  pageQuery: async (
+    _tid: number,
+    _frameId: number | undefined,
+    fn: (...a: unknown[]) => unknown,
+    args: unknown[],
+  ) => {
+    const stripped = new Function(`return (${String(fn)})`)() as (...a: unknown[]) => unknown;
+    return await Promise.resolve(stripped(...args));
+  },
+  mapPageError: (res: { error?: string }) => {
+    throw new Error(res.error ?? "page error");
+  },
+}));
+
+function mkReq(args: Record<string, unknown>): NmRequest {
+  return { type: "tool_request", tool: DomActions.FILL, args, requestId: "r-1" } as NmRequest;
+}
+
+describe("FILL 后回焦 (DESIGN-002 N0063)", () => {
+  let router: ActionRouter;
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dom = new JSDOM(
+      `<!DOCTYPE html><html><body><input id="inp" placeholder="搜索" /></body></html>`,
+      { pretendToBeVisual: true },
+    );
+    const win = dom.window as unknown as Record<string, unknown>;
+    globalThis.window = dom.window as unknown as Window & typeof globalThis;
+    globalThis.document = dom.window.document as unknown as Document;
+    for (const g of ["HTMLElement", "HTMLInputElement", "HTMLTextAreaElement", "HTMLSelectElement", "Event", "InputEvent"]) {
+      (globalThis as Record<string, unknown>)[g] = win[g];
+    }
+
+    const inp = dom.window.document.getElementById("inp")!;
+    inp.getBoundingClientRect = () =>
+      ({ x: 10, y: 10, width: 100, height: 20, top: 10, bottom: 30, left: 10, right: 110 }) as DOMRect;
+
+    (win as Record<string, unknown>).__vortexDomResolve = {
+      queryAllDeep: (sel: string) => Array.from(dom.window.document.querySelectorAll(sel)),
+      isEnabled: () => true,
+    };
+    (win as Record<string, unknown>).__vortexFillReject = {
+      checkRejectPattern: () => ({ rejected: false }),
+    };
+
+    router = new ActionRouter();
+    const debuggerMgr = {
+      attach: vi.fn().mockResolvedValue(undefined),
+      sendCommand: vi.fn().mockResolvedValue(undefined),
+    };
+    registerDomHandlers(router, debuggerMgr as never);
+  });
+
+  it("fill 成功后 activeElement 是被填的 input(让后续 press 命中)", async () => {
+    const resp = await router.dispatch(mkReq({ selector: "#inp", value: "复测0611" }));
+    expect(resp.error).toBeUndefined();
+    // focused 反映真实 activeElement(非硬编码),happy path 应为 true
+    expect(resp.result).toMatchObject({ success: true, focused: true });
+    const inp = dom.window.document.getElementById("inp");
+    expect(dom.window.document.activeElement).toBe(inp);
+    expect((inp as HTMLInputElement).value).toBe("复测0611");
+  });
+});

--- a/packages/extension/tests/file-upload-target-ref.test.ts
+++ b/packages/extension/tests/file-upload-target-ref.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NmRequest } from "@vortex-browser/shared";
+import { FileActions } from "@vortex-browser/shared";
+import { ActionRouter } from "../src/lib/router.js";
+import { registerFileHandlers } from "../src/handlers/file.js";
+import { setSnapshot } from "../src/lib/snapshot-store.js";
+
+/**
+ * DESIGN-001 (N0063): vortex_file_upload 支持 @ref(target)。server.ts 把 @ref 翻成
+ * index+snapshotId 后,file.upload handler 须经 resolveTarget 反查 selector(与其它 14
+ * 工具一致),而非只读 args.selector。历史实现只认 args.selector → @ref 场景必报
+ * "Missing required params"。
+ */
+vi.mock("../src/adapter/page-side-loader.js", () => ({
+  loadPageSideModule: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../src/lib/tab-utils.js", () => ({
+  getActiveTabId: vi.fn().mockResolvedValue(7),
+  buildExecuteTarget: vi.fn((tabId: number) => ({ tabId })),
+  ensureFrameAttached: vi.fn().mockResolvedValue(undefined),
+}));
+
+function mkReq(args: Record<string, unknown>): NmRequest {
+  return { type: "tool_request", tool: FileActions.UPLOAD, args, requestId: "r-1" } as NmRequest;
+}
+
+describe("file.upload @ref 解析 (DESIGN-001 N0063)", () => {
+  let router: ActionRouter;
+  let executeScript: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executeScript = vi.fn().mockResolvedValue([{ result: { result: { success: true, fileName: "t.txt", size: 4 } } }]);
+    (globalThis as unknown as { chrome: unknown }).chrome = {
+      tabs: { query: vi.fn().mockResolvedValue([{ id: 7 }]) },
+      scripting: { executeScript },
+      downloads: { onChanged: { addListener: vi.fn() }, search: vi.fn() },
+    };
+    router = new ActionRouter();
+    const nm = { send: vi.fn() } as never;
+    const dispatcher = { emit: vi.fn() } as never;
+    registerFileHandlers(router, nm, dispatcher);
+  });
+
+  it("index+snapshotId(来自 @ref 翻译)→ resolveTarget 反查 selector 传给 executeScript", async () => {
+    setSnapshot("snap_f", {
+      tabId: 7,
+      capturedAt: Date.now(),
+      elements: [{ index: 9, selector: "#file" }],
+    });
+    const resp = await router.dispatch(
+      mkReq({ index: 9, snapshotId: "snap_f", fileName: "t.txt", fileContent: "dGVzdA==" }),
+    );
+    expect(resp.error).toBeUndefined();
+    expect(executeScript).toHaveBeenCalledTimes(1);
+    // 反查出的 selector "#file" 作 args[0] 传入 page-side func
+    expect(executeScript.mock.calls[0][0].args[0]).toBe("#file");
+  });
+
+  it("裸 selector(向后兼容)仍工作", async () => {
+    const resp = await router.dispatch(
+      mkReq({ selector: "#file2", fileName: "t.txt", fileContent: "dGVzdA==" }),
+    );
+    expect(resp.error).toBeUndefined();
+    expect(executeScript.mock.calls[0][0].args[0]).toBe("#file2");
+  });
+});

--- a/packages/extension/tests/network-resource-timing-backfill.test.ts
+++ b/packages/extension/tests/network-resource-timing-backfill.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NmRequest } from "@vortex-browser/shared";
+import { ActionRouter } from "../src/lib/router.js";
+
+/**
+ * BUG-003 (N0063): vortex_debug_read(source=network) → network.getLogs。CDP Network 仅捕获
+ * enable 之后的请求,首次 debug_read 之前已发生的请求全丢(实测 bytenew CDP 0 vs Resource
+ * Timing 250)。getLogs 须回填 page-side `performance.getEntriesByType('resource')` 历史
+ * (url/initiator/duration,无 method/status),按 pattern 过滤,默认只留 API 类滤静态噪声。
+ */
+let registerNetworkHandlers: typeof import("../src/handlers/network.js")["registerNetworkHandlers"];
+
+function mkReq(tool: string, args: Record<string, unknown> = {}, tabId?: number): NmRequest {
+  return { type: "tool_request", tool, args, requestId: "r-1", ...(tabId != null ? { tabId } : {}) } as NmRequest;
+}
+
+const RT_ENTRIES = [
+  { url: "https://x.com/api/orders", initiatorType: "fetch", startTime: 1000, duration: 12 },
+  { url: "https://x.com/api/user", initiatorType: "xmlhttprequest", startTime: 1001, duration: 8 },
+  { url: "https://x.com/static/app.js", initiatorType: "script", startTime: 1002, duration: 30 },
+];
+
+describe("network getLogs Resource Timing 回填 (BUG-003 N0063)", () => {
+  let router: ActionRouter;
+  let executeScript: ReturnType<typeof vi.fn>;
+  let onEventCb: ((tabId: number, method: string, params: unknown) => void) | undefined;
+
+  beforeEach(async () => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    router = new ActionRouter();
+    executeScript = vi.fn().mockResolvedValue([{ result: RT_ENTRIES }]);
+    onEventCb = undefined;
+    const dbg = {
+      enableDomain: vi.fn().mockResolvedValue(undefined),
+      isAttached: vi.fn().mockReturnValue(false),
+      sendCommand: vi.fn().mockResolvedValue({ body: "", base64Encoded: false }),
+      onEvent: vi.fn((cb: (t: number, m: string, p: unknown) => void) => { onEventCb = cb; }),
+      offEvent: vi.fn(),
+      attach: vi.fn().mockResolvedValue(undefined),
+    } as never;
+    vi.stubGlobal("chrome", {
+      tabs: { query: vi.fn().mockResolvedValue([{ id: 42 }]), onRemoved: { addListener: vi.fn() } },
+      scripting: { executeScript },
+    });
+    ({ registerNetworkHandlers } = await import("../src/handlers/network.js"));
+    registerNetworkHandlers(router, dbg, { send: vi.fn() } as never, { emit: vi.fn() } as never);
+  });
+
+  it("无 CDP 历史时,getLogs 回填 Resource Timing 的 API 类请求(pattern 过滤)", async () => {
+    const resp = await router.dispatch(mkReq("network.getLogs", { pattern: "/api/" }, 42));
+    expect(resp.error).toBeUndefined();
+    const logs = resp.result as Array<{ url: string }>;
+    const urls = logs.map((l) => l.url);
+    expect(urls).toContain("https://x.com/api/orders");
+    expect(urls).toContain("https://x.com/api/user");
+    // 静态 script 非 API 类,默认(无 includeResources)滤掉
+    expect(urls).not.toContain("https://x.com/static/app.js");
+  });
+
+  it("pattern 不匹配的条目被滤掉", async () => {
+    const resp = await router.dispatch(mkReq("network.getLogs", { pattern: "orders" }, 42));
+    const urls = (resp.result as Array<{ url: string }>).map((l) => l.url);
+    expect(urls).toEqual(["https://x.com/api/orders"]);
+  });
+
+  it("includeResources=true 时静态资源也回填", async () => {
+    const resp = await router.dispatch(mkReq("network.getLogs", { pattern: "x.com", includeResources: true }, 42));
+    const urls = (resp.result as Array<{ url: string }>).map((l) => l.url);
+    expect(urls).toContain("https://x.com/static/app.js");
+  });
+
+  it("includeResources=true 时 CDP 静态资源与 RT 同 URL 去重(CDP 优先,不双现)", async () => {
+    // 先订阅(getLogs 触发 ensureSubscribed),再经 onEvent 注入一个 CDP Script 请求 →
+    // 进 resourceLogs;RT 也含同 URL app.js → 应只出现一次(CDP 条目带 status,优先)。
+    await router.dispatch(mkReq("network.getLogs", { pattern: "x.com" }, 42));
+    const sameUrl = "https://x.com/static/app.js";
+    onEventCb!(42, "Network.requestWillBeSent", {
+      requestId: "rq1",
+      request: { url: sameUrl, method: "GET", headers: {} },
+      type: "Script",
+    });
+    onEventCb!(42, "Network.responseReceived", {
+      requestId: "rq1",
+      response: { status: 200, statusText: "OK", mimeType: "application/javascript", headers: {} },
+    });
+    const resp = await router.dispatch(
+      mkReq("network.getLogs", { pattern: "app.js", includeResources: true }, 42),
+    );
+    const logs = resp.result as Array<{ url: string; status?: number }>;
+    const appJs = logs.filter((l) => l.url === sameUrl);
+    expect(appJs).toHaveLength(1);
+    expect(appJs[0].status).toBe(200); // CDP 条目(有 status)胜出,非 RT 摘要
+  });
+});

--- a/packages/extension/tests/page-wait-ref-resolve.test.ts
+++ b/packages/extension/tests/page-wait-ref-resolve.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NmRequest } from "@vortex-browser/shared";
+import { ActionRouter } from "../src/lib/router.js";
+import { registerPageHandlers } from "../src/handlers/page.js";
+import { setSnapshot } from "../src/lib/snapshot-store.js";
+
+/**
+ * BUG-002 (N0063): page.wait(mode=element) 支持 @ref。server.ts 把 @ref 翻成
+ * index+snapshotId 后,WAIT handler 须经 resolveTarget 反查 selector(与 dom.* handler
+ * 同源),再用现有 querySelector 轮询。历史实现只读 args.selector,index+snapshotId
+ * 被忽略 → 落到无目标 plain-wait,等异步元素出现的诉求失效。
+ */
+function mkReq(args: Record<string, unknown>, tabId?: number): NmRequest {
+  return {
+    type: "tool_request",
+    tool: "page.wait",
+    args,
+    requestId: "r-1",
+    ...(tabId != null ? { tabId } : {}),
+  } as NmRequest;
+}
+
+function makeDebuggerMock() {
+  return {
+    enableDomain: vi.fn().mockResolvedValue(undefined),
+    onEvent: vi.fn(),
+    offEvent: vi.fn(),
+    sendCommand: vi.fn(),
+    attach: vi.fn().mockResolvedValue(undefined),
+    isAttached: vi.fn().mockReturnValue(true),
+  } as never;
+}
+
+describe("page.wait @ref 解析 (BUG-002 N0063)", () => {
+  let router: ActionRouter;
+  let executeScript: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    router = new ActionRouter();
+    executeScript = vi.fn().mockResolvedValue([{ result: true }]); // 元素已找到
+    vi.stubGlobal("chrome", {
+      tabs: { query: vi.fn().mockResolvedValue([{ id: 42 }]) },
+      scripting: { executeScript },
+      runtime: { getManifest: vi.fn().mockReturnValue({ host_permissions: ["<all_urls>"] }) },
+    });
+    registerPageHandlers(router, makeDebuggerMock());
+  });
+
+  it("index+snapshotId(来自 @ref 翻译)→ 经 resolveTarget 反查 selector 并轮询", async () => {
+    setSnapshot("snap_x", {
+      tabId: 42,
+      capturedAt: Date.now(),
+      elements: [{ index: 5, selector: "#inp" }],
+    });
+    const resp = await router.dispatch(
+      mkReq({ index: 5, snapshotId: "snap_x", timeout: 1000 }, 42),
+    );
+    expect(resp.error).toBeUndefined();
+    expect(resp.result).toMatchObject({ found: true, selector: "#inp" });
+    // executeScript 收到反查出的 selector 作 args[0]
+    expect(executeScript).toHaveBeenCalledTimes(1);
+    expect(executeScript.mock.calls[0][0].args[0]).toBe("#inp");
+  });
+
+  it("纯 CSS selector 仍直接轮询(无回归)", async () => {
+    const resp = await router.dispatch(
+      mkReq({ selector: ".btn", timeout: 1000 }, 42),
+    );
+    expect(resp.error).toBeUndefined();
+    expect(resp.result).toMatchObject({ found: true, selector: ".btn" });
+  });
+
+  it("无 target(纯等待)→ 不调 executeScript,走 plain wait", async () => {
+    const resp = await router.dispatch(mkReq({ timeout: 30 }, 42));
+    expect(resp.error).toBeUndefined();
+    expect(resp.result).toMatchObject({ waited: 30 });
+    expect(executeScript).not.toHaveBeenCalled();
+  });
+
+  // 空串 selector 历史上是 falsy → 落 plain-wait;改用 resolveTargetOptional 后 "" 非 null
+  // 会进 resolveTarget 抛 INVALID_PARAMS。规范化为无目标,保持旧行为不回归(review N0063)。
+  it("空串 selector → plain wait(不抛 INVALID_PARAMS,保持旧行为)", async () => {
+    const resp = await router.dispatch(mkReq({ selector: "", timeout: 30 }, 42));
+    expect(resp.error).toBeUndefined();
+    expect(resp.result).toMatchObject({ waited: 30 });
+    expect(executeScript).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mcp/src/lib/wait-for-ref.ts
+++ b/packages/mcp/src/lib/wait-for-ref.ts
@@ -1,0 +1,23 @@
+/**
+ * BUG-002 (N0063): wait_for(mode=element) 的 @ref 经 `value` 字段传入(其它 14 个工具走
+ * `target`),不会命中 server.ts 的 target→{index,snapshotId,frameId} 翻译链,历史实现因此
+ * 直接 throw "@ref form not supported here",破坏全程 ref 心智模型。
+ *
+ * 本 helper 在 server.ts target 翻译**之前**调用:把 @ref 形式的 value 抬成 target,复用同一
+ * 条翻译 + STALE/tab 校验(dispatch 拿不到 activeSnapshot 状态无法自译,故必须在 server 层做)。
+ * CSS selector 形式的 value(不以 @ 开头)保持不动,由 dispatch 的 element 分支按 selector 透传。
+ */
+export function liftWaitForRefToTarget(
+  toolName: string,
+  params: Record<string, unknown>,
+): void {
+  if (
+    toolName === "vortex_wait_for" &&
+    params.mode === "element" &&
+    typeof params.value === "string" &&
+    (params.value as string).startsWith("@")
+  ) {
+    params.target = params.value;
+    delete params.value;
+  }
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -16,6 +16,7 @@ import { sendRequest } from "./client.js";
 import { getToolDefs, getToolDef } from "./tools/registry.js";
 import { dispatchNewTool } from "./tools/dispatch.js";
 import { computeTransportTimeout } from "./lib/timeout.js";
+import { liftWaitForRefToTarget } from "./lib/wait-for-ref.js";
 export { dispatchNewTool };
 
 // Read package.json via createRequire so the bundle works under both ts-node
@@ -378,6 +379,10 @@ export async function handleCallTool(
     const resultText = JSON.stringify(resp.result, null, 2) ?? "undefined";
     return withEvents([{ type: "text" as const, text: resultText }]);
   }
+
+  // BUG-002 (N0063): wait_for(mode=element) 的 @ref 经 value 字段传入,这里抬成 target,
+  // 复用下方同一条翻译链 + STALE/tab 校验(dispatch 拿不到 snapshot 状态无法自译)。
+  liftWaitForRefToTarget(toolDef.name, params);
 
   // target 翻译：@eN / @fNeM → { index, snapshotId, frameId }
   const target = params.target as string | undefined;

--- a/packages/mcp/src/tools/dispatch.ts
+++ b/packages/mcp/src/tools/dispatch.ts
@@ -213,11 +213,15 @@ export function dispatchNewTool(
       if (timeout !== undefined) next.timeout = timeout;
       switch (mode) {
         case "element": {
-          // value 不经 server.ts target translation；@ref 形式手动展开
+          // BUG-002 (N0063): @ref 形式的 value 已由 server.ts liftWaitForRefToTarget 抬成
+          // target 并翻译成 selector / index+snapshotId+frameId(随 ...rest 流入 next),这里
+          // 不会再见到 @ref。剩下的 value 是裸 CSS selector,直接透传为 selector。
           if (typeof value === "string" && value.startsWith("@")) {
+            // 防御:正常流不可达(server 已翻译)。若仍见到 @ref,说明无 active snapshot 等
+            // 上游异常,响亮报错而非把 @ref 当 selector 静默失败。
             throw vtxError(
-              VtxErrorCode.INVALID_PARAMS,
-              "wait_for(mode=element): @ref form not supported here. Pass a CSS selector as value.",
+              VtxErrorCode.STALE_SNAPSHOT,
+              "wait_for(mode=element): @ref could not be resolved (no active snapshot — call vortex_observe first).",
             );
           }
           if (value !== undefined) next.selector = value;

--- a/packages/mcp/src/tools/schemas-public.ts
+++ b/packages/mcp/src/tools/schemas-public.ts
@@ -315,13 +315,14 @@ export const PUBLIC_TOOLS: ToolDef[] = [
     schema: {
       type: "object",
       properties: {
+        target: TargetOptional,
         selector: { type: "string" },
         fileName: { type: "string" },
         fileContent: { type: "string" },
         mimeType: { type: "string" },
         ...tabFields,
       },
-      required: ["selector", "fileName", "fileContent"],
+      required: ["fileName", "fileContent"],
     },
     // Submits attacker-chosen bytes to whatever endpoint the page form posts to.
     annotations: { destructiveHint: true, openWorldHint: true },

--- a/packages/mcp/tests/invariants/I16.dispatch-routing.test.ts
+++ b/packages/mcp/tests/invariants/I16.dispatch-routing.test.ts
@@ -102,9 +102,13 @@ describe("I16: dispatch routing for 11 public tools", () => {
       expect(r?.params.selector).toBe("#submit");
     });
 
-    it("mode=element + @ref throws INVALID_PARAMS（value 不经 server.ts target 翻译）", () => {
+    // BUG-002 (N0063): @ref 现已支持 —— server.ts liftWaitForRefToTarget 在 dispatch 前把
+    // @ref value 抬成 target 并翻译成 index+snapshotId(端到端见 wait-for-ref-target /
+    // page-wait-ref-resolve 测试)。到 dispatch 仍见 @ref 表示上游未翻译(无 active snapshot
+    // 等异常),防御性抛 STALE_SNAPSHOT 而非把 @ref 当 selector 静默失败。
+    it("mode=element + 未翻译的 @ref → 防御性 STALE_SNAPSHOT(正常流由 server.ts 翻译)", () => {
       expect(() => dispatchNewTool("vortex_wait_for", { mode: "element", value: "@e3" }))
-        .toThrowError(/INVALID_PARAMS|@ref form not supported/);
+        .toThrowError(/STALE_SNAPSHOT|no active snapshot/);
     });
 
     it("mode=idle value=network → page.waitForNetworkIdle", () => {

--- a/packages/mcp/tests/vortex-wait-for-description.test.ts
+++ b/packages/mcp/tests/vortex-wait-for-description.test.ts
@@ -78,9 +78,11 @@ describe("vortex_wait_for dispatch 行为 (B3-1, 回归保护)", () => {
     expect(r?.params.selector).toBe(".loaded");
   });
 
-  it("mode:element + @ref 抛错 (显式引导用 CSS selector)", () => {
+  // BUG-002 (N0063): @ref 现已支持(server.ts 翻译);dispatch 层见到未翻译 @ref 防御性抛
+  // STALE_SNAPSHOT(端到端正常流见 wait-for-ref-target / page-wait-ref-resolve 测试)。
+  it("mode:element + 未翻译 @ref → STALE_SNAPSHOT(正常流由 server.ts 翻译)", () => {
     expect(() => dispatchNewTool("vortex_wait_for", { mode: "element", value: "@e15" }))
-      .toThrow(/CSS selector/);
+      .toThrow(/STALE_SNAPSHOT|no active snapshot/);
   });
 
   it("mode:custom + JS expression → page.waitForExpression + expression 字段", () => {

--- a/packages/mcp/tests/wait-for-ref-target.test.ts
+++ b/packages/mcp/tests/wait-for-ref-target.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { liftWaitForRefToTarget } from "../src/lib/wait-for-ref.js";
+
+/**
+ * BUG-002 (N0063): wait_for(mode=element) 的 @ref 经 value 字段传入(非 target),
+ * 绕过 server.ts 的 target→{index,snapshotId} 翻译链 → 历史上直接 throw
+ * "@ref form not supported here"。liftWaitForRefToTarget 在翻译前把 @ref 形式的
+ * value 抬成 target,复用同一条翻译+STALE 校验。CSS selector / 其它 mode / 其它工具
+ * 保持原样。
+ */
+describe("liftWaitForRefToTarget (BUG-002 N0063)", () => {
+  it("wait_for mode=element + @ref value → 抬成 target,删 value", () => {
+    const params: Record<string, unknown> = { mode: "element", value: "@be58:e13", timeout: 3000 };
+    liftWaitForRefToTarget("vortex_wait_for", params);
+    expect(params.target).toBe("@be58:e13");
+    expect("value" in params).toBe(false);
+    expect(params.timeout).toBe(3000);
+  });
+
+  it("wait_for mode=element + CSS selector value → 保持 value 不动(走 dispatch selector 透传)", () => {
+    const params: Record<string, unknown> = { mode: "element", value: ".btn" };
+    liftWaitForRefToTarget("vortex_wait_for", params);
+    expect(params.value).toBe(".btn");
+    expect("target" in params).toBe(false);
+  });
+
+  it("wait_for mode=idle + @ref-looking value → 不动(idle 的 value 是 network/dom 语义)", () => {
+    const params: Record<string, unknown> = { mode: "idle", value: "network" };
+    liftWaitForRefToTarget("vortex_wait_for", params);
+    expect(params.value).toBe("network");
+    expect("target" in params).toBe(false);
+  });
+
+  it("其它工具(含 @ 形 value)→ 不动", () => {
+    const params: Record<string, unknown> = { mode: "element", value: "@be58:e1" };
+    liftWaitForRefToTarget("vortex_act", params);
+    expect(params.value).toBe("@be58:e1");
+    expect("target" in params).toBe(false);
+  });
+});


### PR DESCRIPTION
## 背景

来自 N0063 bytenew 工作台评测报告的核实订正。评测报告原列 3 P0 + 4 P1,经**白盒锁源 + 实机黑盒复现**逐项核实后(详见知识库 N0063 V2 订正文档):4 项根因完全准确、1 项需限定(BUG-001 环境依赖)、2 项含误诊(DESIGN-001 observe 漏 file input 被证伪 / DESIGN-004 header 已存在)。本 PR 实现其中**确认为真且高价值的 5 项**(P0×3 + P1×2),全程 TDD。

## 改动

### Phase 1(`834467d`)

- **BUG-001 (P0)** — `vortex_act click` 默认崩溃:合成路径 `executeScript` 的 args 第 4 位 `windowMs` 缺省为 `undefined`,被 structured clone 拒(`unserializable at index 3`),**非 trusted Chrome 默认 click 100% 崩**(trusted 走 CDP 不经此路径,故 bench 与本机均被掩盖)。修:`dom.ts:421` `windowMs ?? 300`(对齐 page-side `click-effect.ts`;`?? 0` 会因 0 非 nullish 把效果窗口塌成 0ms)。
- **DESIGN-002 (P1)** — `vortex_fill` 后失焦:fill 成功后 `activeElement` 停在 BODY → 后续 `vortex_press` Enter 落不到 input,搜索+回车整类失效。修:FILL 成功后 `el.focus({preventScroll})`,`focused` 字段反映真实 activeElement。
- **BUG-002 (P0)** — `vortex_wait_for(mode=element)` 拒收 `@ref`:协议割裂(其它 14 工具全支持 ref)。修:`server.ts` 新 `liftWaitForRefToTarget` 把 @ref 形 `value` 抬成 `target` 复用现成翻译链;`page.ts` WAIT 经 `resolveTargetOptional` 反查 selector(支持 index+snapshotId);空串 selector 规范化保 plain-wait。

### Phase 2(`19effe0`)

- **DESIGN-001 (P1)** — `vortex_file_upload` 不接 ref:14/15 工具支持 `target`,仅它例外。修:schema 加 `target`,`file.ts` 改 `resolveTarget`+`buildExecuteTarget`+`queryAllDeep`(穿 open shadow / 支持 iframe 与 @ref),保留 `selector` 向后兼容。(注:报告另称"observe 漏 file input"经实机证伪——`input:not([type=hidden])` 已收,故未改 observe。)
- **BUG-003 (P1)** — `vortex_debug_read(source=network)` 历史 0 条:CDP Network 仅捕获 enable 之后的请求,首次 debug_read 前的全丢(实测 bytenew CDP 0 vs Resource Timing 250)。修:`getLogs` 回填 `performance.getEntriesByType('resource')` 历史(url/initiator/duration,无 method/status=RT 固有限制),dedup by URL(CDP 优先)+ pattern 过滤 + 默认只留 API 类滤静态噪声;executeScript 失败 warn 不静默吞。

## 测试

- **单元(TDD,全程 RED→GREEN)**:新增 6 个测试文件;`ext 989 + mcp 413` 全过。
- **Code review**:2 并行 reviewer agent,判**无契约破坏 bug**;采纳 5 项低 severity 加固(focused 诚实化 / 空串 selector 不回归 / network dedup 含 cdpResources / executeScript 失败 warn / 复用共享 getActiveTabId)。
- **实机黑盒验收**(vortex MCP 驱动 bytenew):
  - BUG-002 `wait_for({mode:element,value:@ref})` → `{found:true}`(旧 INVALID_PARAMS)
  - DESIGN-002 fill 后 `activeElement=INPUT`(旧 BODY)
  - BUG-003 `debug_read({source:network,pattern:bytenew})` → **27 条历史 API**(旧 `[]`)
  - DESIGN-001 注入 file input → `file_upload({target:@ref})` 成功 + change 触发(旧报 Missing)
  - BUG-001 本机 trusted 走 CDP 不复现,已白盒确认崩溃点唯一在合成路径
- **bench**:`--all` **88/88 pass** + `diff` exit 0 无结构回归(关键 `vortex-debug-read-network` / `i-file-upload-observe` 均 `= unchanged`)。

## 备注

- BUG-001 须知:仅非 trusted Chrome(无 `--silent-debugger-extension-api`)复现;真实 LLM agent 跑普通 Chrome 即 100% 命中,故仍为真 P0。建议后续补真 Chrome 集成测试(Node 单测的 executeScript mock 不校验 structured-clone,抓不到)。
- 报告 2 处误诊(DESIGN-001 observe / DESIGN-004 header)未纳入实现,已在 V2 订正文档说明。
- 余 P2/P3(storage key 命名 / observe attrs / DESIGN-003 icon 大小写 / DESIGN-004 ref 生命周期 header)属低优先,未在本 PR。