### PR TITLE
fix(page): wait_for element 模式补 attributes 监听堵属性变更失明

### DIFF
--- a/packages/extension/src/handlers/page.ts
+++ b/packages/extension/src/handlers/page.ts
@@ -302,7 +302,11 @@ export function registerPageHandlers(router: ActionRouter, debuggerMgr: Debugger
               const observer = new MutationObserver(() => {
                 if (document.querySelector(sel)) { observer.disconnect(); resolve(true); }
               });
-              observer.observe(document.body, { childList: true, subtree: true });
+              // attributes:true 不可省——常见诉求是等已存在元素的 class/属性翻转满足
+              // selector(#modal.open / [aria-expanded=true] / li.selected),纯属性变更
+              // 不产生 childList,缺 attributes 则 observer 失明 → 条件已满足仍 TIMEOUT
+              // (2026-06-20 白盒机制+live 双证;静止页可靠失败,churn 页间歇掩盖)。
+              observer.observe(document.body, { childList: true, subtree: true, attributes: true });
               setTimeout(() => { observer.disconnect(); resolve(false); }, ms);
             });
           },

--- a/packages/extension/tests/page-wait-ref-resolve.test.ts
+++ b/packages/extension/tests/page-wait-ref-resolve.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import type { NmRequest } from "@vortex-browser/shared";
 import { ActionRouter } from "../src/lib/router.js";
 import { registerPageHandlers } from "../src/handlers/page.js";
@@ -85,5 +88,32 @@ describe("page.wait @ref 解析 (BUG-002 N0063)", () => {
     expect(resp.error).toBeUndefined();
     expect(resp.result).toMatchObject({ waited: 30 });
     expect(executeScript).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * element 模式 MutationObserver 属性变更失明回归锁(白盒实机复现,2026-06-20)。
+ *
+ * 现象:wait_for(mode=element, "#x.ready") 等已存在元素的 class/属性翻转满足时,
+ *   observer 配置 `{ childList: true, subtree: true }` 缺 attributes,classList.add
+ *   不触发回调 → 即便条件满足仍 TIMEOUT。机制级(0 churn、DOM 匹配、回调从不触发)
+ *   + live(class 8s 加上、元素真实匹配、12s TIMEOUT)双证。有后台 DOM churn 的页面
+ *   会间歇性掩盖,静止/完成态页面可靠失败。
+ *
+ * 修复:observer 加 attributes:true,attributeName=class/aria-* 等翻转即重查 querySelector。
+ */
+describe("page.wait element 模式属性变更检测", () => {
+  const PAGE_SRC = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "..", "src", "handlers", "page.ts"),
+    "utf8",
+  );
+  it("MutationObserver 监听 attributes(已存在元素 class/属性翻转可被检测)", () => {
+    // observer.observe 配置须含 attributes: true(否则纯属性变更失明)。
+    const cfg = PAGE_SRC.match(
+      /observer\.observe\(\s*document\.body,\s*\{[^}]*attributes:\s*true[^}]*\}\s*\)/,
+    );
+    expect(cfg).not.toBeNull();
+    // childList/subtree 不回归(节点增删仍检测)。
+    expect(PAGE_SRC).toMatch(/observer\.observe\(\s*document\.body,\s*\{[^}]*childList:\s*true[^}]*subtree:\s*true/);
   });
 });


### PR DESCRIPTION
## 背景

白盒审核 `wait_for` 时实机复现:`wait_for(mode=element)` 等**已存在元素的 class/属性翻转**满足 selector 时静默 TIMEOUT,即便条件已满足。

常见受害模式:`#modal.open`、`[aria-expanded=true]`、`li.selected`、`.btn.loading-done`——元素一直在 DOM 里,只是状态类/属性翻转。

## 根因

element 模式的 MutationObserver 配置(`page.ts`):
```js
observer.observe(document.body, { childList: true, subtree: true });  // 缺 attributes
```
`classList.add` 等纯属性变更**不产生 childList 记录** → observer 回调永不触发 → 即便 `querySelector(sel)` 已匹配也等到超时。

## 复现(双重证实)

1. **机制级白盒**:复刻完全相同的 observer 配置,`classList.add` 后 —— `nowMatches:true`(DOM 匹配)、`childListFires:0`(无 churn)、`observerCallbackSawMatch:false`(**回调从不触发**)。
2. **live**:fixture 在 +8s 给已存在 `#x` 加 class `ready`,`wait_for "#x.ready"` timeout 12000 → **TIMEOUT**;同时 `evaluate` 确认 `#x.ready` 真实匹配(`className="ready"`)。

**掩盖机制**:有后台 DOM churn(节点增删)的页面会顺带触发 observer 重查、间歇性掩盖此 bug;**静止/完成态页面**(常见 SPA 视图)可靠失败。

## 修复

observer 加 `attributes: true`:
```js
observer.observe(document.body, { childList: true, subtree: true, attributes: true });
```
class/aria-*/data-* 等翻转即触发回调重查 `querySelector`。`childList`/`subtree` 保留,节点增删检测不回归。

## 验证(真机端到端)

| 设置 | 修复前 | 修复后 |
|---|---|---|
| +8s 加 class,wait_for 12s | **TIMEOUT** ❌ | **found:true** ✓ |

同 8s-arm/12s 设置前后对照隔离修复效果(纯属性变更 `found` 唯一来源是 attributes 监听)。

- 单测:`page-wait-ref-resolve.test.ts` +1 source-lock 回归锁(observe 配置含 attributes:true,且 childList/subtree 不回归)。
- ext 全量 **1255 通过**(177 文件)。
- 污染浏览器环境全程 pin `tabId`(inactive 受控 fixture)。

## Test plan

- [x] `pnpm exec vitest run` 1255 通过
- [x] `pnpm build` 类型/打包正常
- [x] 真机复测:修复前 TIMEOUT → 修复后 found:true