### PR TITLE
fix(console): level='all' 哨兵当作无级别过滤防全量日志漏返

### DIFF
--- a/packages/extension/src/handlers/console.ts
+++ b/packages/extension/src/handlers/console.ts
@@ -159,7 +159,11 @@ export function registerConsoleHandlers(
       await ensureSubscribed(tid);
       const level = args.level as string | undefined;
       let logs = consoleLogs.get(tid) ?? [];
-      if (level) {
+      // 'all' 是文档化的「全部级别」哨兵(dispatch.ts:214,vortex_debug_read
+      // filter.level='error'|'warn'|'all')。没有 entry 的 level 字面为 'all',
+      // 当作具体级别过滤会让「请求全部日志」静默返回 [](silent-false-negative)。
+      // 故 'all' 视作无级别过滤(同时覆盖 vortex_console 与 vortex_debug_read)。
+      if (level && level !== "all") {
         logs = logs.filter((l) => l.level === level);
       }
       return logs;

--- a/packages/extension/tests/console-level-all-filter.test.ts
+++ b/packages/extension/tests/console-level-all-filter.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ActionRouter } from "../src/lib/router.js";
+import { registerConsoleHandlers } from "../src/handlers/console.js";
+
+/**
+ * console.getLogs 的 level='all' 哨兵不被识别(白盒+DAST,2026-06-20)。
+ *
+ * 缺陷(silent-false-negative,文档化输入契约违反):
+ *   GET_LOGS 做 `logs.filter(l => l.level === level)`。公开工具
+ *   vortex_debug_read(source=console) 的 filter 在 dispatch.ts:214 文档化为
+ *   `console:{level:'error'|'warn'|'all'}`,且 dispatch 把 filter 原样
+ *   Object.assign 进 params(level='all' 直达 handler)。但没有 entry 的 level
+ *   是字面 'all' → 请求「全部级别」反而返回 []。
+ *
+ *   DAST 实机复现(example.com 发 log/warn/error/info):
+ *     无 filter → 4 条;filter={level:'all'} → [](应为 4);
+ *     filter={level:'error'} → 1(正常)。
+ *
+ * 修复:GET_LOGS 把 'all' 视作「无级别过滤」(level && level !== 'all'),
+ *   同时覆盖 vortex_console 与 vortex_debug_read 两条 funnel 到 console.getLogs
+ *   的路径。
+ */
+type OnEventCb = (tabId: number, method: string, params: unknown) => void;
+
+interface ConsoleArgs {
+  level?: string;
+}
+
+describe("console.getLogs level='all' 哨兵 = 无级别过滤", () => {
+  let router: ActionRouter;
+  let onEventCb: OnEventCb | undefined;
+
+  function emit(tabId: number, type: string, text: string) {
+    onEventCb!(tabId, "Runtime.consoleAPICalled", {
+      type,
+      args: [{ type: "string", value: text }],
+    });
+  }
+
+  async function getLogs(tabId: number, args: ConsoleArgs = {}) {
+    const resp = await router.dispatch({
+      type: "tool_request",
+      tool: "console.getLogs",
+      args,
+      requestId: "r",
+      tabId,
+    });
+    return resp.result as Array<{ level: string; text: string }>;
+  }
+
+  beforeEach(() => {
+    router = new ActionRouter();
+    const debuggerMgr = {
+      onEvent: vi.fn((cb: OnEventCb) => {
+        onEventCb = cb;
+      }),
+      enableDomain: vi.fn().mockResolvedValue(undefined),
+      attach: vi.fn(),
+      sendCommand: vi.fn(),
+    } as unknown as Parameters<typeof registerConsoleHandlers>[1];
+    const nm = { send: vi.fn() } as unknown as Parameters<typeof registerConsoleHandlers>[2];
+    const dispatcher = { emit: vi.fn() } as unknown as Parameters<typeof registerConsoleHandlers>[3];
+    vi.stubGlobal("chrome", {
+      tabs: { query: vi.fn().mockResolvedValue([]), onRemoved: { addListener: vi.fn() } },
+    });
+    registerConsoleHandlers(router, debuggerMgr, nm, dispatcher);
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  // 先 getLogs 触发 ensureSubscribed(subscribedTabs.has 才让 onEvent 入缓存),
+  // 再灌入 4 条不同级别日志。
+  async function seed(tabId: number) {
+    await getLogs(tabId); // auto-subscribe
+    emit(tabId, "log", "CANARY_LOG");
+    emit(tabId, "warning", "CANARY_WARN"); // CDP 'warning' → 归一 'warn'
+    emit(tabId, "error", "CANARY_ERROR");
+    emit(tabId, "info", "CANARY_INFO");
+  }
+
+  it("无 level → 返回全部 4 条", async () => {
+    await seed(301);
+    const logs = await getLogs(301);
+    expect(logs).toHaveLength(4);
+  });
+
+  it("level='all' → 返回全部 4 条(修复核心,此前返回 0)", async () => {
+    await seed(302);
+    const logs = await getLogs(302, { level: "all" });
+    expect(logs).toHaveLength(4);
+    expect(logs.map((l) => l.level).sort()).toEqual(["error", "info", "log", "warn"]);
+  });
+
+  it("level='error' → 仅 1 条(具体级别过滤不受影响)", async () => {
+    await seed(303);
+    const logs = await getLogs(303, { level: "error" });
+    expect(logs).toHaveLength(1);
+    expect(logs[0].level).toBe("error");
+  });
+
+  it("level='warn' → 仅 1 条(CDP 'warning' 归一后可命中)", async () => {
+    await seed(304);
+    const logs = await getLogs(304, { level: "warn" });
+    expect(logs).toHaveLength(1);
+    expect(logs[0].text).toBe("CANARY_WARN");
+  });
+});


### PR DESCRIPTION
## 缺陷(silent-false-negative,文档化输入契约违反)

`console.getLogs` 做 `logs.filter(l => l.level === level)`。公开工具 `vortex_debug_read(source=console)` 的 filter 在 `dispatch.ts:214` 文档化为 `console:{level:'error'|'warn'|'all'}`,dispatch(`dispatch.ts:299`)把 filter 原样 `Object.assign` 进 params(`level='all'` 直达 handler)。

但没有任何 entry 的 `level` 字面是 `'all'` → 请求「全部级别」的 `level:'all'` 反而过滤成 `[]`。agent 据此可能误判页面无日志。

## 审计方法(白盒 + Semgrep + CodeQL + DAST)

- **白盒**:读出 `if (level) logs.filter(l => l.level === level)` 对 `'all'` 哨兵做了字面等值比较。
- **DAST 实机复现**(隔离 tab example.com 发 4 条不同级别日志):
  | 调用 | 结果 |
  |---|---|
  | 无 filter | 4 条(全部)✅ |
  | `filter={level:'all'}` | **`[]`(应为 4)** ❌ |
  | `filter={level:'error'}` | 1 条 ✅ |

## 修复

`GET_LOGS` 把 `'all'` 视作无级别过滤(`level && level !== 'all'`),一处守卫同时覆盖 `vortex_console` 与 `vortex_debug_read` 两条 funnel 到 `console.getLogs` 的路径。

## 验证

- TDD 4 case(无 filter / all / error / warn)RED→GREEN(`all` 用例 **0→4**)。
- ext 全量 **1288/1288**,零回归。
- **CodeQL** security-extended 零告警;**Semgrep** console.ts 零 finding。
- bug 已在**修复前**实机 DAST 复现确认。

> ⚠️ 注:post-fix live 复验因 `npm run build` 触发 SW 重载、本会话 MCP client 连接未自动恢复而暂阻(已知 dev-reload 摩擦,非修复问题)。改动为单行等值守卫且单测直接覆盖 `0→4`,风险极小;下次 MCP 可达时可一键复验 `filter={level:'all'}` 返回全部。

## Test plan

- [x] `npx vitest run tests/console-level-all-filter.test.ts`(4/4)
- [x] console 全部测试(14/14)
- [x] ext 全量(1288/1288)
- [x] CodeQL 零告警 / Semgrep 零 finding
- [x] 修复前 DAST 实机复现 bug
- [ ] post-fix live 复验(MCP 重连后补)