### PR TITLE
fix(query): vortex_query 两模式穿 open shadow 堵静默漏报

### DIFF
--- a/packages/extension/src/handlers/query.ts
+++ b/packages/extension/src/handlers/query.ts
@@ -36,26 +36,42 @@ export const textSearchFunc = (
     //  ② display:none / visibility:hidden / 祖先隐藏 由 Element.checkVisibility() 兜底
     //     (Chrome 105+);老环境无此 API 时跳过该判定,保持向后兼容(不误杀可见文本)。
     const SKIP_TEXT_TAGS = new Set(["SCRIPT", "STYLE", "NOSCRIPT", "TEMPLATE"]);
-    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
-      acceptNode(n: Node): number {
-        const parent = (n as Text).parentElement;
-        if (!parent) return NodeFilter.FILTER_REJECT;
-        if (SKIP_TEXT_TAGS.has(parent.tagName)) return NodeFilter.FILTER_REJECT;
-        const cv = (parent as unknown as { checkVisibility?: () => boolean }).checkVisibility;
-        if (typeof cv === "function" && !cv.call(parent)) return NodeFilter.FILTER_REJECT;
-        return NodeFilter.FILTER_ACCEPT;
-      },
-    });
     let fullText = "";
     const nodeOffsets: Array<{ offset: number; length: number; node: Node }> = [];
-    while (walker.nextNode()) {
-      const node = walker.currentNode;
-      const text = node.textContent;
-      if (text && text.trim()) {
-        nodeOffsets.push({ offset: fullText.length, length: text.length, node });
-        fullText += text;
+    // 穿 open shadow:每个 root 用 TreeWalker 高效遍历自身 light 文本,再对其内
+    // shadow host 递归(深度封顶 8,与 observe querySelectorAllDeep 同语义)。
+    // 旧实现仅 createTreeWalker(document.body) 不下降 shadow root → web-component
+    // 页面 shadow 内文本被静默漏抓(text total:0,无信号)。closed shadow 的
+    // shadowRoot 返 null 天然不穿。顺序:light 文本在前、各 shadow root 文本顺次追加
+    // (同 querySelectorAllDeep 的 light-先/shadow-后);grep 上下文与 element_path
+    // 按 nodeOffsets 解析,不依赖严格文档序。
+    const SHADOW_WALK_MAX_DEPTH = 8;
+    const collectRoot = (root: Document | ShadowRoot | Element, depth: number): void => {
+      const walker = document.createTreeWalker(root as Node, NodeFilter.SHOW_TEXT, {
+        acceptNode(n: Node): number {
+          const parent = (n as Text).parentElement;
+          if (!parent) return NodeFilter.FILTER_REJECT;
+          if (SKIP_TEXT_TAGS.has(parent.tagName)) return NodeFilter.FILTER_REJECT;
+          const cv = (parent as unknown as { checkVisibility?: () => boolean }).checkVisibility;
+          if (typeof cv === "function" && !cv.call(parent)) return NodeFilter.FILTER_REJECT;
+          return NodeFilter.FILTER_ACCEPT;
+        },
+      });
+      while (walker.nextNode()) {
+        const node = walker.currentNode;
+        const text = node.textContent;
+        if (text && text.trim()) {
+          nodeOffsets.push({ offset: fullText.length, length: text.length, node });
+          fullText += text;
+        }
       }
-    }
+      if (depth >= SHADOW_WALK_MAX_DEPTH) return;
+      for (const host of (root as Document | ShadowRoot).querySelectorAll("*")) {
+        const sr = (host as HTMLElement).shadowRoot;
+        if (sr) collectRoot(sr, depth + 1);
+      }
+    };
+    collectRoot(document.body, 0);
 
     let re: RegExp;
     try {
@@ -127,7 +143,7 @@ export const textSearchFunc = (
  * 参数通过 args: [selector, attributes, maxResults, includeText] 注入。
  * 返回 { elements, total, showing } 或 { error, elements: [], total: 0 }。
  */
-const cssQueryFunc = (
+export const cssQueryFunc = (
   selector: string,
   attributes: string[] | null,
   maxResults: number,
@@ -138,9 +154,24 @@ const cssQueryFunc = (
   showing: number;
 } | { error: string; elements: never[]; total: number } => {
   try {
-    let elements: NodeListOf<Element>;
+    // 穿 open shadow 深度遍历,与 observe 的 querySelectorAllDeep 同语义(98b61e5):
+    // document.querySelectorAll 只查 light DOM,web-component 页面 shadow 内元素被
+    // 静默漏计(css total 偏小,无 error 无信号)。closed shadow 的 shadowRoot 返
+    // null 天然不穿,与 observe 一致。⚠ 内联副本(注入 page-side 丢模块作用域),
+    // 逻辑须与 observe.ts querySelectorAllDeep 保持一致,改一处须同步。
+    const SHADOW_WALK_MAX_DEPTH = 8;
+    const queryAllDeep = (sel: string, root: Document | ShadowRoot, depth: number): Element[] => {
+      const acc: Element[] = Array.from(root.querySelectorAll(sel));
+      if (depth >= SHADOW_WALK_MAX_DEPTH) return acc;
+      for (const host of root.querySelectorAll("*")) {
+        const sr = (host as HTMLElement).shadowRoot;
+        if (sr) acc.push(...queryAllDeep(sel, sr, depth + 1));
+      }
+      return acc;
+    };
+    let elements: Element[];
     try {
-      elements = document.querySelectorAll(selector);
+      elements = queryAllDeep(selector, document, 0);
     } catch (e) {
       return { error: "Invalid CSS selector: " + (e instanceof Error ? e.message : String(e)), elements: [], total: 0 };
     }

--- a/packages/extension/tests/query-shadow-pierce.test.ts
+++ b/packages/extension/tests/query-shadow-pierce.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { JSDOM } from "jsdom";
+import { textSearchFunc, cssQueryFunc } from "../src/handlers/query.js";
+
+/**
+ * vortex_query open shadow 穿透回归锁(白盒实机复现,2026-06-20)。
+ *
+ * 现象:cssQueryFunc 用 document.querySelectorAll、textSearchFunc 用
+ *   createTreeWalker(document.body),两者都不下降 open shadow root。web-component
+ *   页面上 shadow 内的元素/文本 → css total 漏计、text total:0,无 error 无信号
+ *   (silent false-negative,agent 误读「不存在」)。sibling 感知原语 observe 用
+ *   深度封顶 8 的 querySelectorAllDeep 穿 open shadow(98b61e5),两者 reach 不一致。
+ *   live: example.com 注入 open-shadow host,observe 找到 2 button、query css 仅 1、
+ *   text 命中 0。
+ *
+ * 修复:两模式都改深度遍历穿 open shadow(与 observe 同语义,SHADOW_WALK_MAX_DEPTH=8,
+ *   closed shadow 的 shadowRoot 返 null 天然不穿)。textSearchFunc / cssQueryFunc 是
+ *   注入 page-side 的函数,JSDOM 直接执行验证真实遍历行为(JSDOM 实现 open shadow DOM)。
+ */
+describe("vortex_query 穿 open shadow(@since 2026-06-20 白盒审计)", () => {
+  beforeEach(() => {
+    const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>");
+    globalThis.window = dom.window as any;
+    globalThis.document = dom.window.document as unknown as Document;
+    (globalThis as any).Node = dom.window.Node;
+    (globalThis as any).NodeFilter = dom.window.NodeFilter;
+    (globalThis as any).HTMLElement = dom.window.HTMLElement;
+    (globalThis as any).Element = dom.window.Element;
+  });
+
+  function mountShadowFixture(): void {
+    document.body.innerHTML =
+      '<button id="light-btn">Light Button</button><div id="host"></div><p>VISIBLE_LIGHT_TEXT</p>';
+    const host = document.getElementById("host")!;
+    const sr = host.attachShadow({ mode: "open" });
+    sr.innerHTML =
+      '<button id="shadow-btn">Shadow Button</button><span>SHADOW_UNIQUE_TEXT_42</span>';
+  }
+
+  it("css 模式:count 含 open shadow 内 button(light 1 + shadow 1 = 2)", () => {
+    mountShadowFixture();
+    const r = cssQueryFunc("button", null, 20, true) as {
+      elements: Array<{ text?: string }>;
+      total: number;
+    };
+    expect(r.total).toBe(2);
+    const texts = r.elements.map((e) => e.text);
+    expect(texts).toContain("Light Button");
+    expect(texts).toContain("Shadow Button");
+  });
+
+  it("text 模式:grep 命中 open shadow 内文本", () => {
+    mountShadowFixture();
+    const r = textSearchFunc("SHADOW_UNIQUE_TEXT_42", false, false, 20, 10) as {
+      matches: unknown[];
+      total: number;
+    };
+    expect(r.total).toBe(1);
+    expect(r.matches).toHaveLength(1);
+  });
+
+  it("text 模式:light-DOM 文本不回归(仍命中)", () => {
+    mountShadowFixture();
+    const r = textSearchFunc("VISIBLE_LIGHT_TEXT", false, false, 20, 10) as { total: number };
+    expect(r.total).toBe(1);
+  });
+
+  it("css 模式:无 shadow 页面零漂移(light-DOM 计数不变)", () => {
+    document.body.innerHTML = '<button>A</button><button>B</button><a href="#">L</a>';
+    const r = cssQueryFunc("button", null, 20, true) as { total: number; elements: unknown[] };
+    expect(r.total).toBe(2);
+    expect(r.elements).toHaveLength(2);
+  });
+
+  it("css 模式:嵌套 open shadow 也穿(两层)", () => {
+    document.body.innerHTML = '<div id="outer"></div>';
+    const outer = document.getElementById("outer")!;
+    const sr1 = outer.attachShadow({ mode: "open" });
+    sr1.innerHTML = '<div id="inner"></div>';
+    const inner = sr1.getElementById("inner")!;
+    const sr2 = inner.attachShadow({ mode: "open" });
+    sr2.innerHTML = '<button>Deep Button</button>';
+    const r = cssQueryFunc("button", null, 20, true) as {
+      total: number;
+      elements: Array<{ text?: string }>;
+    };
+    expect(r.total).toBe(1);
+    expect(r.elements[0].text).toBe("Deep Button");
+  });
+});


### PR DESCRIPTION
## 背景

白盒审计感知原语时,对 `vortex_query` 与 sibling 原语 `observe` 做对照实验,发现 reach 不一致:`observe` 用深度封顶 8 的 `querySelectorAllDeep` 穿 open shadow(`98b61e5`),而 `vortex_query` 两个模式都停在 light DOM。

## 缺陷(白盒实机复现)

- **css 模式** `cssQueryFunc` 用 `document.querySelectorAll(selector)` —— 只查 light DOM。
- **text 模式** `textSearchFunc` 用 `createTreeWalker(document.body, …)` —— TreeWalker 不下降 shadow root。

web-component 页面(design system 普遍)上 shadow 内的元素/文本被**静默漏报**:css `total` 偏小、text `total:0`,无 `error` 无盲区信号 → agent 误读「不存在」(silent false-negative)。

### 复现(example.com 注入 open-shadow host:light 1 button + shadow 1 button)

| 调用 | 修前 | 修后 | observe(对照) |
|---|---|---|---|
| `query css "button"` | total **1** | total **2** | 2 |
| `query text "SHADOW_…"` | total **0** | total **1** | — |
| `query text "VISIBLE_LIGHT…"`(对照) | 1 | 1 | — |

## 修复

两模式改深度遍历穿 open shadow,与 `observe.ts` 的 `querySelectorAllDeep` 同语义:`SHADOW_WALK_MAX_DEPTH=8`、light 文本/元素在前 shadow 顺次追加、closed shadow 的 `shadowRoot` 返 null 天然不穿。**无 shadow 页面零漂移**。

## 测试

- 新增 `tests/query-shadow-pierce.test.ts`:JSDOM 直接执行注入函数,覆盖 css 计数/text grep/嵌套两层 shadow/light 不回归/零漂移,先 RED(3 fail)后 GREEN。
- 全量扩展套件 **1260 passed**(原 1255 + 新 5),query 既有 14 用例无回归。
- **实机复测**:build → 自动重载 → example.com fixture 重跑,css total 2 / text 1 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)