### PR TITLE
test: source-lock 守卫剥离注释再匹配，消除注释误匹配假阳

### DIFF
--- a/packages/extension/tests/js-evaluate-async-expression.test.ts
+++ b/packages/extension/tests/js-evaluate-async-expression.test.ts
@@ -83,7 +83,9 @@ describe("EVALUATE_ASYNC page-side func — 自包含 + 真跑 (B3-4)", () => {
   // V2 关键守卫:防 V1 假绿 —— func 源码不能引用 buildAsyncSrc
   it("func 序列化安全:源码不引用模块函数 buildAsyncSrc", async () => {
     const fn = await captureAsyncFunc();
-    expect(fn.toString()).not.toMatch(/buildAsyncSrc/);
+    // 剥离行/块注释后再断言:func 已内联,buildAsyncSrc 仅出现在解释性注释,裸正则误匹配 → 假阳。
+    const src = fn.toString().replace(/\/\/.*$/gm, "").replace(/\/\*[\s\S]*?\*\//g, "");
+    expect(src).not.toMatch(/buildAsyncSrc/);
   });
 
   it("纯表达式 'Promise.resolve(42)' → { result: 42 }", async () => {

--- a/packages/extension/tests/js-evaluate-host-object-serialize.test.ts
+++ b/packages/extension/tests/js-evaluate-host-object-serialize.test.ts
@@ -130,7 +130,10 @@ describe("EVALUATE page-side func — host object 展开 (BUG-001 + BUG-005)", (
   // V2 关键守卫:防假绿 — func 源码不能引用模块函数
   it("func 序列化安全:源码不引用 normalizeEvaluateResult", async () => {
     const fn = await captureEvaluateFunc();
-    expect(fn.toString()).not.toMatch(/normalizeEvaluateResult/);
+    // 剥离行/块注释后再断言:func 用独立名 expandHost 内联,normalizeEvaluateResult 仅出现在
+    // 解释性注释(「与 module-level normalizeEvaluateResult 行为一致」),裸正则误匹配注释 → 假阳。
+    const src = fn.toString().replace(/\/\/.*$/gm, "").replace(/\/\*[\s\S]*?\*\//g, "");
+    expect(src).not.toMatch(/normalizeEvaluateResult/);
   });
 
   it("plain object 展开直通", async () => {

--- a/packages/extension/tests/storage-list-keys.test.ts
+++ b/packages/extension/tests/storage-list-keys.test.ts
@@ -144,7 +144,10 @@ describe("GET_LOCAL_STORAGE page-side func — 自包含 + 真注入 (B3-2 V2)",
   // V2 关键守卫:防 V1 假绿 —— func 源码不能引用 summarizeStorage
   it("func 序列化安全:源码不引用模块函数 summarizeStorage", async () => {
     const fn = await captureGetLocalStorageFunc();
-    expect(fn.toString()).not.toMatch(/summarizeStorage/);
+    // 剥离行/块注释后再断言:func 已内联实现,summarizeStorage 仅出现在解释性注释
+    // (「不能调模块级 summarizeStorage」),裸正则会误匹配注释 → 假阳。只查真实代码引用。
+    const src = fn.toString().replace(/\/\/.*$/gm, "").replace(/\/\*[\s\S]*?\*\//g, "");
+    expect(src).not.toMatch(/summarizeStorage/);
   });
 
   it("传 key='a' + 不传 mode → { result: '1' } (单值旧契约不破)", async () => {


### PR DESCRIPTION
## 背景

Ralph-loop 白盒审计期间,全量 extension 测试出现 2 个稳定失败(`storage-list-keys` / `js-evaluate-host-object-serialize`),触发排查。诊断为**测试假阳**,非产品缺陷。

## 缺陷(测试断言误匹配注释)

三个测试的「page-side func 序列化安全」守卫(防 page-side func 注入丢模块作用域)用:

```ts
expect(fn.toString()).not.toMatch(/summarizeStorage/);        // storage-list-keys
expect(fn.toString()).not.toMatch(/normalizeEvaluateResult/); // js-evaluate-host-object-serialize
expect(fn.toString()).not.toMatch(/buildAsyncSrc/);           // js-evaluate-async-expression
```

断言 func 不引用模块级 helper。但**裸标识符正则会误匹配 func 体内的解释性注释**:

- storage func:`// …不能调模块级 summarizeStorage——序列化丢作用域`
- evaluate func:`// 与 module-level normalizeEvaluateResult 行为一致…守卫要求源码不含 "normalizeEvaluateResult" 故用独立名 expandHost`

func 实际**已正确内联**、不真引用 helper → 守卫该过却因注释失败。

## 白盒确认

- `grep 'summarizeStorage(' storage.ts` → 仅定义(line 37),无 func 内调用;
- `grep normalizeEvaluateResult js.ts` → evaluate func 刻意用独立名 `expandHost`,标识符仅在注释;
- `buildAsyncSrc` 同理。

三个 func 均内联,标识符只出现在注释。

## 修复

断言前剥离行注释(`//…`)与块注释(`/*…*/`)再 `toMatch`,只查真实代码引用,守卫意图不变:

```ts
const src = fn.toString().replace(/\/\/.*$/gm, "").replace(/\/\*[\s\S]*?\*\//g, "");
expect(src).not.toMatch(/summarizeStorage/);
```

## 测试

3 文件 53 测试全绿(修复前 2 失败)。

## Test plan

- [x] `vitest run` 三文件 GREEN
- [ ] 全量 `pnpm -r test` 无该假阳