### PR TITLE
fix(capture): 截图 clip 补主文档滚动偏移修正滚动后元素截错

### DIFF
--- a/packages/extension/src/handlers/capture.ts
+++ b/packages/extension/src/handlers/capture.ts
@@ -93,6 +93,29 @@ async function captureTab(
 }
 
 /**
+ * 取顶层 frame(主文档)的滚动偏移。captureBeyondViewport:true 下 CDP clip 用「文档坐标」,
+ * 而 capture.element / computeFrameClip 经 getBoundingClientRect + getIframeOffset 拿到的是
+ * 「顶层视口相对坐标」。页面滚动后两者相差 window.scrollX/Y——不补这一项,滚动后截视口内某
+ * 元素会落到文档同 y 的另一处,返回错误元素截图(白盒实测 2026-06-20)。scrollY=0 时两坐标系
+ * 重合故仅在滚动页面暴露。跨源 iframe 内元素也只需补「顶层」滚动一次:祖先链各级自身滚动已
+ * 包含在 getBoundingClientRect 累加里,唯独顶层视口→文档的换算缺这一项。定位失败时返 {0,0}
+ * (退化为旧行为,绝不引入回归)。
+ */
+async function getTopScroll(tabId: number): Promise<{ x: number; y: number }> {
+  try {
+    const res = await chrome.scripting.executeScript({
+      target: { tabId }, // 不带 frameId → 顶层 frame
+      func: () => ({ result: { x: window.scrollX, y: window.scrollY } }),
+      world: "MAIN",
+    });
+    const v = (res[0]?.result as { result?: { x: number; y: number } })?.result;
+    return v ?? { x: 0, y: 0 };
+  } catch {
+    return { x: 0, y: 0 };
+  }
+}
+
+/**
  * 单截某 frame 时计算 viewport bbox 作 CDP clip。
  * 用 chrome.scripting.executeScript 在目标 frame 内取 documentElement bounding rect,
  * 再加 iframe-offset 拼绝对坐标。frameId=0 不走此路径(由 SCREENSHOT handler 守卫)。
@@ -115,9 +138,10 @@ async function computeFrameClip(
     throw vtxError(VtxErrorCode.JS_EXECUTION_ERROR, `Failed to compute clip for frameId=${frameId}`);
   }
   const { x: offsetX, y: offsetY } = await getIframeOffset(tabId, frameId);
+  const topScroll = await getTopScroll(tabId);
   return {
-    x: rect.x + offsetX,
-    y: rect.y + offsetY,
+    x: rect.x + offsetX + topScroll.x,
+    y: rect.y + offsetY + topScroll.y,
     width: rect.width,
     height: rect.height,
   };
@@ -237,19 +261,22 @@ export function registerCaptureHandlers(
         );
       }
 
-      // 2. iframe 坐标偏移（复用共享工具）
+      // 2. iframe 坐标偏移（复用共享工具）+ 顶层文档滚动偏移
+      //    （captureBeyondViewport:true 的 clip 用文档坐标,须把视口相对坐标补回滚动量）
       const { x: offsetX, y: offsetY } = await getIframeOffset(tid, frameId);
+      const topScroll = await getTopScroll(tid);
+      const absRect = {
+        x: rect.x + offsetX + topScroll.x,
+        y: rect.y + offsetY + topScroll.y,
+        width: rect.width,
+        height: rect.height,
+      };
 
       // 3. CDP 裁剪截图
       const { dataUrl } = await captureTab(debuggerMgr, tid, {
         format,
         quality,
-        clip: {
-          x: rect.x + offsetX,
-          y: rect.y + offsetY,
-          width: rect.width,
-          height: rect.height,
-        },
+        clip: absRect,
       });
 
       return {
@@ -257,12 +284,7 @@ export function registerCaptureHandlers(
         format,
         ...(format === "jpeg" && quality != null ? { quality } : {}),
         selector,
-        rect: {
-          x: rect.x + offsetX,
-          y: rect.y + offsetY,
-          width: rect.width,
-          height: rect.height,
-        },
+        rect: absRect,
         timestamp: Date.now(),
       };
     },

--- a/packages/extension/tests/capture-scroll-clip.test.ts
+++ b/packages/extension/tests/capture-scroll-clip.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NmRequest } from "@vortex-browser/shared";
+import { ActionRouter } from "../src/lib/router.js";
+import { registerCaptureHandlers } from "../src/handlers/capture.js";
+import { _resetPageSideLoader } from "../src/adapter/page-side-loader.js";
+
+/**
+ * capture.element / computeFrameClip clip 文档坐标回归锁(白盒实机复现,2026-06-20)。
+ *
+ * 现象:capture.element 用 getBoundingClientRect()(视口相对坐标)算 clip,但 CDP
+ *   Page.captureScreenshot 在 captureBeyondViewport:true 下 clip 用「文档坐标」。页面滚动
+ *   后两坐标系相差 window.scrollX/Y —— 截视口内某元素时 clip.y 落到文档同 y 的另一处,
+ *   返回的是错误元素的截图(silent-false-success,agent 被严重误导)。
+ *   live: example.com 注入 belowbox(文档 y=3000)+ topbox(文档 y=40),scrollTo(0,2900)
+ *   后 screenshot(#belowbox)(视口 top=100)→ 截到的是 topbox(文档 y=100 处),不是 belowbox。
+ *   scrollY=0 时两坐标系重合故场景1 假性通过,仅滚动页面暴露。
+ *
+ * 修复:clip 加顶层 frame 滚动偏移 getTopScroll(window.scrollX/Y),把顶层视口相对坐标
+ *   转成 captureBeyondViewport 期望的文档坐标。
+ */
+const RECT = { x: 10, y: 20, width: 100, height: 50 };
+
+function mkReq(action: string, args: Record<string, unknown>): NmRequest {
+  return { type: "tool_request", tool: action, args, requestId: "r-1", tabId: 42 };
+}
+
+function setup(scrollX: number, scrollY: number) {
+  _resetPageSideLoader();
+  let capturedClip: any;
+  let captureBeyond: boolean | undefined;
+  vi.stubGlobal("chrome", {
+    tabs: { query: vi.fn().mockResolvedValue([{ id: 42 }]) },
+    scripting: {
+      // rect 查询(args=[selector]) → 返回 RECT;getTopScroll(func 无 args) → 返回滚动量;
+      // loadPageSideModule(files) → 空。
+      executeScript: vi.fn((opts: any) => {
+        if (opts.files) return Promise.resolve([{}]);
+        if (opts.func && (!opts.args || opts.args.length === 0)) {
+          return Promise.resolve([{ result: { result: { x: scrollX, y: scrollY } } }]);
+        }
+        return Promise.resolve([{ result: { result: RECT } }]);
+      }),
+    },
+    webNavigation: { getAllFrames: vi.fn().mockResolvedValue([]) },
+  });
+  const debuggerMgr = {
+    enableDomain: vi.fn().mockResolvedValue(undefined),
+    sendCommand: vi.fn((_tab: number, method: string, params: any) => {
+      if (method === "Page.captureScreenshot") {
+        capturedClip = params.clip;
+        captureBeyond = params.captureBeyondViewport;
+        return Promise.resolve({ data: "BASE64" });
+      }
+      return Promise.resolve({});
+    }),
+  } as any;
+  const router = new ActionRouter();
+  registerCaptureHandlers(router, debuggerMgr);
+  return { router, getClip: () => capturedClip, getBeyond: () => captureBeyond };
+}
+
+describe("capture.element clip 文档坐标(滚动偏移修正)", () => {
+  beforeEach(() => vi.unstubAllGlobals());
+
+  it("页面滚动时 clip 加顶层滚动量(rect 视口坐标 → 文档坐标)", async () => {
+    const { router, getClip, getBeyond } = setup(0, 2900);
+    const resp = await router.dispatch(mkReq("capture.element", { selector: "#belowbox" }));
+    expect(resp.error).toBeUndefined();
+    // clip.y 必须是 rect.y(20) + scrollY(2900) = 2920,否则截到文档 y=20 的错误元素
+    expect(getClip().y).toBe(RECT.y + 2900);
+    expect(getClip().x).toBe(RECT.x + 0);
+    // captureBeyondViewport 须为 true(clip 存在),clip 才按文档坐标解释
+    expect(getBeyond()).toBe(true);
+  });
+
+  it("scrollY=0 时不变(无双重计入,旧行为不回归)", async () => {
+    const { router, getClip } = setup(0, 0);
+    const resp = await router.dispatch(mkReq("capture.element", { selector: "#topbox" }));
+    expect(resp.error).toBeUndefined();
+    expect(getClip().y).toBe(RECT.y);
+    expect(getClip().x).toBe(RECT.x);
+  });
+
+  it("横向滚动 scrollX 也计入", async () => {
+    const { router, getClip } = setup(500, 1200);
+    const resp = await router.dispatch(mkReq("capture.element", { selector: "#el" }));
+    expect(resp.error).toBeUndefined();
+    expect(getClip().x).toBe(RECT.x + 500);
+    expect(getClip().y).toBe(RECT.y + 1200);
+  });
+
+  it("返回的 rect 字段与实际截取区一致(文档坐标)", async () => {
+    const { router } = setup(0, 2900);
+    const resp = await router.dispatch(mkReq("capture.element", { selector: "#belowbox" }));
+    expect((resp.result as any).rect.y).toBe(RECT.y + 2900);
+  });
+});


### PR DESCRIPTION
## 缺陷(白盒审计 · silent-false-success)

`vortex_screenshot({target})` 在**页面已滚动**时会截到**错误的元素**,且返回"成功"+一张看似正常的图,无任何报错信号——严重误导 agent。

### 根因
`capture.element` / `computeFrameClip` 经 `getBoundingClientRect()` + `getIframeOffset()` 得到的是**顶层视口相对坐标**,但 CDP `Page.captureScreenshot` 在 `captureBeyondViewport`(clip 存在时恒为 true)下 clip 用**文档坐标**。两坐标系相差 `window.scrollX/Y`。`scrollY=0` 时恰好重合,故只在滚动页面暴露。

### 白盒实机复现
example.com 注入 belowbox(文档 y=3000)+ topbox(文档 y=40):
| 场景 | 操作 | 期望 | 实际(修复前) |
|---|---|---|---|
| scrollY=0 | screenshot(#belowbox) | 绿块 | ✅ 绿块(坐标系重合) |
| scrollY=2900 | screenshot(#belowbox)(视口 top=100) | 绿块 | ❌ **红块 TOPBOX**(clip.y=100 落到文档 y=100) |

## 修复
新增 `getTopScroll` 取顶层 frame `window.scrollX/Y`,在 `capture.element` 与 `computeFrameClip` 两处 clip 上累加,把视口相对坐标转成 `captureBeyondViewport` 期望的文档坐标。
- 跨源 iframe 内元素只需补**顶层**滚动一次(祖先链各级滚动已含在 `getBoundingClientRect` 累加里)。
- 定位失败退化 `{0,0}`,不引入回归。
- 返回的 `rect` 字段同步为文档坐标,与实际截取区一致。

## 验证
- TDD 4 用例(`capture-scroll-clip.test.ts`):滚动加偏移 / scrollY=0 不变(无双重计入) / 横向滚动 / rect 字段一致 —— RED→GREEN
- 实机复测:修复后滚动 2900 正确截到 belowbox;scrollY=0 截 topbox 无回归
- 全量 **1264 测试通过**,现有 capture 4 套测试无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)