### PR TITLE
fix(observe): iconFontName 保留原 class 大小写 (DESIGN-003 N0063)

### DIFF
--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -520,7 +520,10 @@ async function scanOneFrame(
             if (ICON_FONT_MODIFIERS.has(lower)) continue;
             for (const p of ICON_FONT_PREFIXES) {
               if (lower.startsWith(p) && lower.length > p.length) {
-                return lower.slice(p.length).replace(/-/g, " ");
+                // DESIGN-003 (N0063): 前缀匹配大小写无关,但返回保留原 token 大小写
+                // (与 aria-label/text 路径对称)。c.slice 而非 lower.slice:icon-addCube→
+                // "addCube" 不再压成 "addcube",可读 + 可反查 [class*="addCube"]。
+                return c.slice(p.length).replace(/-/g, " ");
               }
             }
           }
@@ -532,7 +535,9 @@ async function scanOneFrame(
             for (const c of tokens) {
               const lower = c.toLowerCase();
               if (lower.startsWith("icon-") && lower.length > 5) {
-                return lower.slice(5).replace(/-/g, " ");
+                // DESIGN-003 (N0063): 保留原大小写(c.slice 非 lower.slice),icon-addCube→
+                // "addCube"。与上方前缀分支 + 测试副本 WICON_BRANCH 同步。
+                return c.slice(5).replace(/-/g, " ");
               }
             }
           }

--- a/packages/extension/tests/observe-icon-font-name.test.ts
+++ b/packages/extension/tests/observe-icon-font-name.test.ts
@@ -78,7 +78,7 @@ const WICON_BRANCH = `
   if (tokens.includes("wicon")) {
     for (const c of tokens) {
       const lower = c.toLowerCase();
-      if (lower.startsWith("icon-") && lower.length > 5) return lower.slice(5).replace(/-/g, " ");
+      if (lower.startsWith("icon-") && lower.length > 5) return c.slice(5).replace(/-/g, " ");
     }
   }
   return "";
@@ -98,5 +98,15 @@ describe("iconFontName 班牛 wicon 分支(行为)", () => {
   });
   it("有 wicon 但无 icon- 类 → ''", () => {
     expect(wiconName("wicon w-font-more")).toBe("");
+  });
+
+  // DESIGN-003 (N0063): 保留原 class 大小写。原实现全链路 toLowerCase,把 icon-addCube
+  // 压成 "addcube",既不可读也无法反查原 class([class*="addCube"])。匹配前缀仍可大小写
+  // 无关,但返回的图标名须保留原 token 大小写(与 aria-label/text 路径对称,它们都不小写)。
+  it("wicon + icon-addCube → 'addCube'(保留驼峰,不小写化)", () => {
+    expect(wiconName("wicon icon-addCube el-popover__reference")).toBe("addCube");
+  });
+  it("wicon + icon-FlowChart → 'FlowChart'(保留首字母大写)", () => {
+    expect(wiconName("wicon icon-FlowChart")).toBe("FlowChart");
   });
 });


### PR DESCRIPTION
## 背景

N0063 评测报告 DESIGN-003。`vortex_observe` 对无 aria-label/text 的图标按钮从 icon 字体类派生 fallback name,但**全链路 toLowerCase** 把 `icon-addCube` 压成 `"addcube"`。

## 重现(实机 bytenew)

`<div class="appletMenu-top-btn wicon icon-addCube ...">` → observe 输出 `div "addcube"`。问题:① 不可读 ② 无法反查原 class(`.addcube` NOT_FOUND / `.icon-addCube` FOUND)③ 与 aria-label/text 命名路径不对称(后者不小写)。

## 根因 + 方案(根治,非头痛医头)

`observe.ts:iconFontName` 在前缀分支与 wicon 分支都 `return lower.slice(...)`。前缀匹配本就用 `lower` 做大小写无关检测,但**返回值不该丢大小写**。改为 `return c.slice(...)`(原 token),与所有其它 name 来源对称。

## 测试

- TDD RED→GREEN:`observe-icon-font-name.test.ts` 加 2 行为测试(icon-addCube→addCube / icon-FlowChart→FlowChart),同步更新测试副本 WICON_BRANCH。
- `ext 991` 全过。
- **实机**:observe 输出 `div "addcube"` → `div "addCube"`。
- **bench 88/88 + diff exit 0 无回归**(唯一 icon-font case `bi-star` 本就小写,c.slice/lower.slice 结果相同)。

## 备注:N0063 余 P2/P3 经实机重现判为非缺陷,不修

- **storage key 命名**:`Mozilla/5.0...umidSessionTimestamp...` 是页面自身的阿里/淘宝反欺诈指纹 SDK 复合 key,vortex 如实报告;截断会破坏 `get`。误诊。
- **extract 表格分隔符**:extract 实返 `\t\n` 单元格分隔(浏览器 innerText 规范),报告"无分隔符"前提不成立;真问题(空单元格列对齐)需结构化表格提取=新特性,非本项。
- **observe attrs.class**:LLM 走 `ref` 操作非 CSS 反查,加 200+ 字符 class 为非目标膨胀输出。
- **DESIGN-004 ref header**:header 已有 SnapshotId/URL/Title/Viewport;STALE_SNAPSHOT 错误+hint 已自纠正,加每次 observe 警告纯噪声税。