### PR TITLE
fix(observe): 弹层内自定义交互项漏抓 + bnCheck 识别为 checkbox (N0064)

### DIFF
--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -245,6 +245,80 @@ export function applyReactClickableMarker(
   return { reactClickable: true, clickHint: REACT_CLICKABLE_HINT };
 }
 
+/**
+ * 跨池祖先短路的"原子控件 vs 聚焦容器"判据(N0064 D6 dogfood 根因)。
+ *
+ * cursor:pointer fallback 收候选时会跳过"祖先链上已有 INTERACTIVE_SELECTORS 元素"
+ * 的子项,避免 `<button><span cursor:pointer>` 双现。但 Element UI 2.x 的浮层容器
+ * (el-popover/el-dialog/el-drawer)自带 `tabindex="0"` + `role="tooltip|dialog"`,
+ * 因 `[tabindex]:not([-1])` 进池却**不是原子点击目标**——它只是聚焦/浮层容器,内部的
+ * bnCheck / el-dropdown-menu__item 等自定义控件是独立目标。短路若把这类容器当原子控件,
+ * 会把整层弹窗内容全吞掉(实机:columnDisplay 9 列 checkbox 全丢)。
+ *
+ * 判据:祖先 role ∈ 容器角色集(grouping/overlay,不描述子树),或它仅因 tabindex 入池
+ * (不匹配任何原子控件选择器)→ 视为聚焦容器,短路**不**应触发。真原子控件
+ * (button/a/[role=button|menuitem|option…]/label/[onclick] 等)仍触发短路防双现。
+ *
+ * Why export:供 `observe-focus-container-suppress.test.ts` jsdom 直测真源;inject func
+ * 内联同语义副本(closure 注入无法 import),改一处须同步另一处,源码锁守护。
+ */
+export const FOCUS_CONTAINER_ROLES = new Set<string>([
+  "tooltip",
+  "dialog",
+  "alertdialog",
+  "group",
+  "region",
+  "menu",
+  "listbox",
+  "tree",
+  "grid",
+  "table",
+  "tabpanel",
+  "navigation",
+  "toolbar",
+  "document",
+  "application",
+  "none",
+  "presentation",
+]);
+export const ATOMIC_INTERACTIVE_SELECTORS =
+  "button,a[href],summary,input:not([type=hidden]),select,textarea,label,[role=button],[role=link],[role=textbox],[role=checkbox],[role=radio],[role=tab],[role=menuitem],[role=treeitem],[role=option],[contenteditable],[onclick]";
+export function isFocusContainerOnly(el: Element): boolean {
+  const role = el.getAttribute("role")?.trim().split(/\s+/)[0];
+  if (role && FOCUS_CONTAINER_ROLES.has(role)) return true;
+  return !el.matches(ATOMIC_INTERACTIVE_SELECTORS);
+}
+
+/**
+ * 班牛(bytenew)bnCheck 自定义勾选控件识别(N0064 P2-1 dogfood)。
+ *
+ *   <div class="bnCheck"><span class="bnCheck-status[ checked]">…</span>
+ *        <span class="bnCheck-label">名</span></div>
+ *
+ * 无 role / 无原生 <input> / 无 aria-checked,勾选态是 `.bnCheck-status` 上的**裸**
+ * `checked` class。getRole 因此返 tag(span),controlRoleFromClass 末位 token 规则
+ * 抓不到缩写 "bnCheck"(≠checkbox),getUiState 的 is-checked/aria/native 路径也全漏
+ * (checked 落在后代 status span)。本判据从 collected 元素(常是 bnCheck-label)上溯
+ * ≤5 层命中 `.bnCheck` 根 → role=checkbox + checked。只覆盖实机验证过的 bnCheck,
+ * 不臆测 bnRadio(未复现)。
+ *
+ * Why export:供 `observe-bncheck-checkbox.test.ts` jsdom 直测真源;inject func 注入丢
+ * 模块作用域不能 import,内联同语义副本,改一处须同步(源码锁守护)。
+ */
+export function bnCheckInfo(el: Element): { role: "checkbox"; checked: boolean } | null {
+  let root: Element | null = null;
+  for (let p: Element | null = el, d = 0; p && d < 5; p = p.parentElement, d++) {
+    const cls = typeof p.className === "string" ? p.className : "";
+    if (/(^|\s)bnCheck(\s|$)/.test(cls)) {
+      root = p;
+      break;
+    }
+  }
+  if (!root) return null;
+  const status = root.querySelector(".bnCheck-status");
+  return { role: "checkbox", checked: !!status && status.classList.contains("checked") };
+}
+
 async function scanOneFrame(
   tabId: number,
   frameId: number,
@@ -347,6 +421,26 @@ async function scanOneFrame(
           "paragraph",
         ]);
 
+        // bnCheckInfo 内联副本——真源见导出函数(可单测),inject func 注入丢模块作用域
+        // 不能 import,改一处须同步(源码锁守护)。班牛 bnCheck 自定义勾选控件:无 role/无
+        // 原生 input/无 aria-checked,勾选态 = 后代 .bnCheck-status 上裸 `checked` class。
+        // 上溯 ≤5 层命中 .bnCheck 根 → checkbox + checked(N0064 P2-1)。
+        const bnCheckInfo = (
+          el: Element,
+        ): { role: "checkbox"; checked: boolean } | null => {
+          let root: Element | null = null;
+          for (let p: Element | null = el, d = 0; p && d < 5; p = p.parentElement, d++) {
+            const cls = typeof p.className === "string" ? p.className : "";
+            if (/(^|\s)bnCheck(\s|$)/.test(cls)) {
+              root = p;
+              break;
+            }
+          }
+          if (!root) return null;
+          const status = root.querySelector(".bnCheck-status");
+          return { role: "checkbox", checked: !!status && status.classList.contains("checked") };
+        };
+
         function getRole(el: Element): string {
           const explicit = el.getAttribute("role");
           if (explicit) {
@@ -380,6 +474,8 @@ async function scanOneFrame(
           // <summary> 是 disclosure 开合控件,交互模型等同按钮,role 报 button 让
           // LLM 直接理解为可点(原生 <details>/<summary>,2026-06-02 dogfood)。
           if (tag === "summary") return "button";
+          // 班牛 bnCheck 自定义勾选控件(无 role/无原生 input)→ checkbox(N0064 P2-1)。
+          if (bnCheckInfo(el)) return "checkbox";
           return tag;
         }
 
@@ -966,6 +1062,12 @@ async function scanOneFrame(
               s.checked = true;
             }
           }
+          // 班牛 bnCheck:勾选态 = 后代 .bnCheck-status 的裸 `checked` class,既非
+          // is-checked 也非 aria/native,上面全漏——单独补(N0064 P2-1)。
+          if (s.checked === undefined) {
+            const bn = bnCheckInfo(el);
+            if (bn && bn.checked) s.checked = true;
+          }
           // 禁用判定用 :disabled 伪类而非 IDL .disabled 属性:<fieldset disabled>
           // 会级联禁用内部所有控件(浏览器真禁用、阻断交互),但子控件的 IDL
           // .disabled 仍返 false——只有 :disabled 伪类反映级联真状态(同样覆盖
@@ -1287,6 +1389,24 @@ async function scanOneFrame(
         // 自身可点的内容卡(京东 _card)保留入池。
         const isSelfClickable = (el: Element): boolean =>
           getComputedStyle(el).cursor === "pointer" || hasFrameworkClick(el);
+        // isFocusContainerOnly 内联副本——真源见导出函数(可单测),inject func 注入丢
+        // 模块作用域不能 import,改一处须同步另一处(源码锁守护)。判据:祖先 role ∈
+        // 容器角色集 或 仅靠 tabindex 入池(非原子控件)→ 聚焦/浮层容器(Element UI
+        // el-popover/el-dialog/el-drawer 自带 tabindex=0+role=tooltip|dialog),它不
+        // 描述子树,下方跨池祖先短路不应因它跳过其 cursor:pointer 子项(N0064 D6
+        // columnDisplay 9 列 bnCheck 全丢)。
+        const FOCUS_CONTAINER_ROLES = new Set([
+          "tooltip", "dialog", "alertdialog", "group", "region", "menu",
+          "listbox", "tree", "grid", "table", "tabpanel", "navigation",
+          "toolbar", "document", "application", "none", "presentation",
+        ]);
+        const ATOMIC_INTERACTIVE_SELECTORS =
+          "button,a[href],summary,input:not([type=hidden]),select,textarea,label,[role=button],[role=link],[role=textbox],[role=checkbox],[role=radio],[role=tab],[role=menuitem],[role=treeitem],[role=option],[contenteditable],[onclick]";
+        const isFocusContainerOnly = (anc: Element): boolean => {
+          const role = anc.getAttribute("role")?.trim().split(/\s+/)[0];
+          if (role && FOCUS_CONTAINER_ROLES.has(role)) return true;
+          return !anc.matches(ATOMIC_INTERACTIVE_SELECTORS);
+        };
         for (const el of Array.from(fallbackPool)) {
           if (cursorPointerExtras.length >= FALLBACK_CAP) break;
           if (interactiveSet.has(el)) continue;
@@ -1316,9 +1436,13 @@ async function scanOneFrame(
           // `<span cursor:pointer>`、`<button>` 包装饰 span 等），整个 ARIA
           // 子树由 ARIA 池独家表述，fallback 跳过避免双现 dual-instance。
           // 走 parentElement 链，命中第一个 ARIA 祖先即停（O(depth)）。
+          // 例外:仅因 tabindex 可聚焦的浮层容器(Element UI el-popover/el-dialog/
+          // el-drawer:tabindex=0 + role=tooltip|dialog)不是原子点击目标,它不
+          // 描述子树——isFocusContainerOnly 跳过它,否则整层弹窗 cursor:pointer 子项
+          // (bnCheck/el-dropdown-menu__item)被全吞(N0064 D2/D3/D5/D6/D8)。
           let hasInteractiveAncestor = false;
           for (let p = el.parentElement; p && p !== docBody; p = p.parentElement) {
-            if (interactiveSet.has(p)) {
+            if (interactiveSet.has(p) && !isFocusContainerOnly(p)) {
               hasInteractiveAncestor = true;
               break;
             }

--- a/packages/extension/tests/observe-bncheck-checkbox.test.ts
+++ b/packages/extension/tests/observe-bncheck-checkbox.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Author: qingwa
+ * Description: N0064 P2-1 班牛 dogfood —— observe 把 bnCheck 自定义勾选控件识别为
+ *   checkbox role + checked 状态。
+ *
+ *   实机解剖(列表设置弹窗 9 列,2026-06-12):bnCheck 是班牛自定义 Vue 控件,
+ *     <div class="bnCheck"><span class="bnCheck-status[ checked]"><span
+ *      class="bnCheck-status-inner"/></span><span class="bnCheck-label">名</span></div>
+ *   无 role / 无原生 <input> / 无 aria-checked;勾选态 = .bnCheck-status 上的**裸**
+ *   `checked` class(蓝),无则未选(灰)。leaf-selection 收 bnCheck-label(span)。
+ *
+ *   两个缺口:① getRole 返 tag(span);controlRoleFromClass 末位 token 规则抓不到
+ *   缩写 "bnCheck"(≠checkbox)。② getUiState 查 is-checked/aria/native 全漏(checked
+ *   在后代 status span 的裸 class)。bnCheckInfo 统一识别:上溯命中 .bnCheck 根 →
+ *   role=checkbox,checked 读 .bnCheck-status.checked。
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { JSDOM } from "jsdom";
+import { bnCheckInfo } from "../src/handlers/observe.js";
+
+describe("bnCheckInfo (N0064 P2-1: 班牛 bnCheck → checkbox + checked)", () => {
+  let document: Document;
+  const makeBnCheck = (label: string, checked: boolean): Element => {
+    const root = document.createElement("div");
+    root.className = "bnCheck w-default-wrap";
+    const status = document.createElement("span");
+    status.className = checked ? "bnCheck-status checked" : "bnCheck-status";
+    const inner = document.createElement("span");
+    inner.className = "bnCheck-status-inner";
+    status.appendChild(inner);
+    const lab = document.createElement("span");
+    lab.className = "bnCheck-label";
+    lab.textContent = label;
+    root.append(status, lab);
+    document.body.appendChild(root);
+    return root;
+  };
+
+  beforeEach(() => {
+    document = new JSDOM("<!DOCTYPE html><body></body>").window.document;
+  });
+
+  it("从 bnCheck-label(collected leaf)上溯识别为 checkbox", () => {
+    const root = makeBnCheck("工单编号", false);
+    const label = root.querySelector(".bnCheck-label")!;
+    const info = bnCheckInfo(label);
+    expect(info).not.toBeNull();
+    expect(info!.role).toBe("checkbox");
+  });
+
+  it("checked: .bnCheck-status 有 checked class → true", () => {
+    const root = makeBnCheck("创建时间", true);
+    const label = root.querySelector(".bnCheck-label")!;
+    expect(bnCheckInfo(label)!.checked).toBe(true);
+  });
+
+  it("unchecked: .bnCheck-status 无 checked class → false", () => {
+    const root = makeBnCheck("修改时间", false);
+    const label = root.querySelector(".bnCheck-label")!;
+    expect(bnCheckInfo(label)!.checked).toBe(false);
+  });
+
+  it("bnCheck 根自身也能识别(非仅 label)", () => {
+    const root = makeBnCheck("执行人", true);
+    expect(bnCheckInfo(root)!.role).toBe("checkbox");
+    expect(bnCheckInfo(root)!.checked).toBe(true);
+  });
+
+  it("非 bnCheck 元素返 null(普通 cursor:pointer span)", () => {
+    const span = document.createElement("span");
+    span.className = "w-cursor-pointer";
+    span.textContent = "普通文本";
+    document.body.appendChild(span);
+    expect(bnCheckInfo(span)).toBeNull();
+  });
+
+  it("class 前缀相近但非 bnCheck 不误判(bnCheckbox/bnChecklist)", () => {
+    const a = document.createElement("div");
+    a.className = "bnCheckbox-foo";
+    a.textContent = "x";
+    document.body.appendChild(a);
+    expect(bnCheckInfo(a)).toBeNull();
+  });
+});
+
+import { readFileSync } from "node:fs";
+const OBSERVE_SRC = readFileSync(
+  "/Users/lg/workspace/vortex/packages/extension/src/handlers/observe.ts",
+  "utf8",
+);
+
+describe("inject func 内联 bnCheckInfo + getRole/getUiState 接入(源码锁,改一处须同步)", () => {
+  it("inject func 含内联 bnCheckInfo 定义", () => {
+    expect(OBSERVE_SRC).toMatch(/const bnCheckInfo = \(\s*el: Element,?\s*\):/);
+  });
+  it("getRole 用 bnCheckInfo 返 checkbox", () => {
+    expect(OBSERVE_SRC).toMatch(/if \(bnCheckInfo\(el\)\) return "checkbox";/);
+  });
+  it("getUiState 用 bnCheckInfo 补 checked", () => {
+    expect(OBSERVE_SRC).toMatch(/const bn = bnCheckInfo\(el\);\s*\n\s*if \(bn && bn\.checked\) s\.checked = true;/);
+  });
+  it("bnCheckInfo 出现 ≥2 次(导出真源 + 内联副本)", () => {
+    expect((OBSERVE_SRC.match(/bnCheckInfo/g) || []).length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/packages/extension/tests/observe-focus-container-suppress.test.ts
+++ b/packages/extension/tests/observe-focus-container-suppress.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Author: qingwa
+ * Description: N0064 D6 列表设置 dogfood —— observe 漏抓 Element UI 弹层内自定义
+ *   交互项的根因修复。
+ *
+ *   实机白盒锁定:Element UI 2.x el-popover / el-dialog / el-drawer 的浮层容器
+ *   自带 `tabindex="0"`(可聚焦)+ `role="tooltip|dialog"`,因 `[tabindex]:not([-1])`
+ *   命中 INTERACTIVE_SELECTORS 进入 interactiveSet。cursor:pointer fallback 的
+ *   "跨池祖先短路"(observe.ts ancestor loop)原本对任何 interactiveSet 祖先都
+ *   `continue`,于是 columnDisplay 内 9 个 bnCheck(cursor:pointer)因祖先 el-popover
+ *   在池内被全部吞掉 → a11y 树只剩搜索框 + 确定按钮,9 列 checkbox 全丢(D2/D3/D5/D6/D8)。
+ *
+ *   真根因:短路把"仅因 tabindex 可聚焦的容器"误当"原子控件"。原子控件
+ *   (button/a/[role=button|menuitem|option…]/label)确实独占其子树(避免 <button><span>
+ *   双现),但聚焦/浮层容器不"描述"其子项——子项是独立控件,不该被吞。
+ *
+ *   isFocusContainerOnly 判据:祖先若 role ∈ 容器角色集 或 仅靠 tabindex 入池
+ *   (非原子控件)→ 聚焦容器,短路不应触发。
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { JSDOM } from "jsdom";
+import { isFocusContainerOnly } from "../src/handlers/observe.js";
+
+describe("isFocusContainerOnly (N0064 D6: tabindex 容器不吞 cursor:pointer 子项)", () => {
+  let document: Document;
+  beforeEach(() => {
+    document = new JSDOM("<!DOCTYPE html><body></body>").window.document;
+  });
+
+  it("el-popover (role=tooltip + tabindex=0) 是聚焦容器 → 不抑制子项", () => {
+    const pop = document.createElement("div");
+    pop.className = "el-popover el-popper";
+    pop.setAttribute("role", "tooltip");
+    pop.setAttribute("tabindex", "0");
+    document.body.appendChild(pop);
+    expect(isFocusContainerOnly(pop)).toBe(true);
+  });
+
+  it("纯 tabindex 容器 (无 role) → 聚焦容器,不抑制", () => {
+    const div = document.createElement("div");
+    div.setAttribute("tabindex", "0");
+    document.body.appendChild(div);
+    expect(isFocusContainerOnly(div)).toBe(true);
+  });
+
+  it("el-dialog (role=dialog) → 容器,不抑制", () => {
+    const dlg = document.createElement("div");
+    dlg.setAttribute("role", "dialog");
+    document.body.appendChild(dlg);
+    expect(isFocusContainerOnly(dlg)).toBe(true);
+  });
+
+  it("真 <button> → 原子控件,抑制子项(非聚焦容器)", () => {
+    const btn = document.createElement("button");
+    document.body.appendChild(btn);
+    expect(isFocusContainerOnly(btn)).toBe(false);
+  });
+
+  it("[role=menuitem] + tabindex → 原子控件,抑制", () => {
+    const mi = document.createElement("div");
+    mi.setAttribute("role", "menuitem");
+    mi.setAttribute("tabindex", "0");
+    document.body.appendChild(mi);
+    expect(isFocusContainerOnly(mi)).toBe(false);
+  });
+
+  it("[role=button] + tabindex → 原子控件,抑制(role 优先于 tabindex)", () => {
+    const rb = document.createElement("div");
+    rb.setAttribute("role", "button");
+    rb.setAttribute("tabindex", "0");
+    document.body.appendChild(rb);
+    expect(isFocusContainerOnly(rb)).toBe(false);
+  });
+
+  it("<a href> → 原子控件,抑制", () => {
+    const a = document.createElement("a");
+    a.setAttribute("href", "#");
+    document.body.appendChild(a);
+    expect(isFocusContainerOnly(a)).toBe(false);
+  });
+});
+
+import { readFileSync } from "node:fs";
+const OBSERVE_SRC = readFileSync(
+  "/Users/lg/workspace/vortex/packages/extension/src/handlers/observe.ts",
+  "utf8",
+);
+
+describe("inject func 内联 isFocusContainerOnly + 跨池短路接入(源码锁,改一处须同步)", () => {
+  it("inject func 含内联 isFocusContainerOnly 定义", () => {
+    expect(OBSERVE_SRC).toMatch(/const isFocusContainerOnly = \(anc: Element\): boolean =>/);
+  });
+  it("内联含 FOCUS_CONTAINER_ROLES 与 ATOMIC_INTERACTIVE_SELECTORS", () => {
+    expect((OBSERVE_SRC.match(/FOCUS_CONTAINER_ROLES/g) || []).length).toBeGreaterThanOrEqual(2);
+    expect((OBSERVE_SRC.match(/ATOMIC_INTERACTIVE_SELECTORS/g) || []).length).toBeGreaterThanOrEqual(2);
+  });
+  it("跨池祖先短路用 interactiveSet.has(p) && !isFocusContainerOnly(p)", () => {
+    expect(OBSERVE_SRC).toMatch(
+      /interactiveSet\.has\(p\) && !isFocusContainerOnly\(p\)/,
+    );
+  });
+});


### PR DESCRIPTION
## 背景

N0064 班牛(bytenew)dogfood V1 评测报告列出 15 Bug / 13 需求。经 **5 路并行白盒审计 + 班牛实机复现双重核实**,收敛为 **1 个真 bug**(报告其余 2 个 P0 实机证伪、6 个 P1 误诊/已修复/设计如此)。本 PR 修复该真 bug 及其同根的 P2-1。

## 问题与根因(实机白盒逐门锁定)

**observe 抓不到 Element UI 弹层内的自定义交互项**(跨 D2/D3/D5/D6/D8;典型:列表设置弹窗 9 列 checkbox 全丢,只剩搜索框+确定)。

报告归因(BUG-3 过滤过激 / renderObserveTree 压成 tooltip)**全错**。真根因:

- Element UI 2.x 浮层容器(`el-popover`/`el-dialog`/`el-drawer`)自带 `tabindex="0"` + `role="tooltip|dialog"`,因 `[tabindex]:not([-1])` 命中 `INTERACTIVE_SELECTORS` 进入 `interactiveSet`。
- cursor:pointer fallback 的**跨池祖先短路**对任何 `interactiveSet` 祖先都 `continue`(本意:避免 `<button><span>` 双现)。于是弹层内 `bnCheck` / `el-dropdown-menu__item` 等无 role/无原生 input 的自定义子项,因祖先浮层容器在池内被**全部吞掉**。
- "tooltip" 是 `el-popover` **自带 role**,非 vortex 压缩。

附带 **P2-1**:`bnCheck` 即便被收也显示为 `span`——它无 role/无原生 `<input>`/无 `aria-checked`,勾选态是后代 `.bnCheck-status` 上的**裸 `checked` class**;`getRole` 返 tag、`controlRoleFromClass` 末位 token 抓不到缩写 "bnCheck"、`getUiState` 的 is-checked/aria/native 路径全漏。

## 改动

- **`isFocusContainerOnly(el)`**:区分"原子控件 vs 纯聚焦容器"。祖先 `role` ∈ 容器角色集(tooltip/dialog/group/menu/listbox/tree/grid 等)或仅靠 `tabindex` 入池(非原子控件)→ 聚焦容器,跨池祖先短路**不触发**;真原子控件(button/a/`[role=button|menuitem|option…]`/label/`[onclick]`)仍短路防双现。一处修复覆盖全部 Element UI 弹层类型。
- **`bnCheckInfo(el)`**:从 collected 元素上溯 ≤5 层命中 `.bnCheck` 根 → `{role:"checkbox", checked}`(读 `.bnCheck-status.checked`),接入 `getRole` + `getUiState`。仅覆盖实机验证过的 bnCheck,不臆测 bnRadio。
- 两个判据均**导出真源**(jsdom 单测)+ inject func **内联同步副本** + **源码锁**(与 `controlRoleFromClass`/`isSelfClickable` 同模式)。

仅改 `packages/extension/src/handlers/observe.ts` + 2 个新测试文件。

## 实机验证

列表设置弹窗:`span "工单编号"` → `checkbox "工单编号"`(未选)/ `checkbox "工单编号" [checked]`(选中),9 列全现并正确嵌套于弹层节点下;新建 Drawer 字段泛化通过。

## Test plan

- [x] 新增 `observe-focus-container-suppress.test.ts`(10)+ `observe-bncheck-checkbox.test.ts`(10),RED→GREEN
- [x] extension 全量 **1011/1011** 通过(含 I13 a11y 噪声比 / I14 token 预算)
- [x] mcp 全量 **413/413** 通过
- [x] `bench scan --all`:**13/13** fixture recall 100% / 0 P0(含 teleport-popper-overlay)
- [x] `bench fuzz --seeds 50`:structural=0 / name=0,原语自检通过
- [x] `bench diff`:token bytes 全平/略降、missed=0 全场 → observe 收集零回归
- [ ] `bench run --all` 行为基准:本机双 MCP 会话争用导致 act 超时假阳(每 case +6x 延迟,solo 复跑无关 case 同样失败 → 非本改动)。建议在无 Claude/MCP 会话占用的独立 shell 复跑确认 act 行为(observe-only 改动不影响 act)
