### PR TITLE
fix(storage): session-get 补 maxLength 截断对齐 localStorage

### DIFF
--- a/packages/extension/src/handlers/storage.ts
+++ b/packages/extension/src/handlers/storage.ts
@@ -203,25 +203,41 @@ export function registerStorageHandlers(router: ActionRouter): void {
 
     [StorageActions.GET_SESSION_STORAGE]: async (args, tabId) => {
       const key = args.key as string | undefined;
+      // 对齐 GET_LOCAL_STORAGE(BUG-002):加 maxLength 校验 + 截断 trailer。否则大
+      // sessionStorage value 被 MCP 传输层静默截断、无 VORTEX_TRUNCATED 信号,agent 误读为
+      // 完整(sibling 路径不对称,白盒实测 2026-06-20:同 20000 字符值 op:get 截断有信号、
+      // op:session-get 原样返回无信号)。截断逻辑须与 GET_LOCAL_STORAGE 内联 truncate 同步。
+      const maxLength = (args.maxLength as number | undefined) ?? 10240;
+      if (!Number.isInteger(maxLength) || maxLength < 1 || maxLength > 5242880) {
+        throw vtxError(VtxErrorCode.INVALID_PARAMS,
+          `maxLength must be an integer in [1, 5242880]; got ${maxLength}`);
+      }
       const tid = await getActiveTabId((args.tabId as number | undefined) ?? tabId);
       const results = await chrome.scripting.executeScript({
         target: { tabId: tid },
-        func: (k: string | null) => {
+        func: (k: string | null, ml: number) => {
+          const lim = ml || 10240; // 兜底:防御性默认
+          const truncate = (s: string) => {
+            if (s.length <= lim) return s;
+            return s.slice(0, lim) + "\n\n[VORTEX_TRUNCATED original=" + s.length + " limit=" + lim + "] Call vortex_observe first for a structured index on large pages.";
+          };
           try {
             if (k) {
-              return { result: sessionStorage.getItem(k) };
+              const v = sessionStorage.getItem(k);
+              if (v == null) return { result: null };
+              return { result: truncate(v) };
             }
             const all: Record<string, string> = {};
             for (let i = 0; i < sessionStorage.length; i++) {
               const key = sessionStorage.key(i);
-              if (key) all[key] = sessionStorage.getItem(key) ?? "";
+              if (key) all[key] = truncate(sessionStorage.getItem(key) ?? "");
             }
             return { result: all };
           } catch (err) {
             return { error: err instanceof Error ? err.message : String(err) };
           }
         },
-        args: [key ?? null],
+        args: [key ?? null, maxLength],
         world: "MAIN",
       });
       const res = results[0]?.result as { result?: unknown; error?: string };

--- a/packages/extension/tests/storage-session-get-maxlength.test.ts
+++ b/packages/extension/tests/storage-session-get-maxlength.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ActionRouter } from "../src/lib/router.js";
+import { registerStorageHandlers } from "../src/handlers/storage.js";
+
+/**
+ * GET_SESSION_STORAGE maxLength 截断不对称回归锁(白盒实机复现,2026-06-20)。
+ *
+ * 现象:GET_LOCAL_STORAGE(BUG-002)有 maxLength + truncate + VORTEX_TRUNCATED trailer,
+ *   而 sibling 路径 GET_SESSION_STORAGE 完全没有——大 sessionStorage value 被 MCP 传输层
+ *   静默截断,无 trailer 无信号,agent 误读为完整(silent false-negative)。dispatch 层
+ *   (dispatch.ts:315)已把 maxLength 传给 storage.getSessionStorage,但 handler 从不读。
+ *   live: example.com 注入 20000 字符同值,op:get 截到 10240+trailer,op:session-get 原样
+ *   返回 20000 无 trailer。
+ *
+ * 修复:GET_SESSION_STORAGE 对齐 GET_LOCAL_STORAGE,加 maxLength 校验 + 内联 truncate。
+ */
+class StubStorage implements Storage {
+  private store: Record<string, string>;
+  length = 0;
+  constructor(init: Record<string, string>) {
+    this.store = { ...init };
+    this.length = Object.keys(init).length;
+  }
+  key(i: number): string | null { return Object.keys(this.store)[i] ?? null; }
+  getItem(k: string): string | null { return this.store[k] ?? null; }
+  setItem(k: string, v: string): void { this.store[k] = v; this.length = Object.keys(this.store).length; }
+  removeItem(k: string): void { delete this.store[k]; this.length = Object.keys(this.store).length; }
+  clear(): void { this.store = {}; this.length = 0; }
+}
+
+interface NmRequest {
+  type: "tool_request";
+  tool: string;
+  args: Record<string, unknown>;
+  requestId: string;
+  tabId: number;
+}
+function mkReq(tool: string, args: Record<string, unknown> = {}, tabId = 42): NmRequest {
+  return { type: "tool_request", tool, args, requestId: "r-1", tabId };
+}
+
+describe("GET_SESSION_STORAGE maxLength 截断(对齐 localStorage BUG-002)", () => {
+  let router: ActionRouter;
+  let executeScript: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.stubGlobal("sessionStorage", new StubStorage({ small: "x", big: "y".repeat(20000) }));
+    router = new ActionRouter();
+    executeScript = vi.fn();
+    vi.stubGlobal("chrome", {
+      tabs: { query: vi.fn().mockResolvedValue([{ id: 42 }]) },
+      webNavigation: {
+        getAllFrames: vi.fn().mockResolvedValue([{ frameId: 0, parentFrameId: -1, url: "https://x/" }]),
+      },
+      scripting: { executeScript },
+      runtime: { getManifest: vi.fn().mockReturnValue({ host_permissions: ["<all_urls>"] }) },
+    });
+    registerStorageHandlers(router);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  // 捕获注入到 page-side 的 func,在 Node 侧用 stub sessionStorage 真跑(逻辑须含截断)。
+  async function captureFunc(): Promise<(k: string | null, ml?: number) => { result?: unknown; error?: string }> {
+    executeScript.mockResolvedValue([{ result: { result: null } }]);
+    await router.dispatch(mkReq("storage.getSessionStorage", {}, 42));
+    const fn = executeScript.mock.calls[0][0].func;
+    executeScript.mockClear();
+    return fn;
+  }
+
+  it("传 key='big' + maxLength=100 → 截断 + trailer", async () => {
+    const fn = await captureFunc();
+    const out = fn("big", 100);
+    expect(out.result).toMatch(/^y{100}\n\n\[VORTEX_TRUNCATED original=20000 limit=100\]/);
+  });
+
+  it("传 key='big' + 不传 maxLength → 默认 10240 截断 + trailer", async () => {
+    const fn = await captureFunc();
+    const out = fn("big", undefined);
+    expect((out.result as string).length).toBeLessThanOrEqual(10240 + 200);
+    expect(out.result).toMatch(/\[VORTEX_TRUNCATED original=20000 limit=10240\]/);
+  });
+
+  it("传 key='small' → 返完整(未超限)", async () => {
+    const fn = await captureFunc();
+    const out = fn("small", undefined);
+    expect(out.result).toBe("x");
+  });
+
+  it("无 key(全量) + maxLength=50 → values 截断,keys 不受影响", async () => {
+    const fn = await captureFunc();
+    const out = fn(null, 50);
+    const r = out.result as Record<string, string>;
+    expect(r.big).toMatch(/\[VORTEX_TRUNCATED original=20000 limit=50\]/);
+    expect(r.small).toBe("x");
+  });
+
+  it("maxLength=0 或负数 → handler 抛 INVALID_PARAMS", async () => {
+    const out1 = (await router.dispatch(
+      mkReq("storage.getSessionStorage", { key: "small", maxLength: 0 }, 42),
+    )) as { error?: { code: string; message: string } };
+    expect(out1.error?.code).toBe("INVALID_PARAMS");
+    expect(out1.error?.message).toMatch(/maxLength/i);
+
+    const out2 = (await router.dispatch(
+      mkReq("storage.getSessionStorage", { key: "small", maxLength: -1 }, 42),
+    )) as { error?: { code: string } };
+    expect(out2.error?.code).toBe("INVALID_PARAMS");
+  });
+});


### PR DESCRIPTION
## 缺陷(白盒审计 · sibling 路径不对称 / silent false-negative)

`vortex_storage` 读 sessionStorage 大 value 时被 MCP 传输层**静默截断**,无 `VORTEX_TRUNCATED` 信号,agent 误读为完整数据。

### 根因
- `GET_LOCAL_STORAGE`(BUG-002 修过)有 `maxLength` 校验 + `truncate()` + `[VORTEX_TRUNCATED …]` trailer。
- sibling 路径 `GET_SESSION_STORAGE` **完全没有**——大 value 原样返回。
- dispatch 层(`dispatch.ts:315`)已把 `maxLength` 传给 `storage.getSessionStorage`,但 handler 从不读 → 参数被静默丢弃。

### 白盒实机复现(example.com 注入 20000 字符同值)
| op | 后端 | 结果(修复前) |
|---|---|---|
| `get` | localStorage | ✅ 截到 10240 + `[VORTEX_TRUNCATED original=20000 limit=10240]` |
| `session-get` | sessionStorage | ❌ 原样返回 20000,**无 trailer 无信号** |

## 修复
`GET_SESSION_STORAGE` 对齐 `GET_LOCAL_STORAGE`:加 `maxLength` 校验(`[1, 5242880]`,默认 10240)+ 内联 `truncate`(单 key 与全量两路径均截),trailer 文案与 localStorage 一致。

## 验证
- TDD 5 用例(`storage-session-get-maxlength.test.ts`):单 key 截断 / 默认 10240 / 小值不截 / 全量 values 截而 keys 不变 / 非法 maxLength 抛 `INVALID_PARAMS` —— RED→GREEN
- 实机复测:修复后 `session-get` 截断到 10240 + trailer,与 localStorage 一致
- 全量 **1269 测试通过**,现有 storage maxLength/list-keys 测试无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)