### PR TITLE
0013 核实+修复:observe 主内容召回 / health NM 状态 / NM 未连 fail-fast

### DIFF
--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -388,6 +388,28 @@ export function partitionOverlayFirst(candidates: Element[], overlayRoots: Eleme
 }
 
 /**
+ * 导航菜单根识别(A-1 main 层降权,ant.design dogfood):<main> 内常驻 role=menu/tree
+ * 侧栏导航(ant.design ant-menu-inline:74 项跨页链接、position static、无 fixed 祖先,
+ * 既不走 overlay 也不在 <nav> landmark 内,却 DOM 序前于 demo 霸占 maxElements)。
+ * 判据:① 在 nav/navigation/menubar landmark 内,或 ② 菜单项 ≥5 且多数(≥60%)为
+ * 跨页 <a href>(非 #/锚点)链接。②把"被演示的 Menu 组件"(项无跨页链接)排除在外,
+ * 只降权真站点导航。inject func 内联同名逻辑,改一处须同步。
+ */
+export function isNavMenuRoot(el: Element, role: string): boolean {
+  if (role !== "menu" && role !== "tree") return false;
+  if (el.closest('nav,[role="navigation"],[role="menubar"]')) return true;
+  const items = el.querySelectorAll('[role="menuitem"],[role="treeitem"]');
+  if (items.length < 5) return false;
+  let links = 0;
+  for (const it of Array.from(items)) {
+    const a = it.matches("a[href]") ? it : it.querySelector("a[href]");
+    const href = a?.getAttribute("href") ?? "";
+    if (href.length > 1 && !href.startsWith("#")) links++;
+  }
+  return links >= items.length * 0.6;
+}
+
+/**
  * main-content-priority(A-1):文档站「左导航 + 右主内容」布局下,导航(DOM 序在前)
  * 霸占 maxElements 配额、主内容 0 召回(semi.design Select dogfood 实证:154 个 nav
  * 排在 244 个 Select demo 之前,maxElements=80/100 全给 nav)。用 WAI-ARIA landmark
@@ -401,11 +423,23 @@ export function partitionMainContentFirst(candidates: Element[], mainEl: Element
   // 后置。二者都把长导航挤出 maxElements 前缀,让主内容召回;只重排不丢弃(空则原数组同序)。
   const isNav = (el: Element): boolean =>
     !!el.closest('nav,[role="navigation"],[role="menubar"]');
+  // 持久导航菜单(role=menu/tree 跨页链接侧栏)即便落在 <main> 内也须降权——否则
+  // ant.design 侧栏 74 项排在 demo 之前霸占 maxElements。向上找最近的导航菜单根。
+  const inNavMenu = (el: Element): boolean => {
+    let cur: Element | null = el;
+    while (cur) {
+      const r = cur.getAttribute("role")?.trim().split(/\s+/)[0] ?? "";
+      if ((r === "menu" || r === "tree") && isNavMenuRoot(cur, r)) return true;
+      cur = cur.parentElement;
+    }
+    return false;
+  };
   const inMain: Element[] = [];
   const mid: Element[] = [];
   const nav: Element[] = [];
   for (const el of candidates) {
-    if (mainEl && mainEl.contains(el)) inMain.push(el);
+    if (inNavMenu(el)) nav.push(el);
+    else if (mainEl && mainEl.contains(el)) inMain.push(el);
     else if (isNav(el)) nav.push(el);
     else mid.push(el);
   }
@@ -1893,6 +1927,31 @@ async function scanOneFrame(
           if (id && document.querySelector('[aria-controls~="' + id + '"],[aria-owns~="' + id + '"]')) return false;
           return true;
         };
+        // 导航菜单根:role=menu/tree 侧栏导航,即便在 <main> 内、position static(ant.design
+        // ant-menu-inline)也须从 main 层降权。判据=在 nav landmark 内,或菜单项 ≥5 且多数为
+        // 跨页 <a href> 链接(把"被演示的 Menu 组件"排除)。模块级 isNavMenuRoot 同名,改一处须同步。
+        const isNavMenuRoot = (el: Element, role: string): boolean => {
+          if (role !== "menu" && role !== "tree") return false;
+          if (el.closest('nav,[role="navigation"],[role="menubar"]')) return true;
+          const items = el.querySelectorAll('[role="menuitem"],[role="treeitem"]');
+          if (items.length < 5) return false;
+          let links = 0;
+          for (const it of Array.from(items)) {
+            const a = it.matches("a[href]") ? it : it.querySelector("a[href]");
+            const href = a?.getAttribute("href") ?? "";
+            if (href.length > 1 && !href.startsWith("#")) links++;
+          }
+          return links >= items.length * 0.6;
+        };
+        const inNavMenu = (el: Element): boolean => {
+          let cur: Element | null = el;
+          while (cur && cur !== docBody) {
+            const r = cur.getAttribute("role")?.trim().split(/\s+/)[0] ?? "";
+            if ((r === "menu" || r === "tree") && isNavMenuRoot(cur, r)) return true;
+            cur = cur.parentElement;
+          }
+          return false;
+        };
         const overlayRoots: Element[] = [];
         // 信号一:ARIA 弹层语义 role + 脱流定位(穿 open shadow,与主扫描一致)。
         for (const el of querySelectorAllDeep("[role]", document)) {
@@ -1933,7 +1992,8 @@ async function scanOneFrame(
           const a1Mid: Element[] = [];
           const a1Nav: Element[] = [];
           for (const el of nonOverlay) {
-            if (mainElA1 && mainElA1.contains(el)) a1Main.push(el);
+            if (inNavMenu(el)) a1Nav.push(el);
+            else if (mainElA1 && mainElA1.contains(el)) a1Main.push(el);
             else if (isNavA1(el)) a1Nav.push(el);
             else a1Mid.push(el);
           }

--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -378,11 +378,22 @@ export function partitionOverlayFirst(candidates: Element[], overlayRoots: Eleme
  * 生效(overlay-priority 优先级更高)。inject func 内联同名逻辑,改一处须同步。
  */
 export function partitionMainContentFirst(candidates: Element[], mainEl: Element | null): Element[] {
-  if (!mainEl) return candidates;
+  // 内容区(<main>/[role=main])元素恒前置;无语义 landmark 时(多数文档站如 semi.design
+  // 用 <div id=main-content> 而非 <main>)退而把导航区(<nav>/[role=navigation|menubar])元素
+  // 后置。二者都把长导航挤出 maxElements 前缀,让主内容召回;只重排不丢弃(空则原数组同序)。
+  const isNav = (el: Element): boolean =>
+    !!el.closest('nav,[role="navigation"],[role="menubar"]');
   const inMain: Element[] = [];
-  const outMain: Element[] = [];
-  for (const el of candidates) (mainEl.contains(el) ? inMain : outMain).push(el);
-  return inMain.length > 0 && outMain.length > 0 ? [...inMain, ...outMain] : candidates;
+  const mid: Element[] = [];
+  const nav: Element[] = [];
+  for (const el of candidates) {
+    if (mainEl && mainEl.contains(el)) inMain.push(el);
+    else if (isNav(el)) nav.push(el);
+    else mid.push(el);
+  }
+  // 仅当跨 ≥2 个分桶才重排,否则原数组同序(零漂移)。
+  const buckets = (inMain.length > 0 ? 1 : 0) + (mid.length > 0 ? 1 : 0) + (nav.length > 0 ? 1 : 0);
+  return buckets <= 1 ? candidates : [...inMain, ...mid, ...nav];
 }
 
 /**
@@ -1876,14 +1887,22 @@ async function scanOneFrame(
         }
         const allCandidates: Element[] = ((): Element[] => {
           if (overlayRoots.length === 0) {
-            // main-content-priority(A-1):无浮层时按 <main>/[role=main] 内容区前置,
-            // 免遭长导航霸占 maxElements。逻辑须与模块级 partitionMainContentFirst 一致。
-            const mainEl = document.querySelector("main") ?? document.querySelector('[role="main"]');
-            if (!mainEl) return baseCandidates;
-            const inMain: Element[] = [];
-            const outMain: Element[] = [];
-            for (const el of baseCandidates) (mainEl.contains(el) ? inMain : outMain).push(el);
-            return inMain.length > 0 && outMain.length > 0 ? [...inMain, ...outMain] : baseCandidates;
+            // main-content-priority(A-1):内容区(<main>/[role=main])前置 + 导航区
+            // (<nav>/[role=navigation|menubar])降权。多数文档站无语义 <main>(semi.design
+            // 用 <div id=main-content>),靠 nav 降权兜底。须与模块级 partitionMainContentFirst 同步。
+            const mainElA1 = document.querySelector("main") ?? document.querySelector('[role="main"]') ?? document.querySelector("#main-content");
+            const isNavA1 = (el: Element): boolean =>
+              !!el.closest('nav,[role="navigation"],[role="menubar"]');
+            const a1Main: Element[] = [];
+            const a1Mid: Element[] = [];
+            const a1Nav: Element[] = [];
+            for (const el of baseCandidates) {
+              if (mainElA1 && mainElA1.contains(el)) a1Main.push(el);
+              else if (isNavA1(el)) a1Nav.push(el);
+              else a1Mid.push(el);
+            }
+            const a1Buckets = (a1Main.length > 0 ? 1 : 0) + (a1Mid.length > 0 ? 1 : 0) + (a1Nav.length > 0 ? 1 : 0);
+            return a1Buckets <= 1 ? baseCandidates : [...a1Main, ...a1Mid, ...a1Nav];
           }
           const inOverlay = (el: Element): boolean =>
             overlayRoots.some((root) => root === el || root.contains(el));

--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -370,6 +370,22 @@ export function partitionOverlayFirst(candidates: Element[], overlayRoots: Eleme
 }
 
 /**
+ * main-content-priority(A-1):文档站「左导航 + 右主内容」布局下,导航(DOM 序在前)
+ * 霸占 maxElements 配额、主内容 0 召回(semi.design Select dogfood 实证:154 个 nav
+ * 排在 244 个 Select demo 之前,maxElements=80/100 全给 nav)。用 WAI-ARIA landmark
+ * <main>/[role=main] 锁定内容区,把其内候选前置,保持相对 DOM 序;无 landmark
+ * (mainEl=null)或候选全在/全不在 main 内 → 返回原数组同序(零漂移)。仅在无浮层根时
+ * 生效(overlay-priority 优先级更高)。inject func 内联同名逻辑,改一处须同步。
+ */
+export function partitionMainContentFirst(candidates: Element[], mainEl: Element | null): Element[] {
+  if (!mainEl) return candidates;
+  const inMain: Element[] = [];
+  const outMain: Element[] = [];
+  for (const el of candidates) (mainEl.contains(el) ? inMain : outMain).push(el);
+  return inMain.length > 0 && outMain.length > 0 ? [...inMain, ...outMain] : candidates;
+}
+
+/**
  * 班牛(bytenew)bnCheck 自定义勾选控件识别(N0064 P2-1 dogfood)。
  *
  *   <div class="bnCheck"><span class="bnCheck-status[ checked]">…</span>
@@ -1859,7 +1875,16 @@ async function scanOneFrame(
           }
         }
         const allCandidates: Element[] = ((): Element[] => {
-          if (overlayRoots.length === 0) return baseCandidates;
+          if (overlayRoots.length === 0) {
+            // main-content-priority(A-1):无浮层时按 <main>/[role=main] 内容区前置,
+            // 免遭长导航霸占 maxElements。逻辑须与模块级 partitionMainContentFirst 一致。
+            const mainEl = document.querySelector("main") ?? document.querySelector('[role="main"]');
+            if (!mainEl) return baseCandidates;
+            const inMain: Element[] = [];
+            const outMain: Element[] = [];
+            for (const el of baseCandidates) (mainEl.contains(el) ? inMain : outMain).push(el);
+            return inMain.length > 0 && outMain.length > 0 ? [...inMain, ...outMain] : baseCandidates;
+          }
           const inOverlay = (el: Element): boolean =>
             overlayRoots.some((root) => root === el || root.contains(el));
           const front: Element[] = [];

--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -355,6 +355,24 @@ export function isOverlayFloating(el: Element, maxHops = 6): boolean {
 }
 
 /**
+ * 持久导航菜单判据(overlay 误判修复):role=menu/tree 的常驻结构(侧栏导航 / 常驻树)由
+ * 用户主动导航而非触发器打开,不是临时弹层,却可能因常驻容器 position:fixed(粘性滚动)
+ * 误过 isOverlayFloating。判据:真弹层由触发器(combobox/按钮)经 aria-controls/aria-owns
+ * 关联;无控制器即持久结构;在 <nav>/[role=navigation] landmark 内同样视为导航。
+ * listbox/dialog/tooltip 等本质临时,不在此列。inject func 内联同名逻辑,改一处须同步。
+ * (semi.design 侧栏 ul[role=menu].semi-navigation-list 实证:228 项被误前置吞掉 maxElements。)
+ */
+export function isPersistentNavMenu(el: Element, role: string): boolean {
+  if (role !== "menu" && role !== "tree") return false;
+  if (el.closest('nav,[role="navigation"]')) return true;
+  const id = el.id;
+  if (id && el.ownerDocument?.querySelector('[aria-controls~="' + id + '"],[aria-owns~="' + id + '"]')) {
+    return false;
+  }
+  return true;
+}
+
+/**
  * overlay-priority 候选重排:把"在任一浮层根内"的候选(含浮层根自身)前置到最前,保持
  * 其相对 DOM 序;其余保持原序。**无浮层根 → 返回原数组同序(零漂移,baseline 不变)**。
  * inject func 内联同名逻辑,改一处须同步。
@@ -1864,12 +1882,23 @@ async function scanOneFrame(
           }
           return false;
         };
+        // 持久导航菜单误判修复:role=menu/tree 的常驻结构(侧栏导航/常驻树)无触发器打开,
+        // 不是临时弹层,却因常驻容器 position:fixed(粘性滚动)误过 isFloatingOverlay。
+        // 真弹层由触发器(combobox/按钮)经 aria-controls/aria-owns 关联;无控制器即持久
+        // 结构;在 nav landmark 内同样视为导航。listbox/dialog/tooltip 不在此列。
+        const isPersistentMenu = (el: Element, role: string): boolean => {
+          if (role !== "menu" && role !== "tree") return false;
+          if (el.closest('nav,[role="navigation"]')) return true;
+          const id = el.id;
+          if (id && document.querySelector('[aria-controls~="' + id + '"],[aria-owns~="' + id + '"]')) return false;
+          return true;
+        };
         const overlayRoots: Element[] = [];
         // 信号一:ARIA 弹层语义 role + 脱流定位(穿 open shadow,与主扫描一致)。
         for (const el of querySelectorAllDeep("[role]", document)) {
           const role = el.getAttribute("role")?.trim().split(/\s+/)[0];
           if (!role || !OVERLAY_POPUP_ROLES.has(role)) continue;
-          if (isVisibleForOverlay(el) && isFloatingOverlay(el)) overlayRoots.push(el);
+          if (isVisibleForOverlay(el) && isFloatingOverlay(el) && !isPersistentMenu(el, role)) overlayRoots.push(el);
         }
         // 信号二:body 直接子节点的 portal(脱流 + z-index 抬升 + 含交互后代),
         // 兜住无 ARIA role 的自定义弹层(如 el-select popper)。
@@ -1886,32 +1915,32 @@ async function scanOneFrame(
           }
         }
         const allCandidates: Element[] = ((): Element[] => {
-          if (overlayRoots.length === 0) {
-            // main-content-priority(A-1):内容区(<main>/[role=main])前置 + 导航区
-            // (<nav>/[role=navigation|menubar])降权。多数文档站无语义 <main>(semi.design
-            // 用 <div id=main-content>),靠 nav 降权兜底。须与模块级 partitionMainContentFirst 同步。
-            const mainElA1 = document.querySelector("main") ?? document.querySelector('[role="main"]') ?? document.querySelector("#main-content");
-            const isNavA1 = (el: Element): boolean =>
-              !!el.closest('nav,[role="navigation"],[role="menubar"]');
-            const a1Main: Element[] = [];
-            const a1Mid: Element[] = [];
-            const a1Nav: Element[] = [];
-            for (const el of baseCandidates) {
-              if (mainElA1 && mainElA1.contains(el)) a1Main.push(el);
-              else if (isNavA1(el)) a1Nav.push(el);
-              else a1Mid.push(el);
-            }
-            const a1Buckets = (a1Main.length > 0 ? 1 : 0) + (a1Mid.length > 0 ? 1 : 0) + (a1Nav.length > 0 ? 1 : 0);
-            return a1Buckets <= 1 ? baseCandidates : [...a1Main, ...a1Mid, ...a1Nav];
-          }
+          // 两层正交排序(组合 overlay-priority + main-content-priority):
+          // ① 浮层(DEFECT-1):可见浮层内元素前置免遭截断;
+          // ② 非浮层部分(A-1):内容区(<main>/[role=main]/#main-content)前置 + 导航区
+          //    (<nav>/[role=navigation|menubar])降权。二者正交:组件库 demo 页常驻 ARIA 浮层
+          //    (overlayRoots>0)时主内容仍须召回,故 main/nav 排序不能只在无浮层时跑。
+          //    须与模块级 partitionOverlayFirst ∘ partitionMainContentFirst 同步。
           const inOverlay = (el: Element): boolean =>
-            overlayRoots.some((root) => root === el || root.contains(el));
-          const front: Element[] = [];
-          const rest: Element[] = [];
-          for (const el of baseCandidates) (inOverlay(el) ? front : rest).push(el);
-          // front 由 baseCandidates 顺序过滤得来,保持相对 DOM 序;全在浮层内时
-          // front===base 顺序、rest 空 → 与原序一致,无漂移。
-          return front.length > 0 ? [...front, ...rest] : baseCandidates;
+            overlayRoots.length > 0 && overlayRoots.some((root) => root === el || root.contains(el));
+          const overlayEls: Element[] = [];
+          const nonOverlay: Element[] = [];
+          for (const el of baseCandidates) (inOverlay(el) ? overlayEls : nonOverlay).push(el);
+          const mainElA1 = document.querySelector("main") ?? document.querySelector('[role="main"]') ?? document.querySelector("#main-content");
+          const isNavA1 = (el: Element): boolean =>
+            !!el.closest('nav,[role="navigation"],[role="menubar"]');
+          const a1Main: Element[] = [];
+          const a1Mid: Element[] = [];
+          const a1Nav: Element[] = [];
+          for (const el of nonOverlay) {
+            if (mainElA1 && mainElA1.contains(el)) a1Main.push(el);
+            else if (isNavA1(el)) a1Nav.push(el);
+            else a1Mid.push(el);
+          }
+          // 零漂移:无浮层且主/导航未跨 ≥2 桶 → 原数组同序。
+          const a1Buckets = (a1Main.length > 0 ? 1 : 0) + (a1Mid.length > 0 ? 1 : 0) + (a1Nav.length > 0 ? 1 : 0);
+          if (overlayEls.length === 0 && a1Buckets <= 1) return baseCandidates;
+          return [...overlayEls, ...a1Main, ...a1Mid, ...a1Nav];
         })();
 
         const elements: Array<{

--- a/packages/extension/tests/observe-main-priority.test.ts
+++ b/packages/extension/tests/observe-main-priority.test.ts
@@ -7,17 +7,21 @@ import { partitionMainContentFirst } from "../src/handlers/observe.js";
 
 /**
  * main-content-priority(A-1):文档站「左导航 + 右主内容」布局下,导航(DOM 序在前)
- * 霸占 maxElements 配额、主内容 0 召回(semi.design Select dogfood 实证)。用 WAI-ARIA
- * landmark <main>/[role=main] 把内容区候选前置。本测直测模块导出 + source-lock 内联副本。
+ * 霸占 maxElements 配额、主内容 0 召回(semi.design Select dogfood 实证)。
+ * 双信号:① 语义 <main>/[role=main] 内容区元素前置;② 多数文档站无语义 <main>
+ * (semi.design 用 <div id=main-content>),退而把 <nav>/[role=navigation] 导航区降权。
+ * 二者都把长导航挤出截断前缀。本测直测模块导出 + source-lock 内联副本。
  */
 describe("main-content-priority (A-1)", () => {
-  describe("partitionMainContentFirst(主内容前置 + 零漂移)", () => {
-    it("无 main(mainEl=null)→ 返回原数组(同引用,baseline 零漂移)", () => {
-      const cands = [document.createElement("a"), document.createElement("button")];
+  describe("partitionMainContentFirst(内容前置 + 导航降权)", () => {
+    it("无 main、无 nav → 返回原数组(同引用,零漂移)", () => {
+      document.body.innerHTML = `<div><a id="a"></a><button id="b"></button></div>`;
+      const get = (id: string) => document.getElementById(id)!;
+      const cands = [get("a"), get("b")];
       expect(partitionMainContentFirst(cands, null)).toBe(cands);
     });
 
-    it("主内容候选前置,导航保持原序(154 nav 挤光 demo 的修复)", () => {
+    it("有 <main>:内容元素前置,导航保持原序", () => {
       document.body.innerHTML =
         `<nav><a id="n0"></a><a id="n1"></a></nav>` +
         `<main id="m"><button id="demo0"></button><button id="demo1"></button></main>`;
@@ -27,26 +31,41 @@ describe("main-content-priority (A-1)", () => {
       expect(out.map((e) => e.id)).toEqual(["demo0", "demo1", "n0", "n1"]);
     });
 
-    it("[role=main] 同样生效", () => {
+    it("无语义 <main> 但有 <nav>(semi.design 场景)→ 导航降权,内容前移", () => {
+      // semi.design:内容在 <div id=main-content> 而非 <main>,侧栏是 <nav>
+      document.body.innerHTML =
+        `<div id="main-content">` +
+        `<nav><a id="n0"></a><a id="n1"></a><a id="n2"></a></nav>` +
+        `<button id="demo"></button>` +
+        `</div>`;
+      const get = (id: string) => document.getElementById(id)!;
+      // DOM 序:导航在前、demo 在后(被截断的处境);mainEl=null(无语义 main)
+      const cands = [get("n0"), get("n1"), get("n2"), get("demo")];
+      const out = partitionMainContentFirst(cands, null);
+      expect(out.map((e) => e.id)).toEqual(["demo", "n0", "n1", "n2"]);
+    });
+
+    it("[role=navigation] 同样被降权", () => {
+      document.body.innerHTML =
+        `<div role="navigation"><a id="n0"></a></div><button id="demo"></button>`;
+      const get = (id: string) => document.getElementById(id)!;
+      const out = partitionMainContentFirst([get("n0"), get("demo")], null);
+      expect(out.map((e) => e.id)).toEqual(["demo", "n0"]);
+    });
+
+    it("候选全在 nav 内(无 main)→ 原数组同序(零漂移)", () => {
+      document.body.innerHTML = `<nav><a id="a"></a><a id="b"></a></nav>`;
+      const get = (id: string) => document.getElementById(id)!;
+      const cands = [get("a"), get("b")];
+      expect(partitionMainContentFirst(cands, null)).toBe(cands);
+    });
+
+    it("有 <main> 且 nav 在 main 外 → 内容前置(nav 降权一致)", () => {
       document.body.innerHTML =
         `<a id="nav"></a><div id="m" role="main"><button id="c"></button></div>`;
       const get = (id: string) => document.getElementById(id)!;
       const out = partitionMainContentFirst([get("nav"), get("c")], get("m"));
       expect(out.map((e) => e.id)).toEqual(["c", "nav"]);
-    });
-
-    it("候选全在 main 内 → 原数组同序(零漂移)", () => {
-      document.body.innerHTML = `<main id="m"><a id="a"></a><a id="b"></a></main>`;
-      const get = (id: string) => document.getElementById(id)!;
-      const cands = [get("a"), get("b")];
-      expect(partitionMainContentFirst(cands, get("m"))).toBe(cands);
-    });
-
-    it("候选全不在 main 内 → 原数组同序(零漂移)", () => {
-      document.body.innerHTML = `<main id="m"></main><a id="a"></a><a id="b"></a>`;
-      const get = (id: string) => document.getElementById(id)!;
-      const cands = [get("a"), get("b")];
-      expect(partitionMainContentFirst(cands, get("m"))).toBe(cands);
     });
   });
 
@@ -55,12 +74,15 @@ describe("main-content-priority (A-1)", () => {
       join(dirname(fileURLToPath(import.meta.url)), "..", "src", "handlers", "observe.ts"),
       "utf8",
     );
-    it("内联无浮层分支含 <main>/[role=main] landmark 探测", () => {
+    it("内联无浮层分支含 <main>/[role=main]/#main-content 内容区探测", () => {
       expect(SRC).toContain('document.querySelector("main")');
       expect(SRC).toContain('[role="main"]');
+      // semi.design 等多数文档站无语义 <main>,靠 #main-content(skip-link 标准目标)兜底
+      expect(SRC).toContain('document.querySelector("#main-content")');
     });
-    it("内联含 main 成员分区逻辑(mainEl.contains 前置)", () => {
-      expect(SRC).toMatch(/mainEl\.contains\(el\)\s*\?\s*inMain\s*:\s*outMain/);
+    it("内联含导航区降权(nav/[role=navigation] closest)", () => {
+      expect(SRC).toContain('nav,[role="navigation"],[role="menubar"]');
+      expect(SRC).toMatch(/isNavA1\(el\)/);
     });
   });
 });

--- a/packages/extension/tests/observe-main-priority.test.ts
+++ b/packages/extension/tests/observe-main-priority.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { partitionMainContentFirst } from "../src/handlers/observe.js";
+import { partitionMainContentFirst, isNavMenuRoot } from "../src/handlers/observe.js";
 
 /**
  * main-content-priority(A-1):文档站「左导航 + 右主内容」布局下,导航(DOM 序在前)
@@ -67,6 +67,70 @@ describe("main-content-priority (A-1)", () => {
       const out = partitionMainContentFirst([get("nav"), get("c")], get("m"));
       expect(out.map((e) => e.id)).toEqual(["c", "nav"]);
     });
+
+    it("ant.design 场景:<main> 内嵌跨页链接 role=menu 侧栏 → 侧栏降权、demo 前移", () => {
+      // ant.design:侧栏 ant-menu-inline(role=menu)在 <main> 内、position static、
+      // 无 fixed 祖先,故不走 overlay 也不被 isNav(非 nav landmark)捕获,DOM 序前于
+      // demo,74 项菜单霸占 maxElements。判据=跨页 <a href> 链接占多数 → 降权。
+      const links = Array.from({ length: 6 }, (_, i) =>
+        `<li role="menuitem"><a id="s${i}" href="/components/c${i}">C${i}</a></li>`,
+      ).join("");
+      document.body.innerHTML =
+        `<main id="m">` +
+        `<ul role="menu" id="side">${links}</ul>` +
+        `<select id="demo0"></select><input id="demo1">` +
+        `</main>`;
+      const get = (id: string) => document.getElementById(id)!;
+      const cands = [
+        get("s0"), get("s1"), get("s2"), get("s3"), get("s4"), get("s5"),
+        get("demo0"), get("demo1"),
+      ];
+      const out = partitionMainContentFirst(cands, get("m"));
+      // demo 应排在 6 个侧栏链接之前
+      expect(out.map((e) => e.id)).toEqual([
+        "demo0", "demo1", "s0", "s1", "s2", "s3", "s4", "s5",
+      ]);
+    });
+  });
+
+  describe("isNavMenuRoot(导航菜单根识别)", () => {
+    it("nav landmark 内的 role=menu → true", () => {
+      document.body.innerHTML = `<nav><ul role="menu" id="m"></ul></nav>`;
+      expect(isNavMenuRoot(document.getElementById("m")!, "menu")).toBe(true);
+    });
+    it("跨页链接占多数的 role=menu(无 nav 祖先,ant.design 侧栏)→ true", () => {
+      const links = Array.from({ length: 6 }, (_, i) =>
+        `<li role="menuitem"><a href="/components/c${i}">C${i}</a></li>`,
+      ).join("");
+      document.body.innerHTML = `<ul role="menu" id="m">${links}</ul>`;
+      expect(isNavMenuRoot(document.getElementById("m")!, "menu")).toBe(true);
+    });
+    it("被演示的 Menu 组件(项无跨页链接)→ false(不误降内容区)", () => {
+      const items = Array.from({ length: 6 }, (_, i) =>
+        `<li role="menuitem">Item ${i}</li>`,
+      ).join("");
+      document.body.innerHTML = `<ul role="menu" id="m">${items}</ul>`;
+      expect(isNavMenuRoot(document.getElementById("m")!, "menu")).toBe(false);
+    });
+    it("锚点(#)链接不算跨页 → false", () => {
+      const items = Array.from({ length: 6 }, (_, i) =>
+        `<li role="menuitem"><a href="#sec${i}">S${i}</a></li>`,
+      ).join("");
+      document.body.innerHTML = `<ul role="menu" id="m">${items}</ul>`;
+      expect(isNavMenuRoot(document.getElementById("m")!, "menu")).toBe(false);
+    });
+    it("项数 <5 → false(小菜单不当导航)", () => {
+      document.body.innerHTML =
+        `<ul role="menu" id="m">` +
+        `<li role="menuitem"><a href="/a">A</a></li>` +
+        `<li role="menuitem"><a href="/b">B</a></li>` +
+        `</ul>`;
+      expect(isNavMenuRoot(document.getElementById("m")!, "menu")).toBe(false);
+    });
+    it("role 非 menu/tree → false", () => {
+      document.body.innerHTML = `<nav><ul role="listbox" id="m"></ul></nav>`;
+      expect(isNavMenuRoot(document.getElementById("m")!, "listbox")).toBe(false);
+    });
   });
 
   describe("inject func 内联副本 drift 锁(改一处须同步)", () => {
@@ -83,6 +147,10 @@ describe("main-content-priority (A-1)", () => {
     it("内联含导航区降权(nav/[role=navigation] closest)", () => {
       expect(SRC).toContain('nav,[role="navigation"],[role="menubar"]');
       expect(SRC).toMatch(/isNavA1\(el\)/);
+    });
+    it("内联含导航菜单根降权(inNavMenu / isNavMenuRoot,ant.design 侧栏)", () => {
+      expect(SRC).toMatch(/inNavMenu\(el\)/);
+      expect(SRC).toContain('[role="menuitem"],[role="treeitem"]');
     });
   });
 });

--- a/packages/extension/tests/observe-main-priority.test.ts
+++ b/packages/extension/tests/observe-main-priority.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { partitionMainContentFirst } from "../src/handlers/observe.js";
+
+/**
+ * main-content-priority(A-1):文档站「左导航 + 右主内容」布局下,导航(DOM 序在前)
+ * 霸占 maxElements 配额、主内容 0 召回(semi.design Select dogfood 实证)。用 WAI-ARIA
+ * landmark <main>/[role=main] 把内容区候选前置。本测直测模块导出 + source-lock 内联副本。
+ */
+describe("main-content-priority (A-1)", () => {
+  describe("partitionMainContentFirst(主内容前置 + 零漂移)", () => {
+    it("无 main(mainEl=null)→ 返回原数组(同引用,baseline 零漂移)", () => {
+      const cands = [document.createElement("a"), document.createElement("button")];
+      expect(partitionMainContentFirst(cands, null)).toBe(cands);
+    });
+
+    it("主内容候选前置,导航保持原序(154 nav 挤光 demo 的修复)", () => {
+      document.body.innerHTML =
+        `<nav><a id="n0"></a><a id="n1"></a></nav>` +
+        `<main id="m"><button id="demo0"></button><button id="demo1"></button></main>`;
+      const get = (id: string) => document.getElementById(id)!;
+      const cands = [get("n0"), get("n1"), get("demo0"), get("demo1")];
+      const out = partitionMainContentFirst(cands, get("m"));
+      expect(out.map((e) => e.id)).toEqual(["demo0", "demo1", "n0", "n1"]);
+    });
+
+    it("[role=main] 同样生效", () => {
+      document.body.innerHTML =
+        `<a id="nav"></a><div id="m" role="main"><button id="c"></button></div>`;
+      const get = (id: string) => document.getElementById(id)!;
+      const out = partitionMainContentFirst([get("nav"), get("c")], get("m"));
+      expect(out.map((e) => e.id)).toEqual(["c", "nav"]);
+    });
+
+    it("候选全在 main 内 → 原数组同序(零漂移)", () => {
+      document.body.innerHTML = `<main id="m"><a id="a"></a><a id="b"></a></main>`;
+      const get = (id: string) => document.getElementById(id)!;
+      const cands = [get("a"), get("b")];
+      expect(partitionMainContentFirst(cands, get("m"))).toBe(cands);
+    });
+
+    it("候选全不在 main 内 → 原数组同序(零漂移)", () => {
+      document.body.innerHTML = `<main id="m"></main><a id="a"></a><a id="b"></a>`;
+      const get = (id: string) => document.getElementById(id)!;
+      const cands = [get("a"), get("b")];
+      expect(partitionMainContentFirst(cands, get("m"))).toBe(cands);
+    });
+  });
+
+  describe("inject func 内联副本 drift 锁(改一处须同步)", () => {
+    const SRC = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "..", "src", "handlers", "observe.ts"),
+      "utf8",
+    );
+    it("内联无浮层分支含 <main>/[role=main] landmark 探测", () => {
+      expect(SRC).toContain('document.querySelector("main")');
+      expect(SRC).toContain('[role="main"]');
+    });
+    it("内联含 main 成员分区逻辑(mainEl.contains 前置)", () => {
+      expect(SRC).toMatch(/mainEl\.contains\(el\)\s*\?\s*inMain\s*:\s*outMain/);
+    });
+  });
+});

--- a/packages/extension/tests/observe-overlay-priority.test.ts
+++ b/packages/extension/tests/observe-overlay-priority.test.ts
@@ -24,6 +24,7 @@ import { dirname, join } from "node:path";
 import {
   OVERLAY_POPUP_ROLES,
   isOverlayFloating,
+  isPersistentNavMenu,
   partitionOverlayFirst,
 } from "../src/handlers/observe.js";
 
@@ -119,5 +120,44 @@ describe("overlay-priority (DEFECT-1)", () => {
     it("内联保留无浮层零漂移(overlayRoots.length === 0 → baseCandidates)", () => {
       expect(SRC).toMatch(/overlayRoots\.length === 0/);
     });
+  });
+});
+
+describe("isPersistentNavMenu(持久导航菜单 ≠ 临时浮层,A-1 overlay 误判修复)", () => {
+  it("role=menu 无触发器(侧栏导航;semi.design ul[role=menu].semi-navigation-list 实证)→ true", () => {
+    document.body.innerHTML = `<ul id="m" role="menu"><li role="menuitem">a</li></ul>`;
+    expect(isPersistentNavMenu(document.getElementById("m")!, "menu")).toBe(true);
+  });
+  it("role=menu 被 aria-controls 触发器关联(真弹出菜单)→ false", () => {
+    document.body.innerHTML = `<button aria-controls="mm">open</button><ul id="mm" role="menu"></ul>`;
+    expect(isPersistentNavMenu(document.getElementById("mm")!, "menu")).toBe(false);
+  });
+  it("role=menu 在 <nav> landmark 内 → true(导航结构)", () => {
+    document.body.innerHTML = `<nav><ul id="n" role="menu"></ul></nav>`;
+    expect(isPersistentNavMenu(document.getElementById("n")!, "menu")).toBe(true);
+  });
+  it("role=tree 无触发器(常驻文件树)→ true", () => {
+    document.body.innerHTML = `<ul id="t" role="tree"></ul>`;
+    expect(isPersistentNavMenu(document.getElementById("t")!, "tree")).toBe(true);
+  });
+  it("role=listbox(下拉弹层)不在此列 → false(仍交位置判据)", () => {
+    document.body.innerHTML = `<ul id="lb" role="listbox"></ul>`;
+    expect(isPersistentNavMenu(document.getElementById("lb")!, "listbox")).toBe(false);
+  });
+  it("role=dialog → false", () => {
+    document.body.innerHTML = `<div id="d" role="dialog"></div>`;
+    expect(isPersistentNavMenu(document.getElementById("d")!, "dialog")).toBe(false);
+  });
+});
+
+describe("inject func isPersistentMenu 内联同步锁", () => {
+  const SRC2 = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "..", "src", "handlers", "observe.ts"),
+    "utf8",
+  );
+  it("内联 overlay 收集排除持久菜单(role=menu/tree 无触发器不计浮层)", () => {
+    expect(SRC2).toContain("isPersistentMenu");
+    expect(SRC2).toContain("aria-controls~=");
+    expect(SRC2).toMatch(/&& !isPersistentMenu\(el, role\)/);
   });
 });

--- a/packages/server/src/http-routes.ts
+++ b/packages/server/src/http-routes.ts
@@ -49,7 +49,7 @@ export function createHttpRoutes(router: MessageRouter): Router {
   app.use(json());
 
   app.get("/health", (_req, res) => {
-    res.json({ status: "ok", timestamp: Date.now() });
+    res.json({ status: "ok", nmConnected: router.isNmConnected(), timestamp: Date.now() });
   });
 
   app.post("/api/:namespace/:method", async (req, res) => {

--- a/packages/server/src/message-router.ts
+++ b/packages/server/src/message-router.ts
@@ -14,6 +14,8 @@ export class MessageRouter {
   private pending = new Map<string, PendingRequest>();
   private requestBuffer: NmMessageFromServer[] = [];
   private nmConnected = false;
+  /** A-4:本进程生命周期内是否曾建立过 NM 连接。区分「冷启动等首连」与「从未连接」。 */
+  private everConnected = false;
   private stdout: NodeJS.WritableStream;
   private sessions: SessionManager;
   private requestCounter = 0;
@@ -27,6 +29,7 @@ export class MessageRouter {
   setNmConnected(connected: boolean): void {
     this.nmConnected = connected;
     if (connected) {
+      this.everConnected = true;
       this.flushBuffer();
     } else {
       // stdin 'end' = 扩展 SW 拥有的 NM 通道永久关闭(本进程 stdin 终态,之后无 data;
@@ -105,6 +108,22 @@ export class MessageRouter {
         ...(nmReq.args as Record<string, unknown>),
         trustedMode: detectTrustedMode(),
       };
+    }
+
+    // A-4:NM 从未建立连接(手动启 server / NM 配置错)→ 没有 SW 会连上来,buffer 只是
+    // 干等满 30s 才 TIMEOUT。此场景立即 fail-fast 为 EXTENSION_NOT_CONNECTED。Chrome 正常
+    // spawn 本进程时 SW 在毫秒内即发首条 NM 消息(everConnected 先于任何 WS 请求置真),
+    // 故不影响冷启动;曾连接过(everConnected)则照常走下方 buffer/BRIDGE-2。
+    if (!this.nmConnected && !this.everConnected) {
+      this.sendToClient({
+        action: vtxReq.action,
+        id: vtxReq.id,
+        error: {
+          code: VtxErrorCode.EXTENSION_NOT_CONNECTED,
+          message: "Extension has never connected (native messaging not established)",
+        },
+      });
+      return;
     }
 
     const timeout = setTimeout(() => {

--- a/packages/server/tests/health.test.ts
+++ b/packages/server/tests/health.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import express from "express";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { MessageRouter } from "../src/message-router.js";
+
+function mkStdout() {
+  return { write: vi.fn() } as unknown as NodeJS.WritableStream;
+}
+function mkSessions() {
+  return { getClient: () => null } as any;
+}
+
+async function startApp(connected: boolean): Promise<{ port: number; close: () => void }> {
+  const router = new MessageRouter(mkStdout(), mkSessions());
+  if (connected) router.setNmConnected(true);
+  const { createHttpRoutes } = await import("../src/http-routes.js");
+  const app = express();
+  app.use(createHttpRoutes(router));
+  const server = createServer(app);
+  await new Promise<void>((r) => server.listen(0, r));
+  const port = (server.address() as AddressInfo).port;
+  return { port, close: () => server.close() };
+}
+
+describe("GET /health A-3:暴露 NM 连接状态", () => {
+  it("扩展未连:nmConnected=false(监控据此判定链路不可用,非假绿)", async () => {
+    const { port, close } = await startApp(false);
+    const res = await fetch(`http://127.0.0.1:${port}/health`);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+    expect(body.nmConnected).toBe(false);
+    close();
+  });
+
+  it("扩展已连:nmConnected=true", async () => {
+    const { port, close } = await startApp(true);
+    const res = await fetch(`http://127.0.0.1:${port}/health`);
+    const body = await res.json();
+    expect(body.nmConnected).toBe(true);
+    close();
+  });
+});

--- a/packages/server/tests/message-router-never-connected.test.ts
+++ b/packages/server/tests/message-router-never-connected.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MessageRouter } from "../src/message-router.js";
+import { VtxErrorCode } from "@vortex-browser/shared";
+import type { VtxRequest } from "@vortex-browser/shared";
+
+/**
+ * A-4:NM 从未建立连接(手动启 server / NM 配置错)时,WS async 路径不应入 buffer 干等
+ * 满 30s,而应立即 fail-fast 为 EXTENSION_NOT_CONNECTED。曾连接过(SW 睡眠/断开)则保留
+ * buffer 语义不变(冷启动等首连 / BRIDGE-2)。
+ */
+function mkStdout() {
+  return { write: vi.fn() } as unknown as NodeJS.WritableStream;
+}
+function mkWs() {
+  return { readyState: 1, send: vi.fn() };
+}
+function mkSessions(ws: ReturnType<typeof mkWs>) {
+  return { getClient: () => ws } as any;
+}
+function req(id: string, action = "page.info"): VtxRequest {
+  return { action, id, params: {} };
+}
+
+describe("A-4: NM 从未连接 fail-fast", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("从未 setNmConnected(true) → routeToExtension 立即返 EXTENSION_NOT_CONNECTED(不 buffer)", () => {
+    const ws = mkWs();
+    const router = new MessageRouter(mkStdout(), mkSessions(ws));
+    router.routeToExtension(req("mcp-1"));
+    expect(ws.send).toHaveBeenCalledTimes(1);
+    const sent = JSON.parse((ws.send as any).mock.calls[0][0]);
+    expect(sent.id).toBe("mcp-1");
+    expect(sent.error.code).toBe(VtxErrorCode.EXTENSION_NOT_CONNECTED);
+  });
+
+  it("立即 fail-fast 不挂 30s 定时器(快进 30s 无第二次投递)", () => {
+    const ws = mkWs();
+    const router = new MessageRouter(mkStdout(), mkSessions(ws));
+    router.routeToExtension(req("mcp-1"));
+    (ws.send as any).mockClear();
+    vi.advanceTimersByTime(31_000);
+    expect(ws.send).not.toHaveBeenCalled(); // 无 TIMEOUT 兜底投递,证明走的是 fail-fast 而非 buffer
+  });
+
+  it("曾连接过(connect→disconnect)→ 后续请求仍 buffer,不立即 fail-fast", () => {
+    const ws = mkWs();
+    const router = new MessageRouter(mkStdout(), mkSessions(ws));
+    router.setNmConnected(true); // everConnected = true
+    router.setNmConnected(false); // 断开,everConnected 仍 true
+    (ws.send as any).mockClear();
+    router.routeToExtension(req("mcp-2"));
+    // everConnected=true → 跳过 fail-fast,入 buffer,故无立即投递
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it("NM 在线时 routeToExtension 正常写 stdout,不 fail-fast", () => {
+    const ws = mkWs();
+    const stdout = mkStdout();
+    const router = new MessageRouter(stdout, mkSessions(ws));
+    router.setNmConnected(true);
+    router.routeToExtension(req("mcp-3"));
+    expect(ws.send).not.toHaveBeenCalled();
+    expect(stdout.write).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 背景

基于知识库 `0013-vortex-环境回归与新功能验证` 的 opencode 评测报告(6 条异常),**逐条白盒核实 + 真实环境验证**后修复确认为真的缺陷。核心纪律:报告诊断默认不可信;承重改动须**真实扩展端到端验证**(mock 单测与 Playwright 页面复刻都不够)。

## 修复(3 个真缺陷)

### A-1 observe 长导航吃光 maxElements,主内容 0 召回(P0)
- **现象**:文档站「左导航 + 右主内容」布局,observe 截断后主内容 demo 0 召回。
- **真实扩展验证驱动的迭代**(关键):前两次修复(main-content 优先 → 导航降权)经 mock 单测 + Playwright 复刻看似有效,但**真实扩展 observe 实测 semi.design 仍 0 demo**。根因:侧栏 `ul[role=menu].semi-navigation-list`(228 项)被既有 overlay-priority 误判为浮层(role=menu 属弹层集 + 常驻容器 position:fixed 过 isFloatingOverlay),overlayEls 吃光 maxElements 预算。
- **最终修复**:① `isPersistentNavMenu` —— role=menu/tree 无触发器(aria-controls/owns 关联)或在 `<nav>` landmark 内 = 持久导航结构,排除出浮层根(真弹层 listbox 不受影响);② `allCandidates` 组合 overlay + 内容区/导航三层排序(原互斥),组件库 demo 页常驻 ARIA 浮层时主内容仍召回。
- **真实扩展 observe 验证**:semi.design 前 80 从「全侧栏 nav / 0 demo」→「28+ 个 Select combobox demo + 代码编辑器 + API tab / 0 侧栏」(生产构建 mqlthnfg 确认)。
- commits: `44b39a2`(初版) + `52e7468`(导航降权) + `a32424b`(真实扩展验证·持久菜单误判修复)

### A-1 泛化:ant.design 二次实机暴露第二失败模式(`ed95977`)
- **现象**:换 ant.design Select 页真机 re-observe,前 80 **又**全是侧栏 74 项跨页导航(`/components/*`)、0 个 Select demo。
- **白盒根因(与 semi.design 不同的失败模式)**:ant 侧栏 `role=menu.ant-menu-inline` 位于 `<main>` **内部**、`position:static` 无 fixed 祖先 —— 既不走 overlay-priority(无脱流定位),也不在 `<nav>` landmark 内(`isNavA1` 漏判),故被 main-content-priority 当"主内容"整体前置,74 项 DOM 序前于 165 个真 demo。`isPersistentNavMenu` 修不到此处(它只管 overlay 收集)。
- **修复 `isNavMenuRoot`**:role=menu/tree 且(在 nav/menubar landmark 内,或菜单项 ≥5 且**多数为跨页 `<a href>` 链接**)→ 判为导航菜单,从 main 层降到 nav 层。跨页链接判据(`/components/*` ratio 1.0)把"被演示的 Menu 组件"(项无跨页链接)排除,不误伤 `/components/menu` 内容区。
- **真实扩展 observe 验证**(生产构建 `1.0.0+mqlw00al`):ant.design Select 前 80 由「74 侧栏导航 / 0 demo」→「0 侧栏 / Select combobox `[haspopup:listbox]` + 各 demo 的 code/Expand Icon/open-in-new-tab 控件浮现」。
- 单测:`isNavMenuRoot` 6(nav 内 / 跨页链接 / 被演示 Menu / 锚点# / <5 项 / 非 menu role)+ ant 场景 partition 1 + inline source-lock 1。

### A-3 /health 不报 NM 状态(P0)
- 加 `nmConnected: router.isNmConnected()`。**真实 server**:`curl /health` 返回 `{"status":"ok","nmConnected":false,...}`。commit `39c9b28`

### A-4 NM 从未连接时 WS 路径卡 30s(P0 子缺陷)
- `everConnected` 标志,从未连接时立即 fail-fast。**真实 server + WS 客户端**:发 `tab.list` → 14ms 返 `EXTENSION_NOT_CONNECTED`(非 30000ms TIMEOUT)。commit `94ca423`

## 核实订正(未改码)

### A-2 server 进程随 SW 死被杀 —— 实机复现确认=误诊
`native-host.sh` 用 `exec node`(NM host 即 node 进程),关闭 stdin(模拟 SW 死)→ 进程仍存活、`/health` 仍响应(BRIDGE-2 保活)。报告观察到的进程消失真因是 vortex 自身 `killOldProcess()`(`index.ts:85`,新 server 启动杀旧)+ EADDRINUSE `lsof -ti:6800|xargs kill -9`(`index.ts:159-163`)单实例强制,非「随 SW 死亡退出」。报告根因模型与 fork-watchdog 修复方向均误,确认误诊。

### 其余
- A-5(多 mcp 进程):配置层,非代码缺陷。
- A-6(无 standalone):A-4 已让手动启 server 给出干净 fail-fast。

## 测试计划
- [x] A-1 真实扩展 observe 端到端验证(semi.design,前 80 demo 0→28+,生产构建 mqlthnfg 确认)
- [x] A-1 泛化真机验证(ant.design,前 80 侧栏 74→0 / Select combobox demo 浮现,生产构建 mqlw00al 确认)
- [x] A-1 单测(partitionMainContentFirst 9 + isPersistentNavMenu 6 + isNavMenuRoot 6 + source-lock 4)
- [x] A-3 单测 2 + 真实 server curl;A-4 单测 4 + 真实 server WS(14ms)
- [x] A-2 实机复现(关闭 stdin 进程存活,确认误诊)
- [x] extension 全量 1274 通过 / server 全量 38 通过
- [x] 每个修复因果验证(还原源码→测试 RED;恢复→GREEN);tsc 零错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)

