### PR TITLE
fix(click-effect): isVisible 排除 sr-only announcer 防 toast 误判 (#65)

### DIFF
--- a/packages/extension/src/page-side/click-effect.ts
+++ b/packages/extension/src/page-side/click-effect.ts
@@ -151,6 +151,15 @@ interface PendingEntry {
     }
     const r = el.getBoundingClientRect();
     if (r.width === 0 || r.height === 0) return false;
+    // 视觉隐藏(sr-only)的 live-region announcer:checkVisibility 仍判 visible(非
+    // display:none/visibility:hidden)、rect 非 0,却对用户零视觉呈现 —— sr-only 标准做法是
+    // clip/clip-path 折叠 + 收缩到 1×1px(Next.js __next-route-announcer__、Tailwind .sr-only、
+    // react-aria VisuallyHidden、Bootstrap .sr-only 皆如此)。Next.js route announcer(role=alert)
+    // 存在于每个 Next.js 页面,不滤会让 toast 选择器在其上误命中 → 每次 click 误报
+    // userFeedback:"toast"(2026-06-21 mantine.dev dogfood:开/选 Select 两次点击均误报)。
+    // 用尺寸判别(≤1px 任一维):真实 toast/dialog 反馈恒为多 px 框,排除亚像素安全;比 clip
+    // 计算样式判别更稳(unset clip 在 JSDOM 默认即 rect(0..),在真浏览器为 auto,不可靠)。
+    if (r.width <= 1 || r.height <= 1) return false;
     return true;
   }
 

--- a/packages/extension/tests/click-effect.helper.test.ts
+++ b/packages/extension/tests/click-effect.helper.test.ts
@@ -271,4 +271,47 @@ describe("click-effect page-side module (__vortexClickEffect)", () => {
       vi.useRealTimers();
     }
   });
+
+  // 视觉隐藏(sr-only / 屏幕阅读器 live-region announcer)的 role=alert/status 对用户零
+  // 视觉呈现,不应计入 userFeedback。Next.js __next-route-announcer__(role=alert + clip
+  // + 1×1)存在于每个 Next.js 页面,不滤会让每次 click 误报 userFeedback:"toast"
+  // (2026-06-21 mantine.dev dogfood 实测:开/选 Select 两次点击均误报 toast)。
+  // JSDOM 无布局,桩 checkVisibility + getBoundingClientRect 复刻 announcer 几何。
+  describe("collectFeedback 不把 sr-only announcer 误判为 toast(Next.js route announcer 回归)", () => {
+    function stubGeom(el: Element, w: number, h: number): void {
+      (el as any).checkVisibility = () => true; // 非 display:none/visibility:hidden
+      (el as any).getBoundingClientRect = () => ({
+        width: w, height: h, top: 0, left: 0, right: w, bottom: h, x: 0, y: 0, toJSON() {},
+      });
+    }
+
+    it("sr-only role=alert(1×1 + clip,空文本) → toastHit 空, userFeedback != toast", async () => {
+      const ns = await load();
+      const ann = document.createElement("p");
+      ann.setAttribute("role", "alert");
+      ann.setAttribute("aria-live", "assertive");
+      ann.style.position = "absolute";
+      ann.style.overflow = "hidden";
+      ann.style.clip = "rect(0px, 0px, 0px, 0px)";
+      document.body.appendChild(ann);
+      stubGeom(ann, 1, 1);
+      const t = ns.begin("#b", 10);
+      const eff = (await ns.end(t)) as any;
+      expect(eff.toastHit).toEqual([]);
+      expect(eff.userFeedback).not.toBe("toast");
+    });
+
+    it("真实可见 toast(.ant-message,多 px,有文本)仍被检测 → userFeedback=toast", async () => {
+      const ns = await load();
+      const toast = document.createElement("div");
+      toast.className = "ant-message";
+      toast.textContent = "操作成功";
+      document.body.appendChild(toast);
+      stubGeom(toast, 200, 40);
+      const t = ns.begin("#b", 10);
+      const eff = (await ns.end(t)) as any;
+      expect(eff.toastHit).toContain(".ant-message");
+      expect(eff.userFeedback).toBe("toast");
+    });
+  });
 });


### PR DESCRIPTION
## 背景

Ralph dogfood loop 第 2 轮，站点 **mantine.dev/core/select**（fresh React/Next.js 库）。

`vortex_act click`（开/选 Select 两次点击）均返回 `userFeedback:"toast"` / `toastHit:["[role='alert']"]`，但页面**无任何 toast**。

## 确诊（活浏览器 spike）

命中元素 = `<p id="__next-route-announcer__" role="alert" aria-live="assertive">` —— **Next.js 路由播报器**，存在于每个 Next.js 页面。它是 sr-only 视觉隐藏：

```
position:absolute; clip:rect(0,0,0,0); width:1px; height:1px; overflow:hidden;
visibility:visible; display:block; textContent=""
```

`click-effect.ts` 的 `isVisible` 只排除 `display:none`/`visibility:hidden`/零尺寸 —— 该 announcer `checkVisibility()=true`、rect 1×1 非 0，于是被误判为可见 → toast 选择器命中 → 误报 `userFeedback:"toast"`。

**影响面**：每个 Next.js 站点的每次 click 都会误报 toast 反馈，污染 agent 的 silent-fail 判断（与历史 networkRequests/userFeedback 误信号同族）。

## 修复

`isVisible` 增加「≤1px 任一维即判不可见」。sr-only 标准做法恒收缩到 1×1（Next.js / Tailwind `.sr-only` / react-aria VisuallyHidden / Bootstrap 皆如此）。

为什么用尺寸而非 clip 计算样式判别：unset `clip` 在 JSDOM 默认即 `rect(0,0,0,0)`、在真浏览器为 `auto`，不可靠。真实 toast/dialog 反馈恒为多 px 框，排除亚像素安全。

注：`[role='alert']` 仍保留在 `TOAST_SELECTORS`（真 toast 用它），修复在可见性层，符合既有 A5/A6 回归约束。

## 验证

- RED→GREEN 新增 2 单测：sr-only announcer 不误判 + 真实可见 toast 仍检测。
- 扩展全量 **1293/1293** 通过，无回归。
- **Live 验证**：rebuild + 重载页面后同一 click → `toastHit:[]` / `userFeedback:"mutation"`（正确，开下拉是 DOM mutation 非 toast）。

## 残留边际

仅经 `left:-9999px` 离屏定位（rect 非 1px）隐藏的 announcer 不被尺寸判别捕获 —— 罕见、非主流 sr-only 做法，记为理论 edge。

## 测试计划

- [x] `vitest run tests/click-effect.helper.test.ts` 17/17
- [x] 扩展全量单测 1293/1293
- [x] mantine.dev live 复测（修前 toast → 修后 mutation）
- [ ] bench 50 case rerun（本轮未跑；变更隔离于 toast/dialog 可见性判别，click-effect-signal case 不受影响）