### PR TITLE
fix(observe): all-permitted 经继承源纳入 about:srcdoc 子框防富文本编辑器漏扫

### DIFF
--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -220,7 +220,23 @@ export async function resolveTargetFrames(
   if (framesParam === "all-permitted") {
     // 按扩展 manifest host_permissions 过滤。host_permissions=<all_urls> 时
     // 行为等同 "all"；当 manifest 收紧 host_permissions 时，只 scan 有权限的。
-    return asTargets(all.filter((f) => isFrameInPermissions(f.url)));
+    // about:srcdoc 子框的 protocol 是 "about:" —— 按 raw url 判会被 isFrameInPermissions
+    // 直接拒，但 srcdoc 据 HTML spec 恒继承父文档 origin(同源可注入)。改按继承源判权限,
+    // 使 all-permitted 对 srcdoc 与 all-same-origin 一致(否则 TinyMCE 等把 contenteditable
+    // 体放在 about:srcdoc iframe 的富文本编辑器,all-permitted 漏扫编辑器内容。Issue #15 同源
+    // 逻辑此前只覆盖 all-same-origin。2026-06-22 tiny.cloud dogfood)。about:blank 不算
+    // 「作者刻意内容」(常为空/广告/瞬态占位),保持排除以免噪声。
+    const byId = new Map(all.map((f) => [f.frameId, f]));
+    return asTargets(
+      all.filter((f) => {
+        if (isFrameInPermissions(f.url)) return true;
+        if (f.url === "about:srcdoc") {
+          const origin = inheritedOrigin(f, byId);
+          return origin != null && isFrameInPermissions(origin);
+        }
+        return false;
+      }),
+    );
   }
   if (framesParam === "all-same-origin") {
     const main = all.find((f) => f.frameId === 0);

--- a/packages/extension/tests/observe-frames-issue-15.test.ts
+++ b/packages/extension/tests/observe-frames-issue-15.test.ts
@@ -80,3 +80,69 @@ describe("resolveTargetFrames — srcdoc inheritance (issue #15-1)", () => {
   });
 
 });
+
+/**
+ * all-permitted 之前按 raw frame.url 判权限(isFrameInPermissions),about:srcdoc 的
+ * protocol 是 "about:" 直接被拒,导致 all-permitted **不是** all-same-origin 的超集——
+ * 同源 srcdoc 编辑器(TinyMCE 把 contenteditable 体放在 about:srcdoc iframe)被漏扫。
+ * 修复:对 about:srcdoc 子框按 HTML spec 继承父源(inheritedOrigin)判权限,与
+ * all-same-origin 的 srcdoc 处理对齐(2026-06-22 tiny.cloud TinyMCE dogfood)。
+ */
+describe("resolveTargetFrames — all-permitted srcdoc inheritance (TinyMCE 富文本编辑器)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("chrome", {
+      webNavigation: { getAllFrames: vi.fn() },
+      runtime: { getManifest: () => ({ host_permissions: ["<all_urls>"] }) },
+    });
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+  function mockFrames(frames: { frameId: number; parentFrameId: number; url: string }[]): void {
+    (chrome.webNavigation.getAllFrames as ReturnType<typeof vi.fn>).mockResolvedValue(frames);
+  }
+
+  it("all-permitted includes a srcdoc child of the main frame (inherited origin permitted)", async () => {
+    mockFrames([
+      { frameId: 0, parentFrameId: -1, url: "https://example.com/" },
+      { frameId: 1, parentFrameId: 0, url: "about:srcdoc" },
+    ]);
+    const out = await resolveTargetFrames(99, undefined, "all-permitted");
+    expect(out.map((f) => f.frameId).sort()).toEqual([0, 1]);
+  });
+
+  it("all-permitted includes a srcdoc nested inside a srcdoc (recursive inheritance)", async () => {
+    mockFrames([
+      { frameId: 0, parentFrameId: -1, url: "https://example.com/" },
+      { frameId: 1, parentFrameId: 0, url: "about:srcdoc" },
+      { frameId: 2, parentFrameId: 1, url: "about:srcdoc" },
+    ]);
+    const out = await resolveTargetFrames(99, undefined, "all-permitted");
+    expect(out.map((f) => f.frameId).sort()).toEqual([0, 1, 2]);
+  });
+
+  it("all-permitted excludes srcdoc whose inherited origin is not in host_permissions", async () => {
+    (chrome.runtime.getManifest as ReturnType<typeof vi.fn>) = (() => ({
+      host_permissions: ["https://example.com/*"],
+    })) as unknown as ReturnType<typeof vi.fn>;
+    mockFrames([
+      { frameId: 0, parentFrameId: -1, url: "https://example.com/" },
+      { frameId: 1, parentFrameId: 0, url: "https://other.com/widget" },
+      { frameId: 2, parentFrameId: 1, url: "about:srcdoc" }, // inherits other.com (blocked)
+    ]);
+    const out = await resolveTargetFrames(99, undefined, "all-permitted");
+    const ids = out.map((f) => f.frameId).sort();
+    expect(ids).toContain(0);
+    expect(ids).not.toContain(1);
+    expect(ids).not.toContain(2);
+  });
+
+  it("all-permitted still skips about:blank (deliberate contract, not intentional content)", async () => {
+    mockFrames([
+      { frameId: 0, parentFrameId: -1, url: "https://example.com/" },
+      { frameId: 1, parentFrameId: 0, url: "about:blank" },
+    ]);
+    const out = await resolveTargetFrames(99, undefined, "all-permitted");
+    expect(out.map((f) => f.frameId).sort()).toEqual([0]);
+  });
+});


### PR DESCRIPTION
## 背景

Ralph dogfood loop 第 6 轮，按策略转向高产区，测富文本编辑器 **TinyMCE**（tiny.cloud full-featured demo）。

TinyMCE 把 contenteditable 编辑体渲染在 `iframe.tox-edit-area__iframe`（`about:srcdoc`，同源继承）。用文档推荐的 `frames=all-permitted` observe 时，**编辑器内容被静默漏报**：输出只含主帧 UI + 跨域 YouTube 帧，唯独缺了编辑器帧。

## 确诊（活浏览器 spike + 白盒）

- `frames=all` 能完整扫到编辑器帧：`body "Rich Text Area..." [ref=f82e80]` 及全部内容 → 证明 vortex 扫描机制本身能处理 srcdoc。
- `frames=all-permitted` 却独缺该帧（只含跨域 YouTube f83）→ all-permitted **不是** all-same-origin 的超集（反直觉：同源 srcdoc 比跨域帧更可注入）。
- 根因 `observe.ts`：
  - `all-permitted` → `all.filter(f => isFrameInPermissions(f.url))`，而 `isFrameInPermissions` 对非 `http(s)/ws` protocol 直接 `return false` → `about:srcdoc`（protocol `about:`）被拒。
  - `all-same-origin` → 用 `inheritedOrigin()` 走父链解析 srcdoc 继承源（Issue #15），故能纳入。
  - 两路对 srcdoc 处理不一致 = 缺陷。

## 修复

`all-permitted` 对 `about:srcdoc` 子框按 HTML spec 继承父文档 origin（复用既有 `inheritedOrigin`），用继承源判 `host_permissions`，与 `all-same-origin` 对齐。`about:blank` 保持排除（常为空/广告/瞬态占位，非作者刻意内容；既有契约不变）。

## 验证

- TDD RED→GREEN，新增 4 单测：srcdoc 直挂/嵌套纳入、非权限继承源（跨域父）排除、about:blank 仍排除。
- 扩展全量 **1295/1295** 通过（含既有 `observe-all-permitted` / `observe-frames-issue-15` 全绿）。
- **Live**：tiny.cloud TinyMCE，修后 `frames=all-permitted` 正确呈现编辑器 `body "Rich Text Area"` 及其全部内容（链接/表格行）。

## 影响面

凡把可编辑/沙箱内容放在 `about:srcdoc` iframe 的富文本编辑器（TinyMCE classic/iframe 模式等）与 srcdoc 沙箱小部件，用推荐 `frames=all-permitted` observe 时不再漏报。

## 测试计划

- [x] `vitest run observe-frames-issue-15 observe-all-permitted` 13/13
- [x] 扩展全量 1295/1295
- [x] TinyMCE live（修前漏 / 修后含编辑器帧）