### PR TITLE
fix(act): silent-false-success 回读加固(contentEditable type + 单值 select)

### DIFF
--- a/packages/extension/src/handlers/dom.ts
+++ b/packages/extension/src/handlers/dom.ts
@@ -1249,6 +1249,17 @@ export function registerDomHandlers(
             }
             el.value = opt.value;
             el.dispatchEvent(new Event("change", { bubbles: true }));
+            // 回读校验副作用真发生(对齐多选路径 selectedNow 校验):受控/约束 <select>
+            // 可能在 change 监听中把选择 snap-back 还原(React 受控拒收、业务约束回弹),
+            // el.value 读回 ≠ 意图 = 选择被拒,报 NO_EFFECT 而非假成功(2026-06-20 白盒复现)。
+            // option value 是精确值无规范化(不同于 FILL 自由文本的克制空判),严格比对无假阳。
+            if (el.value !== opt.value) {
+              return {
+                errorCode: "NO_EFFECT",
+                error: `<select> ${sel} did not retain selection "${String(val)}" (value is "${el.value}" after change; likely a controlled/constrained select reverting)`,
+                extras: { intended: opt.value, actual: el.value },
+              };
+            }
             return { result: { success: true, value: el.value } };
           } catch (err) {
             return { error: err instanceof Error ? err.message : String(err) };

--- a/packages/extension/src/handlers/dom.ts
+++ b/packages/extension/src/handlers/dom.ts
@@ -622,6 +622,7 @@ export function registerDomHandlers(
       const probe = await nativePageQuery<{
         ok?: true;
         isContentEditable?: boolean;
+        ceText?: string;
         errorCode?: string;
         error?: string;
         extras?: Record<string, unknown>;
@@ -682,7 +683,13 @@ export function registerDomHandlers(
               editSel.addRange(range);
             }
           }
-          return { ok: true, isContentEditable: el.isContentEditable === true };
+          return {
+            ok: true,
+            isContentEditable: el.isContentEditable === true,
+            // 回读校验基线:contentEditable 写入前的文本(select-all 不改 textContent,
+            // 此处捕获安全)。host 端 insertText 后比对,识别编辑器拒收(族 A 护栏)。
+            ceText: el.isContentEditable ? (el.textContent ?? "") : undefined,
+          };
         },
         [selector, text !== ""],
       );
@@ -708,6 +715,35 @@ export function registerDomHandlers(
           }
         } else {
           await debuggerMgr.sendCommand(tid, "Input.insertText", { text });
+        }
+        // 族 A silent-false-success 护栏(对齐 input/textarea 路径 786-793 的回读校验):
+        // CDP Input.insertText 即便被编辑器 beforeinput.preventDefault(只读/受限富文本)
+        // 拒绝也不抛错。回读 textContent,若非空文本写完内容完全未变(now===before)且未含
+        // 写入文本(now!==txt)→ 编辑器拒收,报 NO_EFFECT 而非假成功(2026-06-20 白盒复现)。
+        // now!==txt 排除「重输相同文本」假阳;成功插入必改 textContent(now!==before)已先排除。
+        if (text !== "") {
+          const verify = await nativePageQuery<{
+            errorCode?: string;
+            error?: string;
+            extras?: Record<string, unknown>;
+          } | undefined>(
+            tid,
+            frameId,
+            (sel: string, before: string, txt: string) => {
+              const els = (window as any).__vortexDomResolve.queryAllDeep(sel) as Element[];
+              const now = els.length ? ((els[0] as HTMLElement).textContent ?? "") : "";
+              if (now === before && now !== txt) {
+                return {
+                  errorCode: "NO_EFFECT",
+                  error: `Element ${sel} rejected typed text "${txt}" (contentEditable unchanged; likely a read-only or input-guarded editor)`,
+                  extras: { attempted: txt },
+                };
+              }
+              return {};
+            },
+            [selector, probe?.ceText ?? "", text],
+          );
+          if (verify?.error) mapPageError(verify, selector);
         }
         const cdpTypeResult = { success: true, typed: text.length, path: "cdp-insertText" };
         return __healType.healed ? { ...cdpTypeResult, healed: true } : cdpTypeResult;

--- a/packages/extension/tests/act-primitives-p1-batch4-family-i.test.ts
+++ b/packages/extension/tests/act-primitives-p1-batch4-family-i.test.ts
@@ -24,9 +24,11 @@ const CB_SRC = readFileSync(
   "utf8",
 );
 
-// 原生 SELECT handler 区间
+// 原生 SELECT handler 区间:以下一个 handler([DomActions.SCROLL])为界,
+// 抗 SELECT 块增长(原固定 +9200 偏移在 SELECT 加回读护栏后会把 args 数组挤出窗口)。
 const selectIdx = DOM_SRC.indexOf("[DomActions.SELECT]");
-const SELECT_BLOCK = DOM_SRC.slice(selectIdx, selectIdx + 9200);
+const scrollIdx = DOM_SRC.indexOf("[DomActions.SCROLL]", selectIdx);
+const SELECT_BLOCK = DOM_SRC.slice(selectIdx, scrollIdx > selectIdx ? scrollIdx : selectIdx + 9200);
 
 describe("族 I #25 — checkbox-group label 折叠内部空白匹配", () => {
   it("不再用 (b.innerText||\"\").trim() === name 严格等值", () => {

--- a/packages/extension/tests/dom-select-option-match.test.ts
+++ b/packages/extension/tests/dom-select-option-match.test.ts
@@ -36,4 +36,21 @@ describe("SELECT handler native <select> option 匹配", () => {
     expect(idxErr).toBeGreaterThan(-1);
     expect(idxAssign).toBeGreaterThan(idxErr);
   });
+
+  // silent-false-success 护栏回归锁(白盒实机复现,2026-06-20)。
+  //
+  // 现象:受控/约束 <select> 在 change 监听中把选择 snap-back 还原(如 React 受控
+  //   组件拒收、业务约束回弹)。单值路径 `el.value=opt.value` → dispatch change →
+  //   读回被还原的 el.value 后无条件 return {success:true},不与意图 opt.value 比对,
+  //   对「选了 B 实则回到 A」报假成功。多选路径有 selectedNow 回读(1221),单值漏。
+  //
+  // 修复:单值 dispatch change 后比对 el.value !== opt.value → NO_EFFECT。option value
+  //   是精确值无规范化(不同于 FILL 的自由文本),严格比对无假阳风险。
+  it("单值选择 dispatch change 后回读校验,被还原 → NO_EFFECT(非假成功)", () => {
+    // change 之后必须有 el.value !== opt.value 的回读守卫,且接 NO_EFFECT。
+    const guard = DOM_SRC.match(
+      /el\.value = opt\.value[\s\S]*?el\.value\s*!==\s*opt\.value[\s\S]*?errorCode:\s*"NO_EFFECT"/,
+    );
+    expect(guard).not.toBeNull();
+  });
 });

--- a/packages/extension/tests/dom-type-contenteditable.test.ts
+++ b/packages/extension/tests/dom-type-contenteditable.test.ts
@@ -106,4 +106,30 @@ describe("dom.type contentEditable path (@since 0.8.x Round-1 R1-A)", () => {
     // probe 的 selectAll 实参由 `text !== ""` 传入,空串不全选不清空。
     expect(DOM_SRC).toMatch(/\[selector,\s*text\s*!==\s*""\]/);
   });
+
+  // silent-false-success 护栏回归锁(白盒实机复现,2026-06-20)。
+  //
+  // 现象:对 beforeinput.preventDefault() 的只读/受限富文本编辑器 type 文本,
+  //   CDP Input.insertText 被拒、内容纹丝未动,但 contentEditable 路径无回读校验,
+  //   照报 {success:true, typed:N}。与 input/textarea 路径(786-793 回读 NO_EFFECT)
+  //   护栏不对称——族 A 遗漏点。
+  //
+  // 修复:probe 捕获写入前 textContent(ceText),insertText 后回读比对,内容完全
+  //   未变且未含写入文本 → NO_EFFECT。
+  it("contentEditable 路径 probe 捕获写入前文本基线(ceText)", () => {
+    // probe 返回 ceText 作为回读校验基线。
+    expect(DOM_SRC).toMatch(/ceText/);
+  });
+
+  it("contentEditable insertText 后回读校验,内容未变且未含写入文本 → NO_EFFECT", () => {
+    // insertText 之后、cdp-insertText 结果之前,必须有一次回读把 NO_EFFECT 守卫
+    // 接到 mapPageError(对齐 input/textarea 路径的硬失败上报)。
+    const guard = DOM_SRC.match(
+      /Input\.insertText[\s\S]*?errorCode:\s*"NO_EFFECT"[\s\S]*?path:\s*"cdp-insertText"/,
+    );
+    expect(guard).not.toBeNull();
+    // 守卫条件:内容完全未变(now === before)且未含写入文本(now !== txt),
+    // 避免「重输相同文本」假阳、对齐 input 路径只报硬失败的克制。
+    expect(DOM_SRC).toMatch(/now\s*===\s*before\s*&&\s*now\s*!==\s*txt/);
+  });
 });


### PR DESCRIPTION
## 背景

白盒审核 act 原语时,用「原语上报 success 前是否回读验证副作用真发生」这把刀做系统性 sweep,实机复现 **2 个同类缺陷**——sibling 代码路径间回读护栏不对称,导致动态拒收/还原场景下 silent-false-success。agent 拿到假成功会带错误信号继续,污染任务链。

## 缺陷 1:contentEditable `type`(commit f401c89)

**复现**:对只读/受限富文本编辑器(`beforeinput.preventDefault()`)`type` 文本,CDP `Input.insertText` 被拒、内容不变,但报 `{success:true, typed:N}`。

**根因**:input/textarea 路径写后回读 `el.value` 报 NO_EFFECT(786-793),contentEditable 路径(697-714)`insertText` 后无任何回读。

**修复**:probe 捕获写入前 `textContent`(ceText),insertText 后回读比对 `now===before && now!==txt` → NO_EFFECT(`now!==txt` 排除「重输相同文本」假阳)。

## 缺陷 2:原生 `<select>` 单值(commit a8eb32c)

**复现**:受控/约束 `<select>` 在 change 监听中 snap-back 还原,`select "Option B"` 实则回到 A,但报 `{success:true, value:"a"}`。

**根因**:单值路径 `el.value=opt.value`→dispatch change→读回被还原的 `el.value` 后无条件 success,不与意图比对。多选路径有 `selectedNow` 回读(1221),单值漏。

**修复**:单值 dispatch change 后比对 `el.value !== opt.value` → NO_EFFECT。option value 精确无规范化,严格比对无假阳。

## 验证(均真机端到端 live 扩展)

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 只读 contenteditable type | `success:true` ❌ | `NO_EFFECT` ✓ |
| 普通 contenteditable type | success | `success`+内容变 ✓ |
| 重输相同文本(假阳边界) | — | `success`(不误报)✓ |
| 受控 select 还原 | `success:true,value:"a"` ❌ | `NO_EFFECT` ✓ |
| 正常 select | success | `success`(不误报)✓ |

- 单测:`dom-type-contenteditable.test.ts` +2、`dom-select-option-match.test.ts` +1 source-lock 回归锁;`act-primitives-p1-batch4-family-i.test.ts` SELECT_BLOCK 切片改以下一 handler 为界(抗块增长)。
- ext 全量 **1254 通过**(177 文件)。
- 污染浏览器环境下全程显式 pin `tabId` 取得可信回读。

## Test plan

- [x] `pnpm exec vitest run` 1254 通过
- [x] `pnpm build` 类型/打包正常
- [x] 真机复测:两类 silent-success 均变 NO_EFFECT,对照组与假阳边界均正确