### PR TITLE
fix(observe): 纯 div 虚拟列表盲区漏检补检(react-window/virtuoso/PrimeReact VirtualScroller)

### DIFF
--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -2344,6 +2344,36 @@ async function scanOneFrame(
               pageBlindspots.push({ kind: "virtual", total: __est, rendered: __rendered, name: String(__nm).slice(0, 40), confidence: "low" });
             }
           }
+          // [inline detectDivVirtualScroller] A2-fb-div 纯 div 虚拟列表(react-window/react-virtuoso/
+          // PrimeReact VirtualScroller:容器与行都无 table/ul/[role] 语义,上面语义路径整类漏扫)。
+          // 真源 blindspot-detect.ts detectDivVirtualScroller,改一处须改两处。
+          // 强滚动 div 容器 + 内部 ≥3 等高重复子项 + estTotal>>渲染。廉价 scrollHeight 门先于 getComputedStyle。
+          for (const __sc of querySelectorAllDeep("div", document)) {
+            if (__seenScrollers.has(__sc)) continue;
+            const __sh2 = (__sc as HTMLElement).scrollHeight;
+            const __ch2 = (__sc as HTMLElement).clientHeight;
+            if (__ch2 <= 0 || __sh2 < __ch2 * 4) continue; // 廉价强滚动门
+            const __oy2 = getComputedStyle(__sc as HTMLElement).overflowY;
+            if (__oy2 !== "auto" && __oy2 !== "scroll") continue; // 确认裁剪滚动
+            let __divRows: Element[] = [];
+            for (const __w of Array.from((__sc as HTMLElement).querySelectorAll("div"))) {
+              const __kids = Array.from(__w.children);
+              if (__kids.length < 3) continue;
+              const __h0 = __kids[0].getBoundingClientRect().height;
+              if (__h0 < 4) continue;
+              const __uni = __kids.filter((n) => Math.abs(n.getBoundingClientRect().height - __h0) <= 2);
+              if (__uni.length >= 3 && __uni.length >= __kids.length * 0.7 && __uni.length > __divRows.length) __divRows = __uni;
+            }
+            if (__divRows.length < 3) continue;
+            const __dRendered = __divRows.length;
+            const __dRowH = __divRows[0].getBoundingClientRect().height;
+            const __dEst = Math.round(__sh2 / __dRowH);
+            if (__dEst > __dRendered && __dEst >= Math.max(__dRendered * 2, __dRendered + 20)) {
+              __seenScrollers.add(__sc);
+              const __dnm = (__sc as HTMLElement).getAttribute("aria-label") || "list";
+              pageBlindspots.push({ kind: "virtual", total: __dEst, rendered: __dRendered, name: String(__dnm).slice(0, 40), confidence: "low" });
+            }
+          }
         }
 
         return {

--- a/packages/extension/src/page-side/blindspot-detect.ts
+++ b/packages/extension/src/page-side/blindspot-detect.ts
@@ -88,3 +88,38 @@ export function detectVirtualByScroll(
   }
   return null;
 }
+
+/**
+ * A2-fb-div 纯 div 虚拟列表检测(react-window/react-virtuoso/PrimeReact VirtualScroller 等:
+ * 容器与行都是无 table/ul/[role] 语义的纯 div,detectVirtualByScroll 的语义候选/行选择器整类漏扫)。
+ * 入参为疑似滚动容器。判据(与 detectVirtualByScroll 共享判定门,同 estTotal 公式):
+ *  ① 强滚动:overflowY auto/scroll 且 scrollHeight ≥ clientHeight×4(普通内容达不到)
+ *  ② 渲染窗口:内部存在某容器有 ≥3 个等高(±2px)重复子项,且等高占比 ≥70%(排除异构布局)
+ *  ③ estTotal(scrollH/rowH)远大于渲染数(虚拟本质=只渲染窗口;全量渲染列表 estTotal≈渲染 不触发)。
+ * 廉价 scrollHeight 门先于 getComputedStyle,使可在全 div 上遍历调用而不爆开销。confidence:low。
+ */
+export function detectDivVirtualScroller(scroller: HTMLElement): Blindspot | null {
+  const sh = scroller.scrollHeight;
+  const ch = scroller.clientHeight;
+  if (ch <= 0 || sh < ch * 4) return null; // 廉价强滚动门(先于 getComputedStyle)
+  const oy = getComputedStyle(scroller).overflowY;
+  if (oy !== "auto" && oy !== "scroll") return null; // 确认裁剪滚动(排除内容自然撑高不裁剪的)
+  // 找渲染窗口:内部某 div 的直接子元素 ≥3 且高度近似一致(等高重复行=列表的特征)。
+  let rows: Element[] = [];
+  for (const w of Array.from(scroller.querySelectorAll("div"))) {
+    const kids = Array.from(w.children);
+    if (kids.length < 3) continue;
+    const h0 = kids[0].getBoundingClientRect().height;
+    if (h0 < 4) continue;
+    const uni = kids.filter((n) => Math.abs(n.getBoundingClientRect().height - h0) <= 2);
+    if (uni.length >= 3 && uni.length >= kids.length * 0.7 && uni.length > rows.length) rows = uni;
+  }
+  if (rows.length < 3) return null;
+  const rendered = rows.length;
+  const rowH = rows[0].getBoundingClientRect().height;
+  const estTotal = Math.round(sh / rowH);
+  if (estTotal > rendered && estTotal >= Math.max(rendered * 2, rendered + 20)) {
+    return { kind: "virtual", total: estTotal, rendered, confidence: "low" };
+  }
+  return null;
+}

--- a/packages/extension/tests/blindspot-detect.test.ts
+++ b/packages/extension/tests/blindspot-detect.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from "vitest";
-import { detectBlindspot, detectVirtualByScroll } from "../src/page-side/blindspot-detect.js";
+import { describe, it, expect, beforeEach } from "vitest";
+import { detectBlindspot, detectVirtualByScroll, detectDivVirtualScroller } from "../src/page-side/blindspot-detect.js";
 
 function withRect(el: Element, width: number, height: number) {
   Object.defineProperty(el, "getBoundingClientRect", {
@@ -8,6 +8,31 @@ function withRect(el: Element, width: number, height: number) {
     configurable: true,
   });
   return el as HTMLElement;
+}
+
+// jsdom 无布局:为 scroller 注入 scrollHeight/clientHeight,为子项注入等高 rect。
+function makeDivScroller(opts: {
+  scrollHeight: number;
+  clientHeight: number;
+  overflowY?: string;
+  childCount: number;
+  childHeight: number | number[];
+}): HTMLElement {
+  const sc = document.createElement("div");
+  if (opts.overflowY) sc.style.overflowY = opts.overflowY;
+  Object.defineProperty(sc, "scrollHeight", { value: opts.scrollHeight, configurable: true });
+  Object.defineProperty(sc, "clientHeight", { value: opts.clientHeight, configurable: true });
+  const content = document.createElement("div");
+  for (let i = 0; i < opts.childCount; i++) {
+    const item = document.createElement("div");
+    item.textContent = `Item #${i}`;
+    const h = Array.isArray(opts.childHeight) ? opts.childHeight[i] : opts.childHeight;
+    withRect(item, 300, h);
+    content.appendChild(item);
+  }
+  sc.appendChild(content);
+  document.body.appendChild(sc);
+  return sc;
 }
 
 describe("detectBlindspot", () => {
@@ -93,5 +118,36 @@ describe("detectVirtualByScroll (A2-fb 非 ARIA 虚拟化)", () => {
       rendered: 12,
       confidence: "low",
     });
+  });
+});
+
+describe("detectDivVirtualScroller (A2-fb-div 纯 div 虚拟列表)", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+  it("PrimeReact VirtualScroller 式(div容器+8等高div项/scrollH 5000000/clientH 198) → virtual ~100000 低置信", () => {
+    const sc = makeDivScroller({ scrollHeight: 5000000, clientHeight: 198, overflowY: "auto", childCount: 8, childHeight: 50 });
+    expect(detectDivVirtualScroller(sc)).toEqual({ kind: "virtual", total: 100000, rendered: 8, confidence: "low" });
+  });
+  it("非裁剪容器(overflowY visible 即便强滚动) → 不报（负例）", () => {
+    const sc = makeDivScroller({ scrollHeight: 5000000, clientHeight: 198, overflowY: "visible", childCount: 8, childHeight: 50 });
+    expect(detectDivVirtualScroller(sc)).toBeNull();
+  });
+  it("普通弱滚动 div 列表(scrollH 500/clientH 400,ratio<4) → 不报（负例:强滚动门）", () => {
+    const sc = makeDivScroller({ scrollHeight: 500, clientHeight: 400, overflowY: "auto", childCount: 10, childHeight: 50 });
+    expect(detectDivVirtualScroller(sc)).toBeNull();
+  });
+  it("全量渲染等高列表(50项全在DOM/scrollH 2500/clientH 400,estTotal≈渲染) → 不报（负例）", () => {
+    // sh=2500 ch=400 → 6.25x 强滚动,但 50项全渲染,estTotal=50=rendered 不>>
+    const sc = makeDivScroller({ scrollHeight: 2500, clientHeight: 400, overflowY: "auto", childCount: 50, childHeight: 50 });
+    expect(detectDivVirtualScroller(sc)).toBeNull();
+  });
+  it("异构高度子项(非等高重复) → 不报（负例:非列表）", () => {
+    const sc = makeDivScroller({ scrollHeight: 5000000, clientHeight: 198, overflowY: "auto", childCount: 8, childHeight: [50, 120, 30, 200, 80, 50, 300, 40] });
+    expect(detectDivVirtualScroller(sc)).toBeNull();
+  });
+  it("子项过少(<3) → 不报（负例）", () => {
+    const sc = makeDivScroller({ scrollHeight: 5000000, clientHeight: 198, overflowY: "scroll", childCount: 2, childHeight: 50 });
+    expect(detectDivVirtualScroller(sc)).toBeNull();
   });
 });

--- a/packages/extension/tests/observe-blindspot-scan.test.ts
+++ b/packages/extension/tests/observe-blindspot-scan.test.ts
@@ -21,6 +21,8 @@ describe("scan func 内联 detectBlindspot 与纯函数一致", () => {
     // 误报闸:祖先 DOM 行数 >> 本列表渲染数 → 跳过(MDN 侧栏实证),须与 canonical 同步
     expect(src).toContain("__scrollerRows");
     expect(src).toContain("__scrollerRows > __rendered * 2");
+    // A2-fb-div 纯 div 虚拟列表(react-window/virtuoso/PrimeReact VirtualScroller)内联
+    expect(src).toContain("[inline detectDivVirtualScroller]");
   });
   it("纯函数对 grid aria-rowcount=1000/rendered=10 → virtual(行为基线)", () => {
     document.body.innerHTML = `<div role="grid" aria-rowcount="1000">${"<div role='row'></div>".repeat(10)}</div>`;


### PR DESCRIPTION
## 背景(dogfood iteration 17)

Ralph dogfood 在 **PrimeReact 官网**(primereact.org)轮换测试时,在 VirtualScroller demo 上经 live spike 确诊一个 perception 真缺陷。

## 缺陷

A2-fb 虚拟列表盲区检测:
- 候选选择器只认语义容器 `table,[role=grid],[role=listbox],[role=tree],ul,ol`
- 行选择器只认 `[role=row],tr,li`

而 **react-window / react-virtuoso / PrimeReact VirtualScroller** 这类最主流的现代虚拟列表用**纯 `<div>` 容器 + 纯 `<div>` 行**,无 ARIA role、无语义标签 → 被整类静默漏检。

后果:observe 把一个 **10 万项**的虚拟滚动器输出为单个普通 div `"Item #0...Item #7"` 且**零盲区信号**,agent 误以为只有 8 条数据。

### spike 确诊证据(live)
```
.p-virtualscroller 是 DIV → matches("table,[role=grid]...")  === false   ← 候选漏
8 个列表项也是纯 div → querySelectorAll("[role=row],tr,li") === 0          ← 行漏
isScroller:true / scrollH 5000000 / clientH 198 (ratio 25253) / 8 项等高(50px) / estTotal 100000
```

是 iter-16 虚拟列表**误报**缺陷的对偶(本轮是**漏报**)。

## 修复

新增纯函数 `detectDivVirtualScroller(scroller)`(`blindspot-detect.ts`)+ `observe.ts` 内联镜像(`[inline detectDivVirtualScroller]`,source-lock 守护)。判据:

1. **强滚动**:`overflowY` auto/scroll 且 `scrollH ≥ clientH×4`(普通内容达不到);廉价 `scrollHeight` 门先于 `getComputedStyle`,可在全 div 遍历调用而不爆开销(虚拟列表 DOM 节点本就少)
2. **渲染窗口**:内部某 div 有 ≥3 个等高(±2px)重复子项且等高占比 ≥70%(排除异构布局)
3. **estTotal>>渲染数**:复用 `detectVirtualByScroll` 同一判定门(全量渲染等高列表 estTotal≈渲染 不触发=误报防线)

与语义路径共享 `__seenScrollers` 去重。纯加性,不改既有元素收集。

## 验证

- **TDD**:纯函数 6 行为测(PrimeReact 式正例 `5000000/198/8/50→virtual~100000` + 5 负例:overflow visible / 弱滚动 / 全量渲染 / 异构高度 / 项<3 全 null);source-lock 1 断言守内联接线
- **单测**:blindspot 23 通过;extension 全量 **1307** 通过
- **live**:扩展 reload 后,VirtualScroller demo observe 顶部由「零信号」→ `# blindspots: list virtual(~100000/8)` × 8,白盒核实页面恰有 8 个真实 `.p-virtualscroller`(7× sh=5000000→100000、1× sh=50000→1000,数字精确对应),去重无重复计数
- **bench**:**94/94** 全通过,observeMissed=0,零回归

## 旁证(同轮证伪)

TreeTable 展开/折叠节点、内联单元格编辑(`textbox value=100kb`)observe/act 全正确,无缺陷。