### PR TITLE
fix(act): 合成 click 守卫无 .click() 方法的 SVG 元素防整类崩溃

### DIFF
--- a/packages/extension/src/handlers/dom.ts
+++ b/packages/extension/src/handlers/dom.ts
@@ -501,7 +501,15 @@ export function registerDomHandlers(
             el.dispatchEvent(new MouseEvent("mousedown", mouseDown));
             try { el.dispatchEvent(new PointerEvent("pointerup", { ...ptrInit, buttons: 0 })); } catch { /* */ }
             el.dispatchEvent(new MouseEvent("mouseup", mouseUp));
-            el.click();
+            // 原生 .click() 仅 HTMLElement 有,SVGElement(<g role=slider>/<rect> 等)、MathML
+            // 等无此方法 → 裸调抛 "X.click is not a function"(2026-06-22 APG multi-thumb
+            // slider dogfood)。有则调(触发表单提交/锚点跳转等默认动作),无则派发合成 click
+            // 事件触发监听器(非 HTML 元素无默认 click 动作,事件已够)。
+            if (typeof (el as { click?: unknown }).click === "function") {
+              el.click();
+            } else {
+              el.dispatchEvent(new MouseEvent("click", mouseUp));
+            }
             // GAP-G(N0062): 派发后采集效果信号(await windowMs 窗口)。success 恒 true,effect
             // 仅作旁证;__effectToken 为空(未 opt-in / 模块未就绪)时不带 effect,保持零开销。
             const __effect = __effectToken && __ce ? await __ce.end(__effectToken) : undefined;

--- a/packages/extension/tests/click-synthetic-inline-scope.test.ts
+++ b/packages/extension/tests/click-synthetic-inline-scope.test.ts
@@ -109,4 +109,30 @@ describe("合成 click inline func 注入作用域(P0 isTransient 回归锁)", (
     await router.dispatch(mkReq({ selector: "#btn" }));
     expect(clicked).toBeGreaterThan(0);
   });
+
+  // 2026-06-22 APG multi-thumb slider dogfood:SVG <g role=slider> 等无 .click() 方法的
+  // 非 HTML 元素(SVGElement.prototype.click===undefined),合成 click 路径裸调 el.click()
+  // → "G.click is not a function" JS_EXECUTION_ERROR,SVG 交互元素整类点击崩溃。
+  it("合成 click 对无 .click() 方法的 SVG 元素不抛错且仍派发 click 事件", async () => {
+    const svgNS = "http://www.w3.org/2000/svg";
+    const svg = dom.window.document.createElementNS(svgNS, "svg");
+    const g = dom.window.document.createElementNS(svgNS, "g");
+    g.setAttribute("id", "svgthumb");
+    g.setAttribute("role", "slider");
+    g.setAttribute("tabindex", "0");
+    // 复刻真实 Chrome:SVGElement 无 click 方法(jsdom 可能补全,强制 undefined 求确定性)
+    Object.defineProperty(g, "click", { value: undefined, configurable: true });
+    (g as unknown as { getBoundingClientRect: () => DOMRect }).getBoundingClientRect = () =>
+      ({ x: 10, y: 10, width: 40, height: 20, top: 10, bottom: 30, left: 10, right: 50 }) as DOMRect;
+    svg.appendChild(g);
+    dom.window.document.body.appendChild(svg);
+    let clicked = 0;
+    g.addEventListener("click", () => {
+      clicked++;
+    });
+    const resp = await router.dispatch(mkReq({ selector: "#svgthumb" }));
+    expect(resp.error?.message ?? "").not.toMatch(/is not a function/);
+    expect(resp.error).toBeUndefined();
+    expect(clicked).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## 背景(dogfood iteration 18)

Ralph dogfood 在 **W3C ARIA Authoring Practices Guide**(www.w3.org/WAI/ARIA/apg)的**多滑块 slider 参考实现**上,经 live spike 确诊一个 act 真缺陷。

## 缺陷

合成 click 路径(`dom.ts`)派发完整 `pointerdown→mousedown→pointerup→mouseup` 序列后,**裸调 `el.click()`** 以补触发表单提交 / 锚点跳转等默认动作。但 `.click()` 是 **HTMLElement 专有方法**:

- `SVGElement.prototype.click === undefined`(`<g role=slider>`、`<rect>` 等实现的 slider/button/checkbox/图标按钮)
- MathML 等同理

→ 裸调抛 `"X.click is not a function"` `JS_EXECUTION_ERROR`,使**非 reactClickable 的 SVG 交互元素整类点击崩溃**。

### live + spike 确诊

```
vortex_act click  <SVG g role=slider>  →  JS_EXECUTION_ERROR: G.click is not a function

spike:  SVGElement.prototype.click === undefined   (g.focus 倒是 function)
        HTMLElement.prototype.click === function
```

路径辨析:`useRealMouse||trustedMode` 走全程 CDP(trusted dispatchMouseEvent,SVG-safe);非 trusted 环境走合成路径,其中仅 submit-intent / reactClickable 元素 `deferToCdp`。SVG slider 二者皆非 → 留在合成路径触达 `el.click()` 崩溃。

## 修复

`dom.ts` 合成 click 加 `typeof` 守卫:

```ts
if (typeof (el as { click?: unknown }).click === "function") {
  el.click();                                       // HTML:保表单/锚点默认动作(不变)
} else {
  el.dispatchEvent(new MouseEvent("click", mouseUp)); // SVG/MathML:派发合成 click 事件
}
```

非 HTML 元素无默认 click 动作,合成事件已触发监听器。HTML 路径分支**字节级不变**,纯防御性。

## 验证

- **TDD(高保真)**:回归锁 `click-synthetic-inline-scope.test.ts` 经 `new Function` 剥离模块作用域**真执行 dom.ts 的实际 inline func**(非复刻)。新增 SVG `<g>` 用例(click 强制 undefined 复刻 Chrome):**RED** `el.click is not a function`(精确复现 live 错)→ **GREEN** 无错 + click 监听触发。
- **单测**:extension 全量 **1302** 通过。
- **⚠ live + bench 顺延**:本轮 build 致会话 MCP 断连且未在等待内自动重连,APG slider 的 live 复验 + bench 顺延至下次重连。修复纯加性(HTML 路径不变,bench 全 HTML 元素不受影响),且 TDD 已在单测内跑通 live 崩溃路径。

## 旁证(同轮证伪)

observe 对两个 SVG slider 正确召回 `slider "Hotel Minimum Price..." value=100` / `value=250`(role/name/value 全有)—— **观测层正确,缺陷仅在执行层**,印证「召回 ≠ 可操作,观测与执行须分别验证」。