### PR TITLE
fix(page): wait_for custom 模式隐藏 tab 不再因 rAF 冻结挂死

### DIFF
--- a/docs/audit-ledger.md
+++ b/docs/audit-ledger.md
@@ -1,0 +1,43 @@
+# vortex 白盒原语审计台账
+
+Ralph-loop 跨轮状态锚点。每轮:① 读本文件 + `git log` 定下一个**尚未审计**的原语；② 审计；③ 更新「审计记录」表与「连续无 bug 计数」。
+
+---
+
+## 方法·铁律（每轮必守）
+
+1. **甄别公开可达面**：白盒读 handler + dispatch + 公开 schema。MCP 派发不可达的 legacy handler **不算缺陷**。
+2. **SAST**：Semgrep（`/tmp/vortex-audit.yml`）+ CodeQL（security-extended，对当前源重建 DB）。
+3. **DAST 复现才算真 bug**：候选必须用真扩展隔离 tab（`active:false` + 钉 `tabId`）实机复现。报告命中、SAST 命中**默认不可信**。
+4. **有 bug**：TDD RED → GREEN → build → DAST 复验 → `git-commit` skill 提交 → 开 PR。**连续无 bug 计数清零**。
+5. **无 bug**：如实记 clean，计数 +1。
+6. **不臆造防御代码**，mock 过 ≠ 验证完成。build 后若 MCP 断连，先等重连再复验。
+
+**停止条件**：连续无 bug 计数 ≥ 10 时，输出 `<promise>AUDIT SWEEP CLEAN</promise>`。
+
+---
+
+## 连续无 bug 计数：0
+
+> `fill_form` clean(计数曾 +1);本轮 `wait_for` 发现真 bug(custom 模式隐藏 tab rAF 冻结挂死),计数归零。下一个候选原语：`history`（back/forward/go，CDP Page.navigateToHistoryEntry 边界）或 `query`。
+
+## 待办 backlog（非当前原语，独立迭代）
+
+- **测试假阳(P3,预存)**：`storage-list-keys.test.ts` / `js-evaluate-host-object-serialize.test.ts` 的「源码不引用模块函数」source-lock 用 `fn.toString().not.toMatch(/summarizeStorage|normalizeEvaluateResult/)`，正则误匹配 func 内**注释**里的同名标识符（func 实际已正确内联、不调模块函数）→ 假阳失败。无产品影响。修法：正则改为匹配「调用」形态（如 `/\bsummarizeStorage\s*\(/`）而非裸标识符。
+- **vitest 扫 worktree(P3)**：`.claude/worktrees/*` 被纳入 test 扫描，陈旧副本制造大量假失败。vitest config 应 exclude `**/.claude/**`。
+
+## 审计记录
+
+| 原语 | 结论 | PR / commit | 日期 |
+|---|---|---|---|
+| query | 已审（详见 git log / memory） | — | 2026-06 |
+| screenshot | 已审 | — | 2026-06 |
+| storage | 已审 | — | 2026-06 |
+| file_upload | 已审 | — | 2026-06 |
+| navigate | 已审 | — | 2026-06 |
+| evaluate | 已审 | — | 2026-06 |
+| network（GET_REQUEST_DETAIL 编码） | bug → 修复 | PR #61 `1578e2e` | 2026-06-20 |
+| extract（GET_TEXT 漏 open shadow 文本） | bug → 修复 | PR #62 `ca785eb` | 2026-06-20 |
+| console（GET_LOGS level='all' 哨兵） | bug → 修复 | PR #63 `040cf71` | 2026-06-20 |
+| fill_form | **clean**（部分成功语义对称、DAST 双向证实无假成功/假失败） | — | 2026-06-20 |
+| wait_for（custom 隐藏 tab rAF 冻结挂死） | bug → 修复 | PR 待开 | 2026-06-20 |

--- a/packages/extension/src/handlers/page.ts
+++ b/packages/extension/src/handlers/page.ts
@@ -383,8 +383,11 @@ export function registerPageHandlers(router: ActionRouter, debuggerMgr: Debugger
 
       const results = await chrome.scripting.executeScript({
         target: buildExecuteTarget(tid, frameId),
-        // page-side polling: requestAnimationFrame for the visible-update phase,
-        // setTimeout for the inter-poll gap. Stops on first truthy value or on
+        // page-side polling: 纯 setTimeout 调度(不用 requestAnimationFrame)。
+        // rAF 在隐藏 tab(active:false / 后台 tab,document.visibilityState='hidden')
+        // 被浏览器冻结不回调 → poll 体(含超时判定)永不执行 → promise 挂死到传输超时
+        // (2026-06-20 白盒+DAST 双证)。setTimeout 在隐藏 tab 仍触发(虽节流),与
+        // page.wait / dom.waitSettled 一致。Stops on first truthy value or on
         // timeout. Returns { ok, value, waitedMs, error? } so the caller can
         // distinguish "expr threw" from "expr never went truthy".
         func: (expr: string, timeoutMs: number, intervalMs: number) => {
@@ -416,9 +419,9 @@ export function registerPageHandlers(router: ActionRouter, debuggerMgr: Debugger
                   resolve({ ok: false, waitedMs: Date.now() - start, error: lastError });
                   return;
                 }
-                setTimeout(() => requestAnimationFrame(poll), intervalMs);
+                setTimeout(poll, intervalMs);
               };
-              setTimeout(() => requestAnimationFrame(poll), intervalMs);
+              setTimeout(poll, intervalMs);
             },
           );
         },

--- a/packages/extension/tests/wait-for-custom-hidden-tab-raf.test.ts
+++ b/packages/extension/tests/wait-for-custom-hidden-tab-raf.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ActionRouter } from "../src/lib/router.js";
+import { registerPageHandlers } from "../src/handlers/page.js";
+
+/**
+ * vortex_wait_for mode=custom 在隐藏 tab(active:false)挂死(白盒+DAST 双证,2026-06-20)。
+ *
+ * 缺陷(silent-hang → silent-false-negative + 误导性传输超时):
+ *   WAIT_FOR_EXPRESSION 的 page-side poll 用 `setTimeout(() => requestAnimationFrame(poll))`
+ *   调度。隐藏 tab(document.visibilityState='hidden',正是 agent 隔离常态 active:false)里
+ *   requestAnimationFrame 回调被浏览器冻结(不合成不回调) → poll 体(含超时判定 + 重新求值)
+ *   永不执行 → page-side promise 挂死,直到 MCP 传输层超时(误导成 "no response / Extension
+ *   not loaded")。后果:① 永不真假成功(条件后续变真也检测不到 = silent-false-negative);
+ *   ② 干净的 `[TIMEOUT]: Expression never resolved truthy` 被晦涩传输超时取代。
+ *
+ *   DAST 实机复现(example.com active:false 隐藏 tab):
+ *     wait_for(custom, '() => false', timeout=1500) → 6500ms "no response"(应为 ~1500ms 干净 TIMEOUT);
+ *     spike 证实隐藏 tab requestAnimationFrame 600ms 内 rafFired=false / setTimeout toFired=true;
+ *     element 模式(纯 setTimeout 计时)同条件下干净 [TIMEOUT]@1500ms,佐证根因是 rAF。
+ *
+ * 修复:poll 调度去掉 requestAnimationFrame,改纯 `setTimeout(poll, intervalMs)`
+ *   (与 page.wait / dom.waitSettled 既有惯例一致;rAF 对轮询 JS 表达式无价值)。
+ *
+ * 注:既有 wait-for-custom-iife.test.ts 把 rAF stub 成 setTimeout(cb,0) 总会触发,
+ *   故掩盖了本 bug —— 本测试显式把 rAF 设为 no-op 复刻隐藏 tab 冻结。
+ */
+
+interface NmRequest {
+  type: "tool_request";
+  tool: string;
+  args: Record<string, unknown>;
+  requestId: string;
+  tabId: number;
+}
+
+function mkReq(tool: string, args: Record<string, unknown> = {}, tabId = 42): NmRequest {
+  return { type: "tool_request", tool, args, requestId: "r-1", tabId };
+}
+
+describe("vortex_wait_for mode=custom — 隐藏 tab rAF 冻结仍须超时(不挂死)", () => {
+  let router: ActionRouter;
+  let executeScript: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    router = new ActionRouter();
+    executeScript = vi.fn();
+    vi.stubGlobal("chrome", {
+      tabs: { query: vi.fn().mockResolvedValue([{ id: 42 }]) },
+      webNavigation: {
+        getAllFrames: vi.fn().mockResolvedValue([
+          { frameId: 0, parentFrameId: -1, url: "https://x/" },
+        ]),
+      },
+      scripting: { executeScript },
+      runtime: { getManifest: vi.fn().mockReturnValue({ host_permissions: ["<all_urls>"] }) },
+    });
+    registerPageHandlers(router);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete (globalThis as any).requestAnimationFrame;
+  });
+
+  // 捕获真实注入的 page-side func（与 wait-for-custom-iife.test.ts 同惯例）
+  async function captureFunc() {
+    executeScript.mockResolvedValue([
+      { result: { ok: false, waitedMs: 50 } },
+    ]);
+    try {
+      await router.dispatch(mkReq("page.waitForExpression", { expression: "false", timeout: 100 }, 42));
+    } catch {}
+    const fn = executeScript.mock.calls[0][0].func as (
+      e: string,
+      t: number,
+      i: number,
+    ) => Promise<{ ok: boolean; value?: unknown; waitedMs: number; error?: string }>;
+    executeScript.mockClear();
+    return fn;
+  }
+
+  it("rAF 永不触发(隐藏 tab)→ 'false' 仍在 timeout 后 resolve ok:false,不挂死", async () => {
+    const fn = await captureFunc();
+    // 隐藏 tab:requestAnimationFrame 注册回调但永不调用（浏览器冻结合成）
+    (globalThis as any).requestAnimationFrame = () => 0;
+    const guard = new Promise<"HANG">((res) => setTimeout(() => res("HANG"), 1500));
+    const r = await Promise.race([fn("false", 80, 10), guard]);
+    expect(r).not.toBe("HANG"); // 核心:不能挂死等到传输超时
+    expect((r as { ok: boolean }).ok).toBe(false);
+  });
+
+  it("rAF 永不触发(隐藏 tab)→ 后续变真的表达式仍能检测到 ready(非 false-negative)", async () => {
+    const fn = await captureFunc();
+    (globalThis as any).requestAnimationFrame = () => 0;
+    // 表达式 200ms 后变真：poll 必须在隐藏 tab 持续轮询才能捕获
+    (globalThis as any).__vtxReady = false;
+    setTimeout(() => { (globalThis as any).__vtxReady = true; }, 200);
+    const guard = new Promise<"HANG">((res) => setTimeout(() => res("HANG"), 2000));
+    const r = await Promise.race([fn("globalThis.__vtxReady === true", 1500, 20), guard]);
+    delete (globalThis as any).__vtxReady;
+    expect(r).not.toBe("HANG");
+    expect((r as { ok: boolean }).ok).toBe(true);
+  });
+
+  it("可见 tab(rAF 正常)→ 行为不回归:'false' 超时 ok:false", async () => {
+    const fn = await captureFunc();
+    (globalThis as any).requestAnimationFrame = (cb: () => void) => setTimeout(cb, 0);
+    const r = await fn("false", 60, 10);
+    expect(r.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## 背景

Ralph-loop 白盒原语审计第 N 轮(`wait_for`)。白盒读 dispatch + 6 条 wait_for 子路径,再 DAST 实证,发现 **custom 模式在隐藏 tab 挂死**的真 bug。

## 缺陷(silent-hang → silent-false-negative)

`WAIT_FOR_EXPRESSION`(`page.waitForExpression`)的 page-side poll 用 `setTimeout(() => requestAnimationFrame(poll))` 调度。隐藏 tab(`active:false` / 后台 tab,`visibilityState='hidden'`,**正是 agent 隔离常态**)里 `requestAnimationFrame` 回调被浏览器冻结不回调 → poll 体(含超时判定 + 重新求值)永不执行 → page-side promise 挂死到 MCP 传输超时,surface 成误导性 `no response / Extension not loaded`。

后果:
1. 条件后续变真也检测不到(**silent-false-negative**);
2. 干净的 `[TIMEOUT]: Expression never resolved truthy` 被晦涩传输超时取代。

`element` / `idle` 模式用纯 `setTimeout` 计时,故免疫。

## 白盒 + DAST 双证

| 证据 | 结果 |
|---|---|
| DAST 隔离 tab `wait_for(custom,'() => false',1500)` | 6500ms `no response`(应 ~1500ms 干净 TIMEOUT) |
| evaluate spike(隐藏 tab) | `rafFired=false`(600ms 未触发)/ `toFired=true` / `visibility=hidden` |
| DAST `wait_for(element,'#never',1500)`(纯 setTimeout) | 干净 `[TIMEOUT]@1500ms` —— 佐证根因是 rAF |
| DAST `wait_for(custom,'1 === 1')` | `ready:true`(同步首检正常) |

## 修复

poll 调度去掉 `requestAnimationFrame`,改纯 `setTimeout(poll, intervalMs)`(与 `page.wait` / `dom.waitSettled` 既有惯例一致;rAF 对轮询 JS 表达式无价值)。

## 测试

新增 `wait-for-custom-hidden-tab-raf.test.ts`:把 `requestAnimationFrame` 设为 no-op 复刻隐藏 tab 冻结,断言 ① `'false'` 仍在 timeout 后 resolve `ok:false` 不挂死、② 后续变真表达式仍被检测到 `ready`、③ 可见 tab(rAF 正常)行为不回归。

> 既有 `wait-for-custom-iife.test.ts` 把 rAF stub 成 `setTimeout(cb,0)` 总触发,**掩盖了本 bug**。

- ✅ 新测试 RED(挂死)→ GREEN(修复后);
- ✅ wait 系 5 文件 127/127 通过;
- ⏳ post-fix **live 复验** pending:build 触发 crx HMR 重载导致 MCP 断连,待 `/mcp` 重连后实机确认 `() => false` 隐藏 tab 返回干净 `[TIMEOUT]`。

## SAST

Semgrep(`/tmp/vortex-audit.yml`)扫 `page.ts` 0 命中。

## Test plan

- [ ] `/mcp` 重连后 DAST:`wait_for(custom,'() => false',1500)` 隐藏 tab 返回 `[TIMEOUT]: Expression never resolved truthy within 1500ms`(~1500ms,非 6500ms 传输超时)
- [ ] `wait_for(custom)` 等待一个延迟变真的 flag,隐藏 tab 能在变真后及时 `ready`