### PR TITLE
fix(network): request detail 回传 body encoding 防二进制误读

### DIFF
--- a/packages/extension/src/handlers/network.ts
+++ b/packages/extension/src/handlers/network.ts
@@ -479,11 +479,16 @@ export function registerNetworkHandlers(
         );
       }
 
-      // 获取 body：优先从 FIFO 缓存取，否则实时 CDP 调用
+      // 获取 body：优先从 FIFO 缓存取，否则实时 CDP 调用。
+      // encoding 必须一并回传(对齐 sibling getResponseBody):二进制响应 CDP 返
+      // base64Encoded:true,body 是 base64 串。若丢弃此标志,agent 把 base64 当 text
+      // 误读(实机复现 2026-06-20:image/png 响应 body=iVBORw0KGgo... 无信号)。
       let bodyRaw = "";
+      let encoding = "text";
       const cachedBody = responseBodies.get(requestId);
       if (cachedBody) {
         bodyRaw = cachedBody.body;
+        encoding = cachedBody.encoding;
       } else if (debuggerMgr.isAttached(tid)) {
         try {
           const result = await debuggerMgr.sendCommand(
@@ -492,15 +497,18 @@ export function registerNetworkHandlers(
             { requestId },
           ) as any;
           bodyRaw = result.body ?? "";
+          encoding = result.base64Encoded ? "base64" : "text";
         } catch {
           // 204/重定向/body 已淘汰时静默回退空字符串
           bodyRaw = "";
         }
       }
 
-      // body 截断
+      // body 截断。base64 须对齐 4 字符 quad 边界,否则尾部残缺 quad 让整段
+      // atob 解码抛错(length%4==1 时必失败);对齐后返回前缀整段可解码。
       const truncated = bodyRaw.length > maxLength;
-      const body = truncated ? bodyRaw.slice(0, maxLength) : bodyRaw;
+      const limit = encoding === "base64" ? maxLength - (maxLength % 4) : maxLength;
+      const body = truncated ? bodyRaw.slice(0, limit) : bodyRaw;
 
       return {
         requestId,
@@ -510,6 +518,7 @@ export function registerNetworkHandlers(
         statusText: entry.statusText ?? null,
         headers: entry.responseHeaders ?? {},
         body,
+        encoding,
         truncated,
       };
     },

--- a/packages/extension/tests/network-request-detail.test.ts
+++ b/packages/extension/tests/network-request-detail.test.ts
@@ -230,4 +230,83 @@ describe("network.getRequestDetail (source=request) — 单请求 status+body", 
     expect(detail.truncated).toBe(false);
     expect(detail.status).toBe(201);
   });
+
+  // 独立模块实例 + 自定义 base64 body 的工厂(test ④ 同款隔离手法)
+  async function setupBase64(body: string, base64Encoded: boolean) {
+    vi.resetModules();
+    const router2 = new ActionRouter();
+    const mock2 = makeDebuggerMock({ body, base64Encoded });
+    vi.stubGlobal("chrome", {
+      tabs: {
+        query: vi.fn().mockResolvedValue([{ id: 42 }]),
+        onRemoved: { addListener: vi.fn() },
+      },
+      scripting: { executeScript: vi.fn().mockResolvedValue([{ result: [] }]) },
+    });
+    ({ registerNetworkHandlers } = await import("../src/handlers/network.js"));
+    registerNetworkHandlers(router2, mock2.mgr, { send: vi.fn() } as any, { emit: vi.fn() } as any);
+    await router2.dispatch(mkReq("network.subscribe", {}, 42));
+    const onEventCb2 = mock2.getOnEventCb()!;
+    return { router2, onEventCb2 };
+  }
+
+  // ⑦ 二进制响应(CDP base64Encoded:true)必须回传 encoding:"base64",
+  //    否则 agent 把 base64 串当 text 误读(实机复现 2026-06-20:google PNG,
+  //    body=iVBORw0KGgo... 无 encoding 字段;sibling getResponseBody 却带 encoding)。
+  it("⑦ base64 响应回传 encoding=base64(对齐 getResponseBody)", async () => {
+    // 1KB PNG 的 base64(短,truncated:false),用 PNG magic 前缀
+    const b64 = "iVBORw0KGgoAAAANSUhEUg" + "A".repeat(200);
+    const { router2, onEventCb2 } = await setupBase64(b64, true);
+    simulateRequest(onEventCb2, 42, "req-png", "https://x.com/logo.png", 200, {
+      "content-type": "image/png",
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const resp = await router2.dispatch(
+      mkReq("network.getRequestDetail", { requestId: "req-png" }, 42),
+    );
+    expect(resp.error).toBeUndefined();
+    const detail = resp.result as Record<string, unknown>;
+    expect(detail.encoding).toBe("base64");
+    expect(detail.body).toBe(b64);
+    expect(detail.truncated).toBe(false);
+  });
+
+  // ⑧ text 响应回传 encoding=text(显式标注,消除"无字段=未知"歧义)
+  it("⑧ text 响应回传 encoding=text", async () => {
+    const { router2, onEventCb2 } = await setupBase64('{"ok":true}', false);
+    simulateRequest(onEventCb2, 42, "req-json", "https://x.com/api", 200);
+    await new Promise((r) => setTimeout(r, 10));
+
+    const resp = await router2.dispatch(
+      mkReq("network.getRequestDetail", { requestId: "req-json" }, 42),
+    );
+    const detail = resp.result as Record<string, unknown>;
+    expect(detail.encoding).toBe("text");
+    expect(detail.body).toBe('{"ok":true}');
+  });
+
+  // ⑨ base64 截断须对齐 4 字符 quad,保证返回前缀整段可 atob 解码。
+  //    maxLength=10001 → 10001%4=1,若直接 slice 会留半个 quad → atob 抛错;
+  //    对齐后 body.length=10000(可被 4 整除)。
+  it("⑨ base64 截断对齐 4 字符 quad 边界", async () => {
+    const bigB64 = "QUJD".repeat(5000); // 20000 字符,全合法 base64
+    const { router2, onEventCb2 } = await setupBase64(bigB64, true);
+    simulateRequest(onEventCb2, 42, "req-bigpng", "https://x.com/big.png", 200, {
+      "content-type": "image/png",
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const resp = await router2.dispatch(
+      mkReq("network.getRequestDetail", { requestId: "req-bigpng", maxLength: 10001 }, 42),
+    );
+    const detail = resp.result as Record<string, unknown>;
+    expect(detail.encoding).toBe("base64");
+    expect(detail.truncated).toBe(true);
+    const body = detail.body as string;
+    expect(body.length).toBe(10000); // 10001 - (10001 % 4)
+    expect(body.length % 4).toBe(0);
+    // 前缀可被 atob 解码(不抛错)
+    expect(() => atob(body)).not.toThrow();
+  });
 });


### PR DESCRIPTION
## 缺陷

`vortex_debug_read source=request`(`GET_REQUEST_DETAIL`)返回 body 时**丢弃了 base64 编码标志**,而 sibling 路径 `GET_RESPONSE_BODY`(network.ts:419/426)一直带 `encoding`。

二进制响应(CDP `base64Encoded:true`,如 `image/png`、protobuf、octet-stream)经 source=request 返回时,base64 串被当作 text body **静默返回**,agent 无任何信号得知这是需解码的 base64 —— 典型 **sibling 路径不对称 + 静默损坏**。

## 审计方法(白盒 + Semgrep + CodeQL + DAST)

- **Semgrep**:自定义规则标出 `network.ts:503` 的 body 截断点。
- **白盒**:读出 `GET_REQUEST_DETAIL` 返回结构无 `encoding`,而 sibling 有。
- **DAST 实机复现**:隔离标签 example.com 跨域 `fetch` google PNG(`mode:no-cors`)→ CDP 捕获 reqid → `source=request` 返回 `body: "iVBORw0KGgo..."`(PNG magic 的 base64),**无 `encoding` 字段**,`truncated:false`。

## 修复

1. `GET_REQUEST_DETAIL` 一并回传 `encoding`:cached 路径取 `cachedBody.encoding`,实时 CDP 路径取 `result.base64Encoded ? "base64" : "text"`。text/base64 显式标注,消除「无字段=未知」歧义。
2. base64 截断对齐 **4 字符 quad 边界**(`maxLength - maxLength%4`):否则尾部残缺 quad 让整段 `atob` 抛错(`length%4==1` 时必失败),返回前缀整段可解码。

## 验证

- **DAST 复验**:修复后重载扩展,同一 PNG 复现返回 `"encoding": "base64"`(修复前同一复现无此字段)。完整走通 MCP→扩展→CDP 真实路径。
- **CodeQL** security-extended 对当前工作树(含本修复)**零告警**。
- TDD 新增 3 case(⑦ base64 回传 encoding / ⑧ text 回传 encoding / ⑨ 截断对齐 quad),RED→GREEN。
- ext 全量测试 **1277/1277** 通过,零回归。

## Test plan

- [x] `npx vitest run tests/network-request-detail.test.ts`(9/9)
- [x] 全部 network 测试(25/25)
- [x] ext 全量(1277/1277)
- [x] 实机 DAST 复验 encoding 字段
- [x] CodeQL security-extended 零告警