### PR TITLE
fix(observe): contenteditable 宿主豁免 require-name 防富文本编辑器漏报

### DIFF
--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -2089,13 +2089,22 @@ async function scanOneFrame(
               htmlEl.querySelector(
                 "input[type=checkbox], input[type=radio]",
               ) != null;
+            // contenteditable 宿主(显式 attribute 非 "false")是一等可编辑控件,
+            // 语义等同 textarea —— 富文本编辑器(Quill/ProseMirror/Slate/Lexical)的
+            // 可编辑体常是无 role/无 aria-label 的裸 div(Quill .ql-editor 即如此)。
+            // 不豁免 require-name 门会被当噪声容器丢弃,agent observe 看不到编辑器、
+            // 无法定位输入目标(2026-06-22 quilljs.com dogfood)。仅认显式 attribute
+            // (非继承)避免把编辑器内继承可编辑的子节点也豁免。
+            const ceAttr = htmlEl.getAttribute("contenteditable");
+            const isEditableHost = ceAttr != null && ceAttr !== "false";
             const formLike =
               tag === "input" ||
               tag === "select" ||
               tag === "textarea" ||
               tag === "button" ||
               (tag === "a" && htmlEl.hasAttribute("href")) ||
-              wrapsFormControl;
+              wrapsFormControl ||
+              isEditableHost;
             const hasExplicitRole =
               !!htmlEl.getAttribute("role") ||
               !!htmlEl.getAttribute("aria-label");

--- a/packages/extension/tests/observe-content-card-inlined.test.ts
+++ b/packages/extension/tests/observe-content-card-inlined.test.ts
@@ -77,3 +77,13 @@ describe("observe #42:多 CTA 容器去重内联(源码锁)", () => {
     expect(OBSERVE_SRC).toMatch(/不查子文本互不为子串/);
   });
 });
+
+describe("observe contenteditable 宿主豁免 require-name 门(源码锁,quilljs dogfood)", () => {
+  it("BUG-3 门 formLike 含 isEditableHost(显式 contenteditable 非 false)", () => {
+    // 富文本编辑器(Quill/ProseMirror)的可编辑体常是无 role/无 aria-label 的裸 div,
+    // 不豁免 require-name 会被当噪声容器丢弃 → observe 看不到编辑器。
+    expect(OBSERVE_SRC).toMatch(/const ceAttr = htmlEl\.getAttribute\("contenteditable"\);/);
+    expect(OBSERVE_SRC).toMatch(/const isEditableHost = ceAttr != null && ceAttr !== "false";/);
+    expect(OBSERVE_SRC).toMatch(/wrapsFormControl \|\|\s*\n\s*isEditableHost;/);
+  });
+});


### PR DESCRIPTION
## 背景

Ralph dogfood loop 第 7 轮（高产区策略），测富文本编辑器 **Quill**（quilljs.com）。

`observe` 完整呈现 Quill 工具栏，但**编辑器可编辑体（`.ql-editor`）本身未被surface**——agent 拿不到输入目标的 ref。

## 确诊（活浏览器 spike + 白盒）

- `.ql-editor` = 无 `role`、无 `aria-label`、`cursor:auto` 的 `div[contenteditable=true]`，在视口内、非隐藏。
- spike：给它临时加 `role=textbox`+`aria-label` → observe **立即surface** 为 `textbox`；移除则消失 → 门是「require accessible name」。
- 白盒定位 `observe.ts` BUG-3 噪声门（filter=interactive）：
  ```js
  const formLike = input|select|textarea|button|a[href]|wrapsFormControl;
  const hasExplicitRole = role || aria-label;
  if (!formLike && !hasExplicitRole && !name) continue;   // ← 丢弃无名 contenteditable div
  ```
  `.ql-editor` 非 formLike、无 role/label、无 name → `continue` 丢弃。（contenteditable 已在 `INTERACTIVE_SELECTORS`、`getValueInfo` 也处理其 value，唯独被此噪声门拦下。）

## 修复

把**显式** contenteditable 宿主（attribute 非 `"false"`）纳入 `formLike` 豁免集——它是一等可编辑控件，语义等同 textarea。仅认显式 attribute（非继承），避免编辑器内继承可编辑的子节点也被豁免。

## 验证

- 源码锁单测（`-inlined` 模式）：断言 formLike 含 `isEditableHost`。
- 扩展全量单测通过。
- **Live**：quilljs.com，修前 3 个无名 `.ql-editor` 全被丢弃；修后均以 `div value="Quill Rich Text Editor..."` 呈现（带 ref 可定位）。

## 影响面

富文本编辑器（Quill / 任何无 a11y 标注的裸 contenteditable div）+ 自定义 contenteditable 区域，observe 不再漏报，agent 可发现并定位编辑器。

## 测试计划

- [x] `vitest run observe-content-card-inlined` 13/13
- [x] 扩展全量 1292/1292
- [x] Quill live（修前漏 / 修后 3 编辑器全现）
- [ ] bench 功能 fixture（无名 contenteditable + observe 发现断言）— 跟进（现有 contenteditable fixture 编辑器带 role/label，未覆盖无名场景）