### PR TITLE
fix(observe): testid 选择器转义反斜杠防错配 (CWE-116, CodeQL)

### DIFF
--- a/packages/extension/src/content-isolated.ts
+++ b/packages/extension/src/content-isolated.ts
@@ -24,6 +24,12 @@
 
   // 1. 接 MAIN world 的 dialog 通知
   window.addEventListener("message", (ev) => {
+    // 安全(CWE-345 跨域消息伪造):只接受**本 frame 自身 MAIN world**(content-main)发来的
+    // 消息。合法 bridge 是同 window 的 MAIN→ISOLATED postMessage(ev.source 必为本 window)。
+    // 缺此检查时,任意页面脚本 / 跨域子 iframe 经 window.top.postMessage 即可伪造
+    // dialog.opened 事件注入 MCP 事件流(text 攻击者可控、url 取本顶 frame,伪装成顶页弹框;
+    // 白盒实测 2026-06-20:opaque-origin 子 frame 伪造消息通过旧 __vortex__-only 守卫)。
+    if (ev.source !== window) return;
     const data = ev.data as { __vortex__?: boolean; type?: string; kind?: string; text?: string } | null;
     if (!data || data.__vortex__ !== true) return;
     if (data.type === "dialog.opened") {

--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -1001,7 +1001,11 @@ async function scanOneFrame(
             el.getAttribute("data-testid") || el.getAttribute("data-test");
           if (testId) {
             const attr = el.getAttribute("data-testid") ? "data-testid" : "data-test";
-            const testSel = `[${attr}="${testId.replace(/"/g, '\\"')}"]`;
+            // 反斜杠须先于引号转义(与下方 aria-label 路径一致)。漏转义反斜杠时,
+            // data-testid 含 `\` 的元素(page 可控)会让 CSS 把 `\x` 当转义符 → 选择器
+            // 错配(实测 `a\b` → 旧选择器匹配 0、去转义后若碰撞他元素则返回错误 ref =
+            // silent wrong-target);CodeQL CWE-116 incomplete-escaping 捕获,2026-06-20。
+            const testSel = `[${attr}="${testId.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"]`;
             // 同 id:testid 也可能重复(列表项复用),唯一才用,否则 fall through。
             if (document.querySelectorAll(testSel).length === 1) return testSel;
           }

--- a/packages/extension/tests/content-isolated-dialog-source-guard.test.ts
+++ b/packages/extension/tests/content-isolated-dialog-source-guard.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { JSDOM } from "jsdom";
+
+/**
+ * content-isolated dialog.opened 消息源校验回归锁(CWE-345 跨域消息伪造,白盒实机复现 2026-06-20)。
+ *
+ * 现象:content-isolated.ts 的 message listener 只校验 `data.__vortex__ === true`,不校验
+ *   `ev.source`。合法 bridge 是**同 frame** MAIN world(content-main)→ ISOLATED world 的
+ *   `window.postMessage`(ev.source 必为本 window)。但任意页面脚本 / 跨域子 iframe 经
+ *   `window.top.postMessage({__vortex__:true,type:"dialog.opened",text:...},"*")` 即可伪造
+ *   dialog.opened 事件,被原样转发给 background → MCP 事件流(text 由攻击者控制,url 取
+ *   listener 所在顶 frame,伪装成顶页真实弹框)。
+ *   live: example.com 内嵌 opaque-origin 子 frame,window.top.postMessage 伪造消息通过当前
+ *   唯一守卫(sourceIsWindow=false → ev.source===window 检查可拦)。
+ *
+ * 修复:listener 加 `if (ev.source !== window) return;`——只认本 frame 自身 window 的消息。
+ */
+function postMsg(win: Window, data: unknown, source: unknown): void {
+  const ev = new (win as unknown as { MessageEvent: typeof MessageEvent }).MessageEvent("message", { data } as MessageEventInit);
+  // jsdom 对 MessageEventInit.source 支持不稳;用 defineProperty 强制设定确保可控。
+  Object.defineProperty(ev, "source", { value: source, configurable: true });
+  win.dispatchEvent(ev);
+}
+
+describe("content-isolated dialog.opened 源校验(CWE-345)", () => {
+  let sendMessage: ReturnType<typeof vi.fn>;
+  let dom: JSDOM;
+
+  beforeEach(async () => {
+    dom = new JSDOM("<!DOCTYPE html><body></body>", { url: "https://top.example/" });
+    globalThis.window = dom.window as unknown as Window & typeof globalThis;
+    globalThis.document = dom.window.document as unknown as Document;
+    // content-isolated 的 send() 用裸 `location.href`,node 环境须显式提供 location。
+    (globalThis as unknown as { location: Location }).location = dom.window.location;
+    sendMessage = vi.fn().mockResolvedValue(undefined);
+    (globalThis as unknown as { chrome: unknown }).chrome = {
+      runtime: { sendMessage, onMessage: { addListener: vi.fn() } },
+    };
+    vi.resetModules();
+    // IIFE:导入即注册 window message listener。
+    await import("../src/content-isolated.js");
+  });
+  afterEach(() => {
+    vi.resetModules();
+    sendMessage.mockReset();
+  });
+
+  const forged = { __vortex__: true, type: "dialog.opened", kind: "prompt", text: "FORGED" };
+
+  it("跨 frame 伪造消息(ev.source !== window)→ 不转发", () => {
+    // 模拟子 iframe / 其它窗口:source 是别的 window 对象,非本 window。
+    postMsg(dom.window as unknown as Window, forged, { name: "child-iframe-window" });
+    const dialogCalls = sendMessage.mock.calls.filter(
+      (c) => (c[0] as { event?: string })?.event === "dialog.opened",
+    );
+    expect(dialogCalls).toHaveLength(0);
+  });
+
+  it("source=null(opaque/跨域常见)→ 不转发", () => {
+    postMsg(dom.window as unknown as Window, forged, null);
+    const dialogCalls = sendMessage.mock.calls.filter(
+      (c) => (c[0] as { event?: string })?.event === "dialog.opened",
+    );
+    expect(dialogCalls).toHaveLength(0);
+  });
+
+  it("合法同 frame 消息(ev.source === window)→ 正常转发", () => {
+    postMsg(dom.window as unknown as Window, { ...forged, text: "real" }, dom.window);
+    const dialogCalls = sendMessage.mock.calls.filter(
+      (c) => (c[0] as { event?: string })?.event === "dialog.opened",
+    );
+    expect(dialogCalls).toHaveLength(1);
+    expect((dialogCalls[0][0] as { data: { text: string } }).data.text).toBe("real");
+  });
+});

--- a/packages/extension/tests/observe-testid-selector-escape.test.ts
+++ b/packages/extension/tests/observe-testid-selector-escape.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { JSDOM } from "jsdom";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+/**
+ * observe buildSelector 的 data-testid 选择器转义回归锁(CWE-116 不完整转义,
+ * CodeQL security-extended 捕获 + 白盒实机复现,2026-06-20)。
+ *
+ * 现象:`[${attr}="${testId.replace(/"/g,'\\"')}"]` 只转义引号、不转义反斜杠。page 可控的
+ *   data-testid 含 `\` 时 CSS 把 `\x` 当转义符 → 选择器错配(实测 `a\b`:旧选择器匹配 0;
+ *   若去转义后的值与他元素 testid 碰撞且唯一,则 buildSelector 返回指向**错误元素**的
+ *   selector = silent wrong-target)。同函数 aria-label 路径(observe.ts ~1023)已正确先转
+ *   义反斜杠再转义引号,二者不对称(sibling-path asymmetry)。
+ *
+ * 修复:testid 路径对齐 aria-label,先 `replace(/\\/g,"\\\\")` 再 `replace(/"/g,'\\"')`。
+ * buildSelector 内联在 observe page-side executeScript func 中不可 import,故:
+ *   ① source-lock 锁住 observe.ts 该行用「反斜杠先于引号」转义;
+ *   ② JSDOM 行为验证转义后的选择器能精确命中含反斜杠 testid 的元素。
+ */
+const OBSERVE_SRC = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "..", "src", "handlers", "observe.ts"),
+  "utf8",
+);
+
+describe("observe data-testid 选择器反斜杠转义(CWE-116)", () => {
+  it("source-lock:testid 选择器先转义反斜杠再转义引号", () => {
+    // 反斜杠转义(/\\/g → \\\\)必须出现在 testSel 构造中。
+    expect(OBSERVE_SRC).toMatch(
+      /testSel\s*=\s*`\[\$\{attr\}="\$\{testId\.replace\(\/\\\\\/g,\s*"\\\\\\\\"\)\.replace\(\/"\/g,\s*'\\\\"'\)\}"\]`/,
+    );
+  });
+
+  it("行为验证:正确转义的选择器精确命中含反斜杠 testid 的元素", () => {
+    const dom = new JSDOM("<!DOCTYPE html><body></body>", { url: "https://x/" });
+    const doc = dom.window.document;
+    const el = doc.createElement("div");
+    el.setAttribute("data-testid", "a\\b"); // 真实值 a\b
+    doc.body.appendChild(el);
+    // 干扰元素:去转义后的值 ab(旧 bug 会错配到它)
+    const decoy = doc.createElement("div");
+    decoy.setAttribute("data-testid", "ab");
+    doc.body.appendChild(decoy);
+
+    const testId = "a\\b";
+    const fixedSel = `[data-testid="${testId.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"]`;
+    const oldSel = `[data-testid="${testId.replace(/"/g, '\\"')}"]`;
+
+    // 修复版:精确命中真实元素,不含 decoy
+    const fixedHits = Array.from(doc.querySelectorAll(fixedSel));
+    expect(fixedHits).toHaveLength(1);
+    expect(fixedHits[0]).toBe(el);
+    expect(fixedHits).not.toContain(decoy);
+
+    // 旧版(漏转义反斜杠):CSS 把 `\b` 当转义符 → 绝不命中真实元素 a\b(两引擎一致),
+    // 错配到 0 个或 decoy(ab)——无论哪种都不是真实元素,即 silent wrong/miss target。
+    const oldHits = Array.from(doc.querySelectorAll(oldSel));
+    expect(oldHits).not.toContain(el);
+  });
+});


### PR DESCRIPTION
## 缺陷(CodeQL 发现 · CWE-116 不完整字符串转义 / sibling-path 不对称)

`observe.ts` 的 `buildSelector` 构造 `data-testid` 选择器时只转义引号、**漏转义反斜杠**:
```js
const testSel = `[${attr}="${testId.replace(/"/g, '\\"')}"]`;   // ← 漏 \
```
而同函数 `aria-label` 路径**已做对**(先转义反斜杠):
```js
const escaped = ariaLabel.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
```

`data-testid` 是 page 可控属性。含 `\` 时 CSS 把 `\x` 当转义符 → 选择器错配。

## 审计方法(CodeQL 补位)
- **CodeQL** `javascript-security-extended`(104 查询 / 72 文件):唯一 finding = CWE-116 incomplete escaping @ `observe.ts:1004`「does not escape backslash characters」。**Semgrep 模式匹配抓不到**(需理解 string-transformer 语义,这正是 CodeQL dataflow/语义分析的增量价值)。
- **DAST 白盒实机复现**:元素 `data-testid="a\b"` →

| 选择器 | 命中真实元素 `a\b` |
|---|---|
| 旧(漏转义)`[data-testid="a\b"]` | ❌ 0 命中(`\b` 被 CSS 当转义 → 找 `ab`) |
| 修复 `[data-testid="a\\b"]` | ✅ 1 命中 |

影响:常见情形 fall through 到路径回退(良性);若去转义后的值与他元素 testid 唯一碰撞,则 `buildSelector` 返回指向**错误元素**的 selector = silent wrong-target。

## 修复
testid 路径对齐 aria-label:先 `replace(/\\/g, "\\\\")` 再 `replace(/"/g, '\\"')`。

## 验证
- `buildSelector` 内联在 observe page-side `executeScript` func 中不可 import,故测试 = ① **source-lock** 锁 `observe.ts` 该行用「反斜杠先于引号」转义(回退旧代码即变红)② **JSDOM 行为验证**(修复版精确命中真实元素、旧版绝不命中)
- 全量 **1274 测试通过**

🤖 Generated with [Claude Code](https://claude.com/claude-code)