### PR TITLE
fix(observe): iframe 子框 label 包裹控件补可访问名防表单字段无名

### DIFF
--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -808,7 +808,25 @@ async function scanOneFrame(
               if (t === "reset") return "Reset";
               if (t === "image") return "Submit Query";
             }
-            // AI: <select> 不能落到下面 textContent 兜底——select 的 textContent 是
+            // <label> 包裹的 labelable 控件(无 id 关联、非 radio/checkbox/按钮):
+            // 按 HTML <label> 语义,控件的可及名 = 包裹 label 的文本。手写表单极常见
+            // (httpbin <label>Customer name: <input></label>),此前仅 radio/checkbox
+            // 命中,text/email/tel/textarea 全落到下方 placeholder 兜底 → 空名。
+            // 关键:AX 语义覆盖层仅施加于主 frame 0,iframe 子框(同源/跨域皆然)的
+            // 此类控件只能靠本启发式命名——缺这一支会让所有 iframe 表单字段无名
+            // (2026-06-22 跨域/iframe dogfood)。克隆 label 后剥除嵌套表单控件,避免
+            // textarea 的当前文本 / <select> 的 option 文本拼接污染名(AI 噪声同理规避)。
+            {
+              const wrapLabel = el.closest("label");
+              if (wrapLabel) {
+                const clone = wrapLabel.cloneNode(true) as HTMLElement;
+                for (const ctrl of clone.querySelectorAll("input, textarea, select"))
+                  ctrl.remove();
+                const txt = normName(clone.textContent);
+                if (txt) return txt;
+              }
+            }
+            // <select> 无包裹 label 时不落 textContent 兜底——select 的 textContent 是
             // 全部 <option> 文本的拼接("Name (A to Z)Name (Z to A)Price..."噪声)。
             // 名应来自 label/aria(已在上面解析),无 label 则返空(当前选中值由
             // getValueInfo 以 value= 暴露)(2026-06-02 dogfood AI)。

--- a/packages/extension/tests/observe-wrapping-label-name.test.ts
+++ b/packages/extension/tests/observe-wrapping-label-name.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+/**
+ * Regression lock：<label> 包裹的「非 radio/checkbox」labelable 控件的可访问名。
+ *
+ * 现象(2026-06-22 跨域/iframe dogfood,httpbin /forms/post):
+ *   `<label>Customer name: <input name="custname"></label>` 这类手写表单——
+ *   控件无 id、无 label[for]、type 为 text/email/tel/time——在 **iframe 子框**内
+ *   被 observe 报成无名 `textbox`,而同一表单在顶层文档却正确显示 "Customer name:"。
+ *
+ * 根因:AX 语义覆盖层(captureAXNodeMap + applyOverlay)**仅施加于主 frame 0**
+ *   (observe.ts「AX 语义覆盖层(v1 仅主 frame frameId 0)」)。子框(同源/跨域皆然)
+ *   只靠 page-side getAccessibleName 启发式,而该启发式的「包裹 label」分支此前
+ *   只覆盖 radio/checkbox;text/email/tel/textarea 落到末尾 placeholder||title||""
+ *   → 空名。于是所有 iframe 内手写表单字段对 agent 不可辨。
+ *
+ * 修复:getAccessibleName 增加通用「包裹 label」兜底——克隆 label、剥除嵌套表单
+ *   控件(避免 textarea 当前文本 / select 的 option 文本污染),取其余文本为名。
+ *   radio/checkbox 仍由上方专支提前返回;submit/button/image 仍由 value 提前返回。
+ */
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OBSERVE_SRC = readFileSync(
+  join(__dirname, "..", "src", "handlers", "observe.ts"),
+  "utf8",
+);
+
+describe("observe accessible-name — 包裹 <label> 的非 radio/checkbox 控件(iframe 子框无 AX 覆盖)", () => {
+  it("getAccessibleName 有通用包裹-label 兜底(克隆 label 后剥除嵌套表单控件)", () => {
+    expect(OBSERVE_SRC).toMatch(
+      /const wrapLabel = el\.closest\("label"\);[\s\S]{0,260}cloneNode\(true\)[\s\S]{0,160}querySelectorAll\("input, textarea, select"\)/,
+    );
+  });
+
+  it("剥除嵌套控件后用其 textContent 作名(规避 textarea 值 / select option 噪声)", () => {
+    expect(OBSERVE_SRC).toMatch(
+      /for \(const ctrl of clone\.querySelectorAll\("input, textarea, select"\)\)[\s\S]{0,60}ctrl\.remove\(\);[\s\S]{0,160}normName\(clone\.textContent\)/,
+    );
+  });
+
+  it("通用包裹-label 兜底位于 INPUT 分支末尾 placeholder 兜底之前(label 优先于 placeholder)", () => {
+    const wrapCloneIdx = OBSERVE_SRC.search(/const clone = wrapLabel\.cloneNode\(true\)/);
+    const placeholderIdx = OBSERVE_SRC.search(
+      /el\.getAttribute\("placeholder"\) \|\| el\.getAttribute\("title"\) \|\| ""/,
+    );
+    expect(wrapCloneIdx).toBeGreaterThan(0);
+    expect(placeholderIdx).toBeGreaterThan(0);
+    expect(wrapCloneIdx).toBeLessThan(placeholderIdx);
+  });
+});


### PR DESCRIPTION
## 问题（dogfood 实测，2026-06-22 跨域/iframe 轮次）

在 `example.com` 注入指向 `httpbin.org/forms/post` 的**真跨域** iframe，`observe(frames=all)` 把表单字段全报成**无名** `textbox`；同一表单在顶层文档却正确显示 `textbox "Customer name:"`。隔离实验确认：**同源** iframe 同样丢名 —— 根因不是跨域，而是「任何 iframe 子框内」。

| 元素 | 顶层文档 | iframe 子框（修复前） |
|---|---|---|
| Customer name 输入 | `textbox "Customer name:"` ✓ | `textbox`（无名）✗ |
| Telephone / E-mail | 命名正确 ✓ | 无名 ✗ |
| Preferred delivery time | `InputTime "..."` ✓ | 无名 textbox ✗ |
| Delivery instructions | `textbox "..."` ✓ | 无名 ✗ |
| Submit order | `button "Submit order"` ✓ | `button "Submit order"` ✓ |

## 根因

`observe.ts` 的 AX 语义覆盖层（`captureAXNodeMap` + `applyOverlay`，提供准确 role/name/state）**仅施加于主 frame 0**。iframe 子框（同源/跨域皆然）只能靠 page-side `getAccessibleName` 启发式命名，而其「包裹 label」分支此前**只覆盖 radio/checkbox**；`<label>Customer name: <input></label>` 这类手写表单的 text/email/tel/textarea/time 控件（无 `id`、无 `label[for]`）全落到末尾 `placeholder || title || ""` → 空名。Submit 因名取自自身 `value` 不受影响。

影响：所有 iframe 内手写表单字段对 agent 不可辨（支付字段、嵌入式表单、富文本工具等）。

## 修复

`getAccessibleName` 增加通用「包裹 label」兜底——克隆 `<label>`、剥除嵌套表单控件（规避 textarea 当前文本 / select 的 option 文本污染），取其余文本为名。
- radio/checkbox 仍由上方专支提前返回；
- submit/button/image 仍由 `value` 提前返回；
- 主 frame 的 AX 覆盖层照常覆写，无回归。

## 验证

- 单测：全量 1301 通过（新增 3 条 source-lock 回归 `observe-wrapping-label-name.test.ts`）。
- 真站（httpbin `/forms/post` 跨域 iframe，已重载扩展 live）：修复后 5 个字段全部正确命名；对命名后的跨域字段 `fill` 返回 `success:true`，跨域 act 闭环确认。
- 同源 iframe 同症，同复。

## 已知遗留（backlog，不在本 PR）

iframe 子框内 `<input type=time>` 仍报 `textbox` 而非 `InputTime`（role 退化）—— 因 role 同样来自仅限主 frame 的 AX 覆盖层。本 PR 只补 name（load-bearing）；子框 role 覆盖是更大的架构项（per-frame AX overlay / OOPIF），另开。

🤖 Generated with [Claude Code](https://claude.com/claude-code)