### PR TITLE
fix(observe): 虚拟列表盲区按祖先行数加误报闸防全渲染列表误报

### DIFF
--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -2301,6 +2301,12 @@ async function scanOneFrame(
             const __sh = __scroller.scrollHeight;
             const __ch = __scroller.clientHeight;
             if (__ch <= 0 || __sh < __ch * 4) continue;
+            // 误报闸:真虚拟列表的滚动祖先只含视口窗口的行(≈__rendered);若祖先 DOM
+            // 行数远多于本候选渲染数,说明 __sh 来自祖先里其它真实内容(整片导航侧栏含
+            // 多个列表),__est 把整片高度误当本列表的行 → 误报。MDN CSS 参考 aside 含
+            // 1249 项,某 6 项小列表被估成 303(scrollH 9692/rowH 32)实证。
+            const __scrollerRows = __scroller.querySelectorAll("[role=row],tr,li").length;
+            if (__scrollerRows > __rendered * 2) continue;
             const __est = Math.round(__sh / __rowH);
             if (__est > __rendered && __est >= Math.max(__rendered * 2, __rendered + 20)) {
               __seenScrollers.add(__scroller);

--- a/packages/extension/src/page-side/blindspot-detect.ts
+++ b/packages/extension/src/page-side/blindspot-detect.ts
@@ -68,11 +68,20 @@ export function detectVirtualByScroll(
   scroller: { scrollHeight: number; clientHeight: number },
   renderedRows: number,
   rowHeight: number,
+  // 滚动祖先 DOM 内实际行数(li/tr/role=row)。默认等于 renderedRows(向后兼容:
+  // 不传时视为「祖先只含本列表」,闸不触发)。调用方应传真实测量值。
+  scrollerRowCount: number = renderedRows,
 ): Blindspot | null {
   if (renderedRows < 3 || rowHeight < 4) return null;
   const sh = scroller.scrollHeight;
   const ch = scroller.clientHeight;
   if (ch <= 0 || sh < ch * 4) return null;
+  // 误报闸(MDN CSS 参考侧栏实证):真虚拟列表的滚动祖先只含视口窗口的行
+  // (scrollerRowCount ≈ renderedRows);若祖先 DOM 行数远多于本列表渲染数,说明
+  // scrollHeight 来自祖先里**其它真实内容**(整片导航侧栏含多个列表共 1249 项),
+  // estTotal=scrollH/rowH 把整片高度误当本列表的行 → 误报。某 6 项小列表的祖先
+  // aside scrollH=9692/rowH=32 被估成 303,但 aside 实含 1249 项全在 DOM(非虚拟)。
+  if (scrollerRowCount > renderedRows * 2) return null;
   const estTotal = Math.round(sh / rowHeight);
   if (estTotal > renderedRows && estTotal >= Math.max(renderedRows * 2, renderedRows + 20)) {
     return { kind: "virtual", total: estTotal, rendered: renderedRows, confidence: "low" };

--- a/packages/extension/tests/blindspot-detect.test.ts
+++ b/packages/extension/tests/blindspot-detect.test.ts
@@ -78,4 +78,20 @@ describe("detectVirtualByScroll (A2-fb 非 ARIA 虚拟化)", () => {
     // sh=1200 ch=240 → 5x, rowH=40, estTotal=30, rendered=18 → 30<max(36,38) 不触发
     expect(detectVirtualByScroll({ scrollHeight: 1200, clientHeight: 240 }, 18, 40)).toBeNull();
   });
+  it("小列表嵌于高大导航祖先(scrollerRowCount 1249 >> rendered 6) → 不报（误报闸:MDN 实证）", () => {
+    // aside scrollH=9692/clientH=634 → 15x 强滚动,rowH=32,est=303>>6 本会误报,
+    // 但 scrollerRowCount=1249 > 6*2 → 祖先含其它内容,非本列表虚拟化 → null。
+    expect(
+      detectVirtualByScroll({ scrollHeight: 9692, clientHeight: 634 }, 6, 32, 1249),
+    ).toBeNull();
+  });
+  it("真虚拟列表祖先只含窗口行(scrollerRowCount≈rendered) → 仍正常报", () => {
+    // 显式传 scrollerRowCount=12(≈rendered 12,真虚拟:祖先只渲染窗口)→ 闸不触发,照常报。
+    expect(detectVirtualByScroll({ scrollHeight: 48000, clientHeight: 250 }, 12, 48, 12)).toEqual({
+      kind: "virtual",
+      total: 1000,
+      rendered: 12,
+      confidence: "low",
+    });
+  });
 });

--- a/packages/extension/tests/observe-blindspot-scan.test.ts
+++ b/packages/extension/tests/observe-blindspot-scan.test.ts
@@ -18,6 +18,9 @@ describe("scan func 内联 detectBlindspot 与纯函数一致", () => {
     expect(src).toContain("candidateCount: s.page.candidateCount");
     // A2-fb 非 ARIA 虚拟化回退内联
     expect(src).toContain("[inline detectVirtualByScroll]");
+    // 误报闸:祖先 DOM 行数 >> 本列表渲染数 → 跳过(MDN 侧栏实证),须与 canonical 同步
+    expect(src).toContain("__scrollerRows");
+    expect(src).toContain("__scrollerRows > __rendered * 2");
   });
   it("纯函数对 grid aria-rowcount=1000/rendered=10 → virtual(行为基线)", () => {
     document.body.innerHTML = `<div role="grid" aria-rowcount="1000">${"<div role='row'></div>".repeat(10)}</div>`;


### PR DESCRIPTION
## 背景(iteration 16 MDN Web Docs dogfood)

真站轮换:连撞 4 个 bot 墙(ag-grid CloudFront / eBay 错误页 / Reddit 网络安全拦截 / npm Cloudflare)→ pivot 到 MDN。

### 真缺陷(白盒 + spike 确诊)
observe 顶部 meta 报 `# blindspots: ol virtual(~303/6)`,但 spike 实测:
- 所有 `<ol>` **全渲染**(`inDom === laidOut`:174/174 等)
- `scrollHeight === clientHeight`(无内部滚动,整页滚动非列表虚拟化)

→ **误报**。复刻启发式逐元素定位触发源:侧栏一个 **6 项工具列表**(rowH=32),其滚动祖先 `<aside class="layout__left-sidebar">`(scrollH=9692/clientH=634,**实含整片 CSS 参考共 1249 个 li**),`est = 9692/32 = 303`。

根因 `detectVirtualByScroll`:用滚动**祖先**的 scrollHeight ÷ 本候选 rowH 估算 total,**隐含假设「祖先只装本列表」**;当祖先是含多列表的导航区,scrollHeight 来自其它真实内容 → est 暴涨误报。

### 影响
盲区「假阳」与「漏报」同等有害:让 agent 误以为内容被隐藏(303 项只显示 6 项)而徒劳滚动 / distrust 快照,实则 6 项全在 DOM 可观测。

## 修复

`detectVirtualByScroll` 加 `scrollerRowCount` 参数 + 误报闸:真虚拟列表的滚动祖先只含视口窗口的行(`scrollerRowCount ≈ renderedRows`);若 `scrollerRowCount > renderedRows × 2`(祖先含远多于本列表的行,内容全在 DOM)→ 返回 null。

canonical(`blindspot-detect.ts`)+ observe.ts 内联副本(新增 `__scrollerRows = __scroller.querySelectorAll("[role=row],tr,li").length` 测量)双源同步。向后兼容:`scrollerRowCount` 默认 `renderedRows`(不传时闸不触发)。

## 验证

- **TDD**:canonical +2 测(MDN 精确输入 9692/634/6/32/**1249**→null 误报闸 + 显式 `scrollerRowCount≈rendered` 真虚拟仍报);source-lock +2 守内联闸
- **盲区单测 19** 通过 / **extension 1303** 通过
- **bench 94/94** 无回归
- 注:live 复验受会话 MCP 本轮断连阻;spike 已在 live MDN 测得精确输入,单测用该精确组喂 canonical 证 null,内联经 source-lock 同步双重保

## Test plan
- [x] 盲区检测单测(canonical + source-lock)
- [x] spike 确诊触发元素(6 项列表 + 1249 项 aside)
- [x] bench 全量回归