### PR TITLE
fix(debug_read): network/console getLogs 兑现文档化的 statusMin/statusMax/tail

### DIFF
--- a/packages/extension/src/handlers/console.ts
+++ b/packages/extension/src/handlers/console.ts
@@ -166,6 +166,13 @@ export function registerConsoleHandlers(
       if (level && level !== "all") {
         logs = logs.filter((l) => l.level === level);
       }
+      // tail(dispatch 把 debug_read 顶层 tail 写成 limit):取末 N 条 = 最近 N 条日志。
+      // 文档化但此前 getLogs 漏读 → tail=N 求最近 N 却返回全部(silent no-op,与 network
+      // getLogs 同类,2026-06-20)。
+      const limit = args.limit as number | undefined;
+      if (limit != null && limit >= 0 && logs.length > limit) {
+        logs = logs.slice(logs.length - limit);
+      }
       return logs;
     },
 

--- a/packages/extension/src/handlers/network.ts
+++ b/packages/extension/src/handlers/network.ts
@@ -356,7 +356,22 @@ export function registerNetworkHandlers(
       if (!includeResources) merged = merged.filter((e) => API_TYPES.has(e.type ?? ""));
       // pattern 过滤(debug_read 必带 pattern;缺省则不滤)。
       if (pattern) merged = merged.filter((e) => e.url.includes(pattern));
-      return merged.sort((a, b) => a.startTime - b.startTime);
+      // status 范围过滤:debug_read filter.statusMin/statusMax 文档化(schema network:
+      // {pattern,statusMin/Max}),但此前 getLogs 漏读 → 求「仅失败请求」却混入 200
+      // (silent-false 结果,2026-06-20 白盒+DAST)。status 缺失的条目(RT 摘要无 status)
+      // 在设了下/上限时一并排除,语义同 network.filter。
+      const statusMin = args.statusMin as number | undefined;
+      const statusMax = args.statusMax as number | undefined;
+      if (statusMin != null) merged = merged.filter((e) => e.status != null && e.status >= statusMin);
+      if (statusMax != null) merged = merged.filter((e) => e.status != null && e.status <= statusMax);
+      merged.sort((a, b) => a.startTime - b.startTime);
+      // tail(dispatch 写成 limit):取末 N 条 = 最近 N 个请求。文档化(顶层 tail)但
+      // 此前 getLogs 漏读 → tail=N 求最近 N 却返回全部(silent no-op)。
+      const limit = args.limit as number | undefined;
+      if (limit != null && limit >= 0 && merged.length > limit) {
+        merged = merged.slice(merged.length - limit);
+      }
+      return merged;
     },
 
     [NetworkActions.GET_ERRORS]: async (args, tabId) => {

--- a/packages/extension/tests/console-level-all-filter.test.ts
+++ b/packages/extension/tests/console-level-all-filter.test.ts
@@ -24,6 +24,7 @@ type OnEventCb = (tabId: number, method: string, params: unknown) => void;
 
 interface ConsoleArgs {
   level?: string;
+  limit?: number;
 }
 
 describe("console.getLogs level='all' 哨兵 = 无级别过滤", () => {
@@ -103,5 +104,20 @@ describe("console.getLogs level='all' 哨兵 = 无级别过滤", () => {
     const logs = await getLogs(304, { level: "warn" });
     expect(logs).toHaveLength(1);
     expect(logs[0].text).toBe("CANARY_WARN");
+  });
+
+  // debug_read 顶层 tail → dispatch 写成 limit。此前 console.getLogs 漏读 = silent no-op。
+  it("tail(limit)=2 → 仅最近 2 条(此前返回全部 4 条 = silent no-op)", async () => {
+    await seed(305);
+    const logs = await getLogs(305, { limit: 2 });
+    expect(logs).toHaveLength(2);
+    expect(logs.map((l) => l.text)).toEqual(["CANARY_ERROR", "CANARY_INFO"]);
+  });
+
+  it("level + tail 组合:无 level 全 4 条时 limit=1 → 最近 1 条(CANARY_INFO)", async () => {
+    await seed(306);
+    const logs = await getLogs(306, { limit: 1 });
+    expect(logs).toHaveLength(1);
+    expect(logs[0].text).toBe("CANARY_INFO");
   });
 });

--- a/packages/extension/tests/network-getlogs-status-tail-filter.test.ts
+++ b/packages/extension/tests/network-getlogs-status-tail-filter.test.ts
@@ -1,0 +1,136 @@
+/**
+ * network.getLogs 漏实现 debug_read 文档化的 statusMin/statusMax + tail(白盒+DAST,2026-06-20)。
+ *
+ * 缺陷(silent no-op,文档化输入契约违反):
+ *   vortex_debug_read 公开 schema 暴露顶层 `tail` 与 filter `network:{pattern,statusMin/Max}`。
+ *   dispatch(dispatch.ts:284-302)把 source=network 路由到 `network.getLogs`,并把
+ *   filter Object.assign 进 params、tail 写成 params.limit。但 GET_LOGS handler 只按
+ *   pattern 过滤,**不读 statusMin/statusMax/limit** —— statusMin/statusMax 的真实现在
+ *   独立的 network.filter action(debug_read 从不走它)。后果:
+ *     - filter={pattern,statusMin:400} 求「仅失败请求」却返回 200 一并混入(silent-false 结果);
+ *     - tail=N 求「最近 N 条」却返回全部。
+ *
+ *   DAST 实机复现(example.com 发 200 + 404 两 fetch):
+ *     filter={pattern:'vtx',statusMin:400} → 返回 200+404 两条(应仅 404);
+ *     tail=1 → 返回 2 条(应 1)。
+ *
+ * 修复:GET_LOGS 在 pattern 过滤后追加 statusMin/statusMax 范围过滤,sort 后按 limit
+ *   取末 N 条(tail 语义=最近 N)。覆盖 debug_read network 唯一 funnel。
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NmRequest } from "@vortex-browser/shared";
+import { ActionRouter } from "../src/lib/router.js";
+
+let registerNetworkHandlers: typeof import("../src/handlers/network.js")["registerNetworkHandlers"];
+
+function mkReq(tool: string, args: Record<string, unknown> = {}, tabId?: number): NmRequest {
+  return { type: "tool_request", tool, args, requestId: "r-1", ...(tabId != null ? { tabId } : {}) };
+}
+
+function makeDebuggerMock() {
+  let onEventCb: ((tabId: number, method: string, params: unknown) => void) | undefined;
+  const mgr = {
+    enableDomain: vi.fn().mockResolvedValue(undefined),
+    isAttached: vi.fn().mockReturnValue(true),
+    sendCommand: vi.fn().mockResolvedValue({ body: "", base64Encoded: false }),
+    onEvent: vi.fn((cb: (t: number, m: string, p: unknown) => void) => { onEventCb = cb; }),
+    offEvent: vi.fn(),
+    attach: vi.fn().mockResolvedValue(undefined),
+  } as any;
+  return { mgr, getOnEventCb: () => onEventCb };
+}
+
+function simulateRequest(
+  onEventCb: (tabId: number, method: string, params: unknown) => void,
+  tabId: number,
+  requestId: string,
+  url: string,
+  status: number,
+) {
+  onEventCb(tabId, "Network.requestWillBeSent", {
+    requestId,
+    request: { url, method: "GET", headers: {} },
+    type: "Fetch",
+  });
+  onEventCb(tabId, "Network.responseReceived", {
+    requestId,
+    response: { status, statusText: "", mimeType: "application/json", headers: {} },
+  });
+  onEventCb(tabId, "Network.loadingFinished", { requestId });
+}
+
+describe("network.getLogs — debug_read statusMin/statusMax + tail(silent no-op 修复)", () => {
+  let router: ActionRouter;
+  let getOnEventCb: () => ((tabId: number, method: string, params: unknown) => void) | undefined;
+
+  beforeEach(async () => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    router = new ActionRouter();
+    const mock = makeDebuggerMock();
+    getOnEventCb = mock.getOnEventCb;
+    vi.stubGlobal("chrome", {
+      tabs: { query: vi.fn().mockResolvedValue([{ id: 42 }]), onRemoved: { addListener: vi.fn() } },
+      scripting: { executeScript: vi.fn().mockResolvedValue([{ result: [] }]) },
+    });
+    ({ registerNetworkHandlers } = await import("../src/handlers/network.js"));
+    registerNetworkHandlers(router, mock.mgr, { send: vi.fn() } as any, { emit: vi.fn() } as any);
+    await router.dispatch(mkReq("network.subscribe", {}, 42));
+  });
+
+  // 灌入 3 条 API 请求:200 / 404 / 500（按序,startTime 递增）
+  function seed() {
+    const cb = getOnEventCb()!;
+    simulateRequest(cb, 42, "r200", "https://x.com/api/ok", 200);
+    simulateRequest(cb, 42, "r404", "https://x.com/api/missing", 404);
+    simulateRequest(cb, 42, "r500", "https://x.com/api/boom", 500);
+  }
+
+  async function getLogs(args: Record<string, unknown>) {
+    const resp = await router.dispatch(mkReq("network.getLogs", { pattern: "/api/", ...args }, 42));
+    return resp.result as Array<{ url: string; status: number }>;
+  }
+
+  it("无 status/tail → 返回全部 3 条(基线不回归)", async () => {
+    seed();
+    const logs = await getLogs({});
+    expect(logs).toHaveLength(3);
+  });
+
+  it("statusMin=400 → 仅 404+500(此前返回全部 3 条 = bug)", async () => {
+    seed();
+    const logs = await getLogs({ statusMin: 400 });
+    expect(logs.map((l) => l.status).sort()).toEqual([404, 500]);
+  });
+
+  it("statusMax=299 → 仅 200", async () => {
+    seed();
+    const logs = await getLogs({ statusMax: 299 });
+    expect(logs.map((l) => l.status)).toEqual([200]);
+  });
+
+  it("statusMin=400 + statusMax=499 → 仅 404", async () => {
+    seed();
+    const logs = await getLogs({ statusMin: 400, statusMax: 499 });
+    expect(logs.map((l) => l.status)).toEqual([404]);
+  });
+
+  it("tail=1 → 仅最近 1 条(startTime 最大,此前返回全部 3 条 = bug)", async () => {
+    seed();
+    const logs = await getLogs({ limit: 1 });
+    expect(logs).toHaveLength(1);
+    expect(logs[0].status).toBe(500); // 最后 seed 的请求
+  });
+
+  it("tail=2 → 最近 2 条(404+500,保持升序)", async () => {
+    seed();
+    const logs = await getLogs({ limit: 2 });
+    expect(logs.map((l) => l.status)).toEqual([404, 500]);
+  });
+
+  it("status + tail 组合:statusMin=400 + tail=1 → 先 status 过滤再取末 1 = 500", async () => {
+    seed();
+    const logs = await getLogs({ statusMin: 400, limit: 1 });
+    expect(logs.map((l) => l.status)).toEqual([500]);
+  });
+});


### PR DESCRIPTION
## 背景

Ralph-loop 白盒原语审计(`debug_read` network source;#61 审过 request detail、#63 审过 console level)。白盒读 dispatch + getLogs handler,DAST 实证,发现 **文档化过滤参数被静默忽略**。

## 缺陷(silent no-op,文档化输入契约违反)

`vortex_debug_read` 公开 schema 暴露:
- 顶层 `tail: number`
- `filter` 子字段 `network: {pattern, statusMin, statusMax}`(schema description 明文)

dispatch(`dispatch.ts:284-302`)把 `source=network` 路由到 `network.getLogs`,把 `filter` `Object.assign` 进 params、`tail` 写成 `params.limit`。但 **`GET_LOGS` handler 只按 `pattern` 过滤,漏读 `statusMin/statusMax/limit`** —— status 过滤的真实现在**独立的 `network.filter` action**,而 debug_read 从不走它。`console.getLogs` 同样漏读 `limit`。

后果:
1. `filter={pattern, statusMin:400}` 求「仅失败请求」→ **把 200 一并返回**(silent-false 结果,可误导 agent 误判错误);
2. `tail=N` 求「最近 N 条」→ **返回全部**。

## 白盒 + DAST 双证

DAST(example.com 发 200 + 404 两 fetch,隔离 tab):

| 查询 | 修复前 | 期望 |
|---|---|---|
| `filter={pattern:'vtx', statusMin:400}` | 返回 **200 + 404** 两条 | 仅 404 |
| `tail:1` | 返回 **2 条** | 仅 1 条 |

## 修复

- `network.getLogs`:pattern 过滤后追加 `statusMin/statusMax` 范围过滤(status 缺失的条目在设了限时排除,语义同 `network.filter`),`sort` 后按 `limit` 取末 N 条(tail=最近 N);
- `console.getLogs`:同样按 `limit` 取末 N 条。

覆盖 debug_read network/console 两条 funnel。

## 测试

- 新增 `network-getlogs-status-tail-filter.test.ts`(7 例:基线 / statusMin / statusMax / 区间 / tail=1 / tail=2 / status+tail 组合);
- `console-level-all-filter.test.ts` 补 2 例 tail。
- ✅ RED(6/7 失败)→ GREEN(22/22,含 network-request-detail 无回归)。

## SAST

Semgrep 仅 2 命中,均为 #61 预存的 body/base64 slice(有界 + 信号);新增 tail slice 有界透明。

## Test plan

- [ ] `/mcp` 重连后 DAST:`filter={pattern, statusMin:400}` 仅返回 ≥400 的请求;`tail:1` 仅返回最近 1 条;console `tail:N` 仅返回最近 N 条日志