### PR TITLE
fix(content): dialog.opened 消息加源校验防跨域伪造 (CWE-345)

### DIFF
--- a/packages/extension/src/content-isolated.ts
+++ b/packages/extension/src/content-isolated.ts
@@ -24,6 +24,12 @@
 
   // 1. 接 MAIN world 的 dialog 通知
   window.addEventListener("message", (ev) => {
+    // 安全(CWE-345 跨域消息伪造):只接受**本 frame 自身 MAIN world**(content-main)发来的
+    // 消息。合法 bridge 是同 window 的 MAIN→ISOLATED postMessage(ev.source 必为本 window)。
+    // 缺此检查时,任意页面脚本 / 跨域子 iframe 经 window.top.postMessage 即可伪造
+    // dialog.opened 事件注入 MCP 事件流(text 攻击者可控、url 取本顶 frame,伪装成顶页弹框;
+    // 白盒实测 2026-06-20:opaque-origin 子 frame 伪造消息通过旧 __vortex__-only 守卫)。
+    if (ev.source !== window) return;
     const data = ev.data as { __vortex__?: boolean; type?: string; kind?: string; text?: string } | null;
     if (!data || data.__vortex__ !== true) return;
     if (data.type === "dialog.opened") {

--- a/packages/extension/tests/content-isolated-dialog-source-guard.test.ts
+++ b/packages/extension/tests/content-isolated-dialog-source-guard.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { JSDOM } from "jsdom";
+
+/**
+ * content-isolated dialog.opened 消息源校验回归锁(CWE-345 跨域消息伪造,白盒实机复现 2026-06-20)。
+ *
+ * 现象:content-isolated.ts 的 message listener 只校验 `data.__vortex__ === true`,不校验
+ *   `ev.source`。合法 bridge 是**同 frame** MAIN world(content-main)→ ISOLATED world 的
+ *   `window.postMessage`(ev.source 必为本 window)。但任意页面脚本 / 跨域子 iframe 经
+ *   `window.top.postMessage({__vortex__:true,type:"dialog.opened",text:...},"*")` 即可伪造
+ *   dialog.opened 事件,被原样转发给 background → MCP 事件流(text 由攻击者控制,url 取
+ *   listener 所在顶 frame,伪装成顶页真实弹框)。
+ *   live: example.com 内嵌 opaque-origin 子 frame,window.top.postMessage 伪造消息通过当前
+ *   唯一守卫(sourceIsWindow=false → ev.source===window 检查可拦)。
+ *
+ * 修复:listener 加 `if (ev.source !== window) return;`——只认本 frame 自身 window 的消息。
+ */
+function postMsg(win: Window, data: unknown, source: unknown): void {
+  const ev = new (win as unknown as { MessageEvent: typeof MessageEvent }).MessageEvent("message", { data } as MessageEventInit);
+  // jsdom 对 MessageEventInit.source 支持不稳;用 defineProperty 强制设定确保可控。
+  Object.defineProperty(ev, "source", { value: source, configurable: true });
+  win.dispatchEvent(ev);
+}
+
+describe("content-isolated dialog.opened 源校验(CWE-345)", () => {
+  let sendMessage: ReturnType<typeof vi.fn>;
+  let dom: JSDOM;
+
+  beforeEach(async () => {
+    dom = new JSDOM("<!DOCTYPE html><body></body>", { url: "https://top.example/" });
+    globalThis.window = dom.window as unknown as Window & typeof globalThis;
+    globalThis.document = dom.window.document as unknown as Document;
+    // content-isolated 的 send() 用裸 `location.href`,node 环境须显式提供 location。
+    (globalThis as unknown as { location: Location }).location = dom.window.location;
+    sendMessage = vi.fn().mockResolvedValue(undefined);
+    (globalThis as unknown as { chrome: unknown }).chrome = {
+      runtime: { sendMessage, onMessage: { addListener: vi.fn() } },
+    };
+    vi.resetModules();
+    // IIFE:导入即注册 window message listener。
+    await import("../src/content-isolated.js");
+  });
+  afterEach(() => {
+    vi.resetModules();
+    sendMessage.mockReset();
+  });
+
+  const forged = { __vortex__: true, type: "dialog.opened", kind: "prompt", text: "FORGED" };
+
+  it("跨 frame 伪造消息(ev.source !== window)→ 不转发", () => {
+    // 模拟子 iframe / 其它窗口:source 是别的 window 对象,非本 window。
+    postMsg(dom.window as unknown as Window, forged, { name: "child-iframe-window" });
+    const dialogCalls = sendMessage.mock.calls.filter(
+      (c) => (c[0] as { event?: string })?.event === "dialog.opened",
+    );
+    expect(dialogCalls).toHaveLength(0);
+  });
+
+  it("source=null(opaque/跨域常见)→ 不转发", () => {
+    postMsg(dom.window as unknown as Window, forged, null);
+    const dialogCalls = sendMessage.mock.calls.filter(
+      (c) => (c[0] as { event?: string })?.event === "dialog.opened",
+    );
+    expect(dialogCalls).toHaveLength(0);
+  });
+
+  it("合法同 frame 消息(ev.source === window)→ 正常转发", () => {
+    postMsg(dom.window as unknown as Window, { ...forged, text: "real" }, dom.window);
+    const dialogCalls = sendMessage.mock.calls.filter(
+      (c) => (c[0] as { event?: string })?.event === "dialog.opened",
+    );
+    expect(dialogCalls).toHaveLength(1);
+    expect((dialogCalls[0][0] as { data: { text: string } }).data.text).toBe("real");
+  });
+});


### PR DESCRIPTION
## 缺陷(安全 · CWE-345 跨域消息伪造)

`content-isolated` 的 `window` message listener 只校验 `data.__vortex__ === true`,**不校验 `ev.source`**。任意页面脚本或跨域子 iframe 经 `window.top.postMessage({__vortex__:true, type:"dialog.opened", text:...}, "*")` 即可**伪造 `dialog.opened` 事件**注入 MCP 事件流——`text` 攻击者可控、`url` 取 listener 所在顶 frame,伪装成顶页真实弹框,误导订阅 dialog 事件的 agent。

合法 bridge 只是**同 frame** MAIN world(`content-main` 拦截 alert/confirm/prompt)→ ISOLATED world 的 `window.postMessage`,`ev.source` 必为本 `window`。

## 审计方法(本轮引入 SAST + DAST)
- **Semgrep**(pipx 1.167.0,本地规则集):扫到 `content-main.ts:35` `postMessage(..., "*")` 通配源线索,人工追踪到接收侧 `content-isolated.ts:26` 守卫缺失。
- **DAST**(真扩展实机白盒复现):`example.com` 内嵌 opaque-origin(`null`)子 frame,从子 frame `window.top.postMessage` 发伪造消息 → 探针(复刻旧守卫)确认 `acceptedByCurrentGuard:true` 且 `sourceIsWindow:false`,即跨域伪造消息通过旧 `__vortex__`-only 守卫,而 `ev.source===window` 检查可拦。

| 消息来源 | 旧守卫(`__vortex__`-only) | 修复后(+`ev.source===window`) |
|---|---|---|
| 同 frame MAIN world(合法) | ✅ 转发 | ✅ 转发 |
| 跨域子 iframe `window.top.postMessage`(伪造) | ❌ **被转发** | ✅ 拒绝 |

## 修复
listener 加 `if (ev.source !== window) return;`——只认本 frame 自身 window 的消息。
`chrome.runtime` 通道(`background`/`content-isolated` 的 `onMessage`,校验 `source:"vortex-content"`/`"vortex-bg"`)本就受 Chrome 发送方隔离、页面无法伪造,无需改。

## 验证
- TDD 3 用例(`content-isolated-dialog-source-guard.test.ts`,JSDOM 导入 IIFE + dispatch 受控 `ev.source` 的 MessageEvent):跨 frame 源拒转发 / `source=null` 拒转发 / 合法同 window 正常转发 —— RED(2 fail)→GREEN
- dist 部署核验:`dist/assets/content-isolated.ts-*.js` 含 `.source!==window`
- 全量 **1272 测试通过**
- 注:`dialog.opened` 事件流不可经 MCP debug_read 观测,故端到端验证 = 实机 exploit 复现 + 真 listener 源码 unit RED→GREEN + dist 核验

🤖 Generated with [Claude Code](https://claude.com/claude-code)