### PR TITLE
fix(observe): listener discovery 纳入投放区补 [dropzone] 信号

### DIFF
--- a/packages/extension/src/handlers/observe-js-listener.ts
+++ b/packages/extension/src/handlers/observe-js-listener.ts
@@ -45,6 +45,14 @@ import type { DebuggerManager } from "../lib/debugger-manager.js";
 export const LISTENER_MARK_ATTR = "data-vtx-listener";
 
 /**
+ * scan 用来识别「拖放投放区(drop target)」元素的属性名（pre-scan 打、post-scan 清）。
+ * 与 LISTENER_MARK_ATTR 并列但语义不同:drop 区不是点击目标,渲染为独立 [dropzone] 信号,
+ * 供 ref-based vortex_drag 的 endRef 定位投放区(无此信号则仅靠 drop/dragover 监听、无
+ * role/无 cursor/非 draggable 的 drop 区对 observe 完全不可见 → 拖放任务无 endRef 可表达)。
+ */
+export const DROPZONE_MARK_ATTR = "data-vtx-dropzone";
+
+/**
  * 点击监听器元素数上限：超过此值跳过标记，静默回退（召回安全）。
  * 与 browser-use 同量级（10000）——监听器极多的页让位给现有启发式。
  */
@@ -56,6 +64,15 @@ export const JS_LISTENER_ELEMENT_CAP = 10000;
  */
 const CLICK_EVENT_TYPES = ["click", "mousedown", "mouseup", "pointerdown", "pointerup"];
 
+/**
+ * 拖放投放区事件类型:含其一即判为 drop target。
+ * - `drop`:标准 HTML5 投放处理器(决定性信号)。
+ * - `dragenter`/`dragover`:react-dnd / 多数库给投放节点绑的接受信号(其 drop 常在 window
+ *   级集中处理,投放节点自身可能只有 dragenter/dragover/dragleave)——纳入以覆盖库模式。
+ * 不含 `dragstart`/`drag`/`dragend`(那是**拖源**信号,拖源已由 draggable=true 召回)。
+ */
+const DROP_TARGET_EVENT_TYPES = ["drop", "dragenter", "dragover"];
+
 /** DOMDebugger.getEventListeners 单条监听器形（只用到 type + backendNodeId）。 */
 interface CdpEventListener {
   type?: string;
@@ -66,7 +83,10 @@ interface CdpEventListener {
 export type ListenerMechanism = "domDebugger" | "skipped-heavy" | "error";
 
 export interface ListenerMarkResult {
+  /** 打了 data-vtx-listener 的点击类元素数。 */
   count: number;
+  /** 打了 data-vtx-dropzone 的投放区元素数。 */
+  dropzoneCount: number;
   mechanism: ListenerMechanism;
 }
 
@@ -100,7 +120,7 @@ export async function markListenerElements(
       returnByValue: false,
     })) as { result?: { objectId?: string } } | undefined;
     docObjectId = docResp?.result?.objectId;
-    if (!docObjectId) return { count: 0, mechanism: "error" };
+    if (!docObjectId) return { count: 0, dropzoneCount: 0, mechanism: "error" };
 
     // 一次拿整个文档子树（含 shadow / iframe）所有监听器，每条带 backendNodeId
     const leResp = (await debuggerMgr.sendCommand(tabId, "DOMDebugger.getEventListeners", {
@@ -110,44 +130,54 @@ export async function markListenerElements(
     })) as { listeners?: CdpEventListener[] } | undefined;
     const listeners = leResp?.listeners ?? [];
 
-    const backendIds = new Set<number>();
+    // 同一次 getEventListeners 结果分两类:点击类(→data-vtx-listener)与投放区(→data-vtx-dropzone)。
+    const clickIds = new Set<number>();
+    const dropIds = new Set<number>();
     for (const l of listeners) {
-      if (CLICK_EVENT_TYPES.includes(l.type ?? "") && typeof l.backendNodeId === "number") {
-        backendIds.add(l.backendNodeId);
-      }
+      const t = l.type ?? "";
+      if (typeof l.backendNodeId !== "number") continue;
+      if (CLICK_EVENT_TYPES.includes(t)) clickIds.add(l.backendNodeId);
+      if (DROP_TARGET_EVENT_TYPES.includes(t)) dropIds.add(l.backendNodeId);
     }
-    if (backendIds.size === 0) return { count: 0, mechanism: "domDebugger" };
-    if (backendIds.size > JS_LISTENER_ELEMENT_CAP) return { count: 0, mechanism: "skipped-heavy" };
+    if (clickIds.size === 0 && dropIds.size === 0) {
+      return { count: 0, dropzoneCount: 0, mechanism: "domDebugger" };
+    }
+    if (clickIds.size + dropIds.size > JS_LISTENER_ELEMENT_CAP) {
+      return { count: 0, dropzoneCount: 0, mechanism: "skipped-heavy" };
+    }
 
     // pushNodesByBackendIdsToFrontend 要求 DOM agent 已「请求过文档」(否则
     // "Document needs to be requested first")。depth:-1+pierce 确保 shadow/iframe
     // 节点也在 frontend map 内，与 getEventListeners 的 pierce:true 对齐。仅在确有
-    // 点击监听器(且 ≤cap)时才付此遍历代价。
+    // 关注监听器(且 ≤cap)时才付此遍历代价。
     await debuggerMgr.sendCommand(tabId, "DOM.getDocument", { depth: -1, pierce: true });
 
-    // backendNodeId → nodeId（批量一次）
-    const pushResp = (await debuggerMgr.sendCommand(tabId, "DOM.pushNodesByBackendIdsToFrontend", {
-      backendNodeIds: [...backendIds],
-    })) as { nodeIds?: number[] } | undefined;
-    const nodeIds = pushResp?.nodeIds ?? [];
-
-    let count = 0;
-    for (const nodeId of nodeIds) {
-      if (!nodeId) continue;
-      try {
-        await debuggerMgr.sendCommand(tabId, "DOM.setAttributeValue", {
-          nodeId,
-          name: LISTENER_MARK_ATTR,
-          value: "",
-        });
-        count++;
-      } catch {
-        // 单节点失败跳过（如节点已从 frontend map 失效），继续
+    // 单类标记:backendNodeId 集合 → nodeId → setAttributeValue。返回实际标记数。
+    const markSet = async (ids: Set<number>, attr: string): Promise<number> => {
+      if (ids.size === 0) return 0;
+      const pushResp = (await debuggerMgr.sendCommand(tabId, "DOM.pushNodesByBackendIdsToFrontend", {
+        backendNodeIds: [...ids],
+      })) as { nodeIds?: number[] } | undefined;
+      const nodeIds = pushResp?.nodeIds ?? [];
+      let n = 0;
+      for (const nodeId of nodeIds) {
+        if (!nodeId) continue;
+        try {
+          await debuggerMgr.sendCommand(tabId, "DOM.setAttributeValue", { nodeId, name: attr, value: "" });
+          n++;
+        } catch {
+          // 单节点失败跳过（如节点已从 frontend map 失效），继续
+        }
       }
-    }
-    return { count, mechanism: "domDebugger" };
+      return n;
+    };
+
+    // 点击类先标(保序:既有测试断言首个 push 为点击集),投放区后标。
+    const count = await markSet(clickIds, LISTENER_MARK_ATTR);
+    const dropzoneCount = await markSet(dropIds, DROPZONE_MARK_ATTR);
+    return { count, dropzoneCount, mechanism: "domDebugger" };
   } catch {
-    return { count: 0, mechanism: "error" };
+    return { count: 0, dropzoneCount: 0, mechanism: "error" };
   } finally {
     if (docObjectId) {
       try {

--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -106,6 +106,9 @@ interface ScannedElement {
   /** CDP getEventListeners 确认有 click/mousedown/pointerdown 监听器。
    * 高优先交互判定信号（优先级高于 cursor:pointer 启发），并集增强不删元素。@since T3 */
   listenerInteractive?: true;
+  /** CDP getEventListeners 确认有 drop/dragenter/dragover 监听器 → 投放区,渲染 [dropzone]。
+   * 入池信号(否则无 role/cursor 的 drop 区不可见),与 listenerInteractive 正交。@since dropzone-discovery */
+  dropzoneInteractive?: true;
   /** 最近的已收集祖先的 frame-local index；根节点 undefined。@since a11y-tree */
   parentIndex?: number;
   /** role=link 的 href，供 compact 树渲染 /url。@since a11y-tree */
@@ -1673,13 +1676,19 @@ async function scanOneFrame(
             // 标记的纯 addEventListener 元素,vanilla/jQuery 直绑——见 observe-js-listener.ts)。
             // 二者并集:framework 覆盖委托型、listener 覆盖直绑型,互补无盲区(T3 discovery)。
             const __hasDirectListener = el.hasAttribute("data-vtx-listener");
-            if (!hasFrameworkClick(el) && !__hasDirectListener) continue;
+            // 投放区(drop target)入池信号:pre-scan CDP 标的 data-vtx-dropzone(见
+            // observe-js-listener.ts)。body/html 排除——全局 file-drop 监听常绑在
+            // 文档根,不该把整页当 drop 区。drop 区不是点击目标,渲染 [dropzone] 而非
+            // [listener](透传见下方 entry 构造)。
+            const __hasDropzone =
+              el.hasAttribute("data-vtx-dropzone") && el.tagName !== "BODY" && el.tagName !== "HTML";
+            if (!hasFrameworkClick(el) && !__hasDirectListener && !__hasDropzone) continue;
             // framework onClick 常挂事件委托的**容器**层;若内部已有更细 cursor:pointer
             // 子项(如多个 SKU 选项),让位给子项各自入池——否则下方择叶因容器文字最长
             // 保留容器,把多真选项合并成一个不可操作大块(2026-06-04 淘宝 SKU 区回归)。
-            // **direct listener 不让位**:addEventListener 绑在元素自身,它就是精确点击
-            // 目标(非委托容器),不该让位给装饰性 pointer 子项。仅 framework 委托路径让位。
-            if (!__hasDirectListener) {
+            // **direct listener / dropzone 不让位**:addEventListener / drop 监听绑在元素自身,
+            // 它就是精确目标(非委托容器),不该让位给装饰性 pointer 子项。仅 framework 委托路径让位。
+            if (!__hasDirectListener && !__hasDropzone) {
               const finerDesc = el.querySelectorAll("*");
               let hasFinerPointer = false;
               for (let di = 0; di < finerDesc.length && di < 200; di++) {
@@ -2216,6 +2225,13 @@ async function scanOneFrame(
             // T3 discovery: pre-scan CDP getEventListeners 标记的纯 addEventListener
             // 元素带 data-vtx-listener → 渲染 [listener] 真值信号(此处属性尚存,清理在后)。
             ...(htmlEl.hasAttribute("data-vtx-listener") ? { listenerInteractive: true as const } : {}),
+            // 投放区:data-vtx-dropzone(drop/dragenter/dragover 监听)→ 渲染 [dropzone] 信号,
+            // 与 [listener] 正交(同一元素可兼具)。body/html 排除全局 file-drop 误标。
+            ...(htmlEl.hasAttribute("data-vtx-dropzone") &&
+            htmlEl.tagName !== "BODY" &&
+            htmlEl.tagName !== "HTML"
+              ? { dropzoneInteractive: true as const }
+              : {}),
             ...(__href !== undefined ? { href: __href } : {}),
             ...(__inputCompound !== undefined ? { compound: __inputCompound } : {}),
             ...(__vtxBlind ? { blindspot: __vtxBlind } : {}),
@@ -2534,7 +2550,7 @@ export function registerObserveHandlers(router: ActionRouter, debuggerMgr: Debug
       // data-vtx-listener 属性直接生成,不再需要事后 CDP pass。
 
       // marker 清理(无条件):data-vtx-ax(scan stamping)+ data-vtx-listener
-      // (pre-scan discovery)。两者无条件打,故清理也须无条件,防标记残留。清理失败不致命。
+      // + data-vtx-dropzone(pre-scan discovery)。无条件打,故清理也须无条件,防标记残留。清理失败不致命。
       try {
         await chrome.scripting.executeScript({
           target: { tabId: tid, allFrames: true },
@@ -2542,6 +2558,8 @@ export function registerObserveHandlers(router: ActionRouter, debuggerMgr: Debug
             for (const el of document.querySelectorAll("[data-vtx-ax]")) el.removeAttribute("data-vtx-ax");
             for (const el of document.querySelectorAll("[data-vtx-listener]"))
               el.removeAttribute("data-vtx-listener");
+            for (const el of document.querySelectorAll("[data-vtx-dropzone]"))
+              el.removeAttribute("data-vtx-dropzone");
           },
         });
       } catch {
@@ -2570,6 +2588,8 @@ export function registerObserveHandlers(router: ActionRouter, debuggerMgr: Debug
         clickHint?: string;
         /** CDP getEventListeners 真值信号，透传渲染层。@since T3 */
         listenerInteractive?: true;
+        /** 投放区(drop/dragenter/dragover 监听)真值信号 → 渲染 [dropzone]。@since dropzone-discovery */
+        dropzoneInteractive?: true;
         frameId: number;
         // Issue #21 — populated only when input.includeBoxes && e.inViewport (T4).
         bbox?: [number, number, number, number];
@@ -2679,6 +2699,8 @@ export function registerObserveHandlers(router: ActionRouter, debuggerMgr: Debug
                 : {}),
               // T3: CDP getEventListeners 真值信号透传渲染层（并集增强）。
               ...(e.listenerInteractive ? { listenerInteractive: true as const } : {}),
+              // 投放区真值信号透传渲染层（→ [dropzone]）。
+              ...(e.dropzoneInteractive ? { dropzoneInteractive: true as const } : {}),
               // a11y-tree: 全局重映射后的父指针 + href（link 元素）。
               ...(globalParentIndex !== undefined ? { parentIndex: globalParentIndex } : {}),
               ...(e.href ? { href: e.href } : {}),
@@ -2721,6 +2743,8 @@ export function registerObserveHandlers(router: ActionRouter, debuggerMgr: Debug
                 : {}),
               // T3: CDP getEventListeners 真值信号透传渲染层（并集增强）。
               ...(e.listenerInteractive ? { listenerInteractive: true as const } : {}),
+              // 投放区真值信号透传渲染层（→ [dropzone]）。
+              ...(e.dropzoneInteractive ? { dropzoneInteractive: true as const } : {}),
               // a11y-tree: 全局重映射后的父指针 + href（link 元素）。
               ...(globalParentIndex !== undefined ? { parentIndex: globalParentIndex } : {}),
               ...(e.href ? { href: e.href } : {}),

--- a/packages/extension/tests/observe-dropzone-discovery.test.ts
+++ b/packages/extension/tests/observe-dropzone-discovery.test.ts
@@ -1,0 +1,59 @@
+/**
+ * source-lock 测试:observe.ts 投放区(drop target)发现接线。
+ *
+ * 背景(iteration 14 真站确诊):observe 的 listener discovery 只筛点击类事件
+ * (observe-js-listener.ts CLICK_EVENT_TYPES),drop/dragenter/dragover 监听的投放区
+ * 若无 role/无 cursor:pointer/非 draggable,则既不被 discovery 标记也不被启发式收集
+ * → 对 observe 任何 filter 不可见 → ref-based vortex_drag 无合法 endRef 投放。
+ *
+ * 修复:扩展 discovery 标 data-vtx-dropzone,observe scan 把它当入池信号 + 渲染 [dropzone]。
+ * scan 内联于 executeScript func,无法行为执行,故以源码锁保护接线不被回退。
+ * (marker 模块与渲染层的真行为测试见 observe-js-listener.test.ts。)
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OBSERVE_SRC = readFileSync(join(__dirname, "../src/handlers/observe.ts"), "utf8");
+
+describe("observe.ts 投放区发现接线(source-lock)", () => {
+  it("入池信号:cursor!=pointer 分支纳入 data-vtx-dropzone(并集 framework/listener)", () => {
+    // __hasDropzone 须参与 continue 守卫,否则仅 drop 监听的 div 被滤掉
+    expect(OBSERVE_SRC).toMatch(/__hasDropzone\s*=[\s\S]*?hasAttribute\("data-vtx-dropzone"\)/);
+    expect(OBSERVE_SRC).toMatch(
+      /if\s*\(\s*!hasFrameworkClick\(el\)\s*&&\s*!__hasDirectListener\s*&&\s*!__hasDropzone\s*\)\s*continue/,
+    );
+  });
+
+  it("body/html 排除:全局 file-drop 监听绑文档根,不得把整页当投放区", () => {
+    // 收集侧守卫
+    expect(OBSERVE_SRC).toMatch(
+      /hasAttribute\("data-vtx-dropzone"\)\s*&&\s*el\.tagName\s*!==\s*"BODY"\s*&&\s*el\.tagName\s*!==\s*"HTML"/,
+    );
+  });
+
+  it("dropzone 不让位 finer-pointer 子项(与 direct listener 同,绑在元素自身)", () => {
+    expect(OBSERVE_SRC).toMatch(/if\s*\(\s*!__hasDirectListener\s*&&\s*!__hasDropzone\s*\)\s*\{/);
+  });
+
+  it("entry 构造:data-vtx-dropzone(排除 body/html)→ dropzoneInteractive 真值透传", () => {
+    expect(OBSERVE_SRC).toMatch(/dropzoneInteractive:\s*true as const/);
+    // entry 侧也带 body/html 守卫
+    const entryGuard =
+      /hasAttribute\("data-vtx-dropzone"\)\s*&&[\s\S]{0,80}tagName\s*!==\s*"BODY"[\s\S]{0,40}tagName\s*!==\s*"HTML"[\s\S]{0,40}dropzoneInteractive/;
+    expect(OBSERVE_SRC).toMatch(entryGuard);
+  });
+
+  it("透传渲染层:e.dropzoneInteractive → 输出 entry(compact + full 两路径)", () => {
+    const matches = OBSERVE_SRC.match(/e\.dropzoneInteractive\s*\?\s*\{\s*dropzoneInteractive:\s*true as const\s*\}/g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBeGreaterThanOrEqual(2); // compact + full
+  });
+
+  it("marker 清理含 data-vtx-dropzone(防标记残留)", () => {
+    expect(OBSERVE_SRC).toMatch(/querySelectorAll\("\[data-vtx-dropzone\]"\)/);
+  });
+});

--- a/packages/extension/tests/observe-js-listener.test.ts
+++ b/packages/extension/tests/observe-js-listener.test.ts
@@ -23,6 +23,7 @@ import {
   markListenerElements,
   JS_LISTENER_ELEMENT_CAP,
   LISTENER_MARK_ATTR,
+  DROPZONE_MARK_ATTR,
 } from "../src/handlers/observe-js-listener.js";
 import { renderObserveTree } from "../../mcp/src/lib/observe-render.js";
 
@@ -63,7 +64,9 @@ function makeDbg(config: DbgConfig): {
       return Promise.resolve({ root: { nodeId: 1 } });
     }
     if (method === "DOM.pushNodesByBackendIdsToFrontend") {
-      return Promise.resolve({ nodeIds: config.nodeIds ?? [] });
+      // config.nodeIds 显式提供时用之(legacy 单 push 测试);否则 echo 入参 backendNodeIds
+      // 作 nodeIds(支持 click+dropzone 两次 push 各自返回对应节点)。
+      return Promise.resolve({ nodeIds: config.nodeIds ?? params?.backendNodeIds ?? [] });
     }
     return Promise.resolve({});
   });
@@ -162,6 +165,135 @@ describe("markListenerElements · 召回零回退", () => {
 
   it("LISTENER_MARK_ATTR 是 data-vtx-listener", () => {
     expect(LISTENER_MARK_ATTR).toBe("data-vtx-listener");
+  });
+});
+
+// ---- 投放区(drop target)发现 ----
+
+describe("markListenerElements · dropzone 发现", () => {
+  it("drop/dragover 监听 → 打 data-vtx-dropzone(同节点去重计 1)", async () => {
+    const dbg = makeDbg({
+      listeners: [
+        { type: "drop", backendNodeId: 5 },
+        { type: "dragover", backendNodeId: 5 }, // 同节点,Set 去重
+        { type: "dragenter", backendNodeId: 5 },
+      ],
+    });
+    const res = await markListenerElements(dbg as any, 1);
+    expect(res.mechanism).toBe("domDebugger");
+    expect(res.dropzoneCount).toBe(1);
+    expect(res.count).toBe(0); // 无点击类
+    const setCall = dbg.calls.find((c) => c.method === "DOM.setAttributeValue");
+    expect(setCall!.params.name).toBe(DROPZONE_MARK_ATTR);
+  });
+
+  it("DROPZONE_MARK_ATTR 是 data-vtx-dropzone", () => {
+    expect(DROPZONE_MARK_ATTR).toBe("data-vtx-dropzone");
+  });
+
+  it("拖源信号 dragstart/drag/dragend 不算投放区(它们是拖源,由 draggable 召回)", async () => {
+    const dbg = makeDbg({
+      listeners: [
+        { type: "dragstart", backendNodeId: 9 },
+        { type: "drag", backendNodeId: 9 },
+        { type: "dragend", backendNodeId: 9 },
+      ],
+    });
+    const res = await markListenerElements(dbg as any, 1);
+    expect(res.dropzoneCount).toBe(0);
+    expect(res.count).toBe(0);
+  });
+
+  it("点击 + 投放区共存 → 各打各属性,两次 push 互不污染", async () => {
+    const dbg = makeDbg({
+      listeners: [
+        { type: "click", backendNodeId: 11 },
+        { type: "drop", backendNodeId: 22 },
+      ],
+      // 不设 nodeIds → mock echo 入参,使 click push 返 [11]、drop push 返 [22]
+    });
+    const res = await markListenerElements(dbg as any, 1);
+    expect(res.count).toBe(1);
+    expect(res.dropzoneCount).toBe(1);
+    const setCalls = dbg.calls.filter((c) => c.method === "DOM.setAttributeValue");
+    const listenerSet = setCalls.find((c) => c.params.name === LISTENER_MARK_ATTR);
+    const dropzoneSet = setCalls.find((c) => c.params.name === DROPZONE_MARK_ATTR);
+    expect(listenerSet!.params.nodeId).toBe(11);
+    expect(dropzoneSet!.params.nodeId).toBe(22);
+  });
+
+  it("点击集先 push(保序,不破坏既有点击断言)", async () => {
+    const dbg = makeDbg({
+      listeners: [
+        { type: "drop", backendNodeId: 22 },
+        { type: "click", backendNodeId: 11 },
+      ],
+    });
+    await markListenerElements(dbg as any, 1);
+    const pushes = dbg.calls.filter((c) => c.method === "DOM.pushNodesByBackendIdsToFrontend");
+    expect(pushes[0].params.backendNodeIds).toEqual([11]); // 首个 push 为点击集
+    expect(pushes[1].params.backendNodeIds).toEqual([22]);
+  });
+
+  it("无任何监听器 → dropzoneCount 0,不触发 getDocument", async () => {
+    const dbg = makeDbg({ listeners: [] });
+    const res = await markListenerElements(dbg as any, 1);
+    expect(res.dropzoneCount).toBe(0);
+    expect(dbg.calls.some((c) => c.method === "DOM.getDocument")).toBe(false);
+  });
+
+  it("CDP 抛错 → dropzoneCount 0 + error(召回零回退)", async () => {
+    const dbg = makeDbg({ throwOn: "DOMDebugger.getEventListeners" });
+    const res = await markListenerElements(dbg as any, 1);
+    expect(res.dropzoneCount).toBe(0);
+    expect(res.mechanism).toBe("error");
+  });
+});
+
+// ---- 渲染层 [dropzone] 标记 ----
+
+describe("observe-render [dropzone] 标记", () => {
+  it("dropzoneInteractive=true → 渲染输出含 [dropzone]", () => {
+    const data = {
+      snapshotId: "s1",
+      url: "https://example.com",
+      elements: [
+        { index: 0, tag: "div", role: "div", name: "Drop files here", frameId: 0, dropzoneInteractive: true },
+      ],
+    };
+    const out = renderObserveTree(data as any, null);
+    expect(out).toContain("[dropzone]");
+  });
+
+  it("无 dropzoneInteractive → 不含 [dropzone]", () => {
+    const data = {
+      snapshotId: "s1",
+      url: "https://example.com",
+      elements: [{ index: 0, tag: "button", role: "button", name: "提交", frameId: 0 }],
+    };
+    const out = renderObserveTree(data as any, null);
+    expect(out).not.toContain("[dropzone]");
+  });
+
+  it("listener + dropzone 正交共存 → 同时含 [listener] 和 [dropzone]", () => {
+    const data = {
+      snapshotId: "s1",
+      url: "https://example.com",
+      elements: [
+        {
+          index: 0,
+          tag: "div",
+          role: "div",
+          name: "可点亦可投放",
+          frameId: 0,
+          listenerInteractive: true,
+          dropzoneInteractive: true,
+        },
+      ],
+    };
+    const out = renderObserveTree(data as any, null);
+    expect(out).toContain("[listener]");
+    expect(out).toContain("[dropzone]");
   });
 });
 

--- a/packages/mcp/src/lib/observe-render.ts
+++ b/packages/mcp/src/lib/observe-render.ts
@@ -20,6 +20,8 @@ export interface CompactElement {
   reactClickable?: true;
   /** CDP getEventListeners 确认有 click/mousedown/pointerdown 监听器 → 渲染 [listener]。@since T3 */
   listenerInteractive?: true;
+  /** CDP getEventListeners 确认有 drop/dragenter/dragover 监听器 → 渲染 [dropzone]（投放区，vortex_drag endRef 目标）。@since dropzone-discovery */
+  dropzoneInteractive?: true;
   /** role=link 的 href，渲染 /url: 属性行。@since a11y-tree */
   href?: string;
   /** AX nameSource：名称来源(label/placeholder/title/heuristic 等)。@since ax-overlay */
@@ -405,6 +407,8 @@ export function renderObserveTree(
     const cursor = e.reactClickable ? " [cursor=pointer]" : "";
     // CDP getEventListeners 真值信号：[listener] 标记区分「真有 JS 监听器」vs「仅 cursor 启发」。
     const listener = e.listenerInteractive ? " [listener]" : "";
+    // 投放区信号：[dropzone] 告知 agent 此元素接受拖放，是 vortex_drag 的 endRef 目标。
+    const dropzone = e.dropzoneInteractive ? " [dropzone]" : "";
     const valueSeg =
       e.valueNow !== undefined
         ? ` value=${/\s/.test(e.valueNow) ? JSON.stringify(e.valueNow) : e.valueNow}`
@@ -456,7 +460,7 @@ export function renderObserveTree(
     const isNew = prevKeys !== null && !prevKeys.has(buildElementKey(e));
     const newPrefix = isNew ? "* " : "";
     lines.push(
-      `${indent}${newPrefix}- ${e.role}${name}${ref}${stateFlags(e.state)}${weak}${cursor}${listener}${valueSeg}${comp}${err}${ctrl}${desc}${offscreenSeg}${blindspotTag(e.blindspot)}${bboxSeg}${hasChildren ? ":" : ""}`,
+      `${indent}${newPrefix}- ${e.role}${name}${ref}${stateFlags(e.state)}${weak}${cursor}${listener}${dropzone}${valueSeg}${comp}${err}${ctrl}${desc}${offscreenSeg}${blindspotTag(e.blindspot)}${bboxSeg}${hasChildren ? ":" : ""}`,
     );
     if (hasUrl) lines.push(`${indent}  - /url: ${e.href}`);
     for (const k of kids) emit(k, depth + 1);


### PR DESCRIPTION
## 背景(iteration 14 拖放 dogfood)

目标:拖放(冷结构边)。HTML5 原生拖放与 vortex_drag 的 CDP trusted 指针拖放协议不同,经典自动化难点。

### 证伪(vortex_drag 原语正确)
- react-dnd sortable simple:`vortex_drag` 拖 PROFIT→首位,白盒核验 React 渲染顺序真变 ✓
- **受控最小 spike**(标准 HTML5 drop 区):`vortex_drag` 触发完整序列 `src:dragstart→zone:drop:payload→src:dragend`,dataTransfer payload 正确传递,`zoneText=DROPPED:payload` ✓ → **vortex_drag 正确实现 HTML5 原生拖放(含 dataTransfer+drop)**
- react-dnd dustbin 不记录 drop = react-dnd 内部 dataTransfer 校验特有,**非 vortex 缺陷**

### 真缺陷(白盒确诊)
**observe 不发现/暴露投放区(drop target)**。受控最小用例钉死:可拖源因 `draggable=true` 召回为 group,而 drop 区(仅 drop/dragover 监听、无 role、非 draggable)**即便 `filter:all`+`scope:full` 也完全不出现**。

根因 `observe-js-listener.ts`:listener discovery 的 `CLICK_EVENT_TYPES` 只含点击类(click/mousedown/mouseup/pointerdown/pointerup),**不含 drop/dragenter/dragover** → 投放区永不入池 → ref-based vortex_drag 无合法 endRef 投放。与盲区降级哲学相悖(应发信号非静默漏)。

## 修复

同一次 `getEventListeners` 结果分两类:
- 点击类 → `data-vtx-listener`(不变)
- 投放区(drop/dragenter/dragover)→ 新 `data-vtx-dropzone`

observe scan 把后者当**入池信号** + 渲染独立 **`[dropzone]`** 信号(与 `[listener]` 正交,不暗示可点击)。**body/html 排除**防全局 file-drop 把整页当投放区。纯加性,CDP 失败→0 标记退回启发式(召回零回退)。

## 验证

- **TDD**:marker 模块 9 真行为测 + render `[dropzone]` 3 测 + observe.ts 接线 6 source-lock
- **单测**:extension **1317** + mcp **508** 通过(+16)
- **live 三连**:① drop 区从不可见→`div "Drag a box here" [dropzone]` 带 ref ② `vortex_drag` 用其 endRef 投放→`DROPPED:payload` ③ body+document 绑全局 drop 后 body **不**被标 [dropzone](守卫生效无过收)
- **bench**:**94/94** 无回归

## Test plan
- [x] extension + mcp 单测
- [x] live 行为验证(暴露 + 投放 + 守卫)
- [x] bench 全量回归