### PR TITLE
fix(observe): 补召回带交互信号的 SVG 内部元素防整类漏报

### DIFF
--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -1532,6 +1532,16 @@ async function scanOneFrame(
           "*:not(svg *):not(script):not(style):not(meta):not(link):not(head):not(head *)",
           document,
         );
+        // SVG 内部交互元素补集:上面 `:not(svg *)` 把 svg 后代整类排除(防装饰 path/g
+        // 刷屏),但带交互信号的 svg 子元素(role/onclick/直绑 listener/可聚焦)是真控件——
+        // recharts/d3 可点 rect·circle、draw.io/流程图形状、地图可点区域。无 role 仅靠
+        // listener/cursor 信号的 svg 控件此前整类漏(2026-06-22 APG/recharts dogfood,
+        // act 侧 SVG click 崩溃的 observe 对偶)。仅选带信号者控开销,仍走下方同一入池门
+        // (cursor/framework/listener + require-name)过滤装饰。
+        const svgInteractivePool = querySelectorAllDeep(
+          "svg [role],svg [onclick],svg [data-vtx-listener],svg [tabindex]:not([tabindex='-1'])",
+          document,
+        );
         const FALLBACK_CAP = 5000; // hard ceiling against pathological pages
         const docRoot = document.documentElement;
         const docBody = document.body;
@@ -1620,7 +1630,7 @@ async function scanOneFrame(
           if (role && FOCUS_CONTAINER_ROLES.has(role)) return true;
           return !anc.matches(ATOMIC_INTERACTIVE_SELECTORS);
         };
-        for (const el of Array.from(fallbackPool)) {
+        for (const el of [...Array.from(fallbackPool), ...Array.from(svgInteractivePool)]) {
           if (cursorPointerExtras.length >= FALLBACK_CAP) break;
           if (interactiveSet.has(el)) continue;
           // Skip <html> / <body> — a SPA setting cursor:pointer on the root
@@ -1662,7 +1672,14 @@ async function scanOneFrame(
           }
           if (hasInteractiveAncestor) continue;
           const htmlEl = el as HTMLElement;
-          if (htmlEl.offsetWidth === 0 || htmlEl.offsetHeight === 0) continue;
+          // SVG 元素无 offsetWidth/offsetHeight(undefined),退回 getBoundingClientRect 测尺寸,
+          // 否则 `undefined === 0` 恒 false 使零尺寸 svg defs/clip 漏过尺寸门。
+          if (typeof htmlEl.offsetWidth === "number") {
+            if (htmlEl.offsetWidth === 0 || htmlEl.offsetHeight === 0) continue;
+          } else {
+            const __r = el.getBoundingClientRect();
+            if (__r.width === 0 || __r.height === 0) continue;
+          }
           // 入池信号:cursor:pointer(常见但继承可疑)或框架确凿绑定的 onClick。
           // 后者更强,覆盖 cursor:auto 的 React/Vue 裸 div 按钮(2026-06-04 淘宝评价区
           // 真漏「查看全部评价」「切换大图模式」)。下游 require-name + 含交互后代/祖先

--- a/packages/extension/tests/observe-svg-interactive-pool.test.ts
+++ b/packages/extension/tests/observe-svg-interactive-pool.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(join(__dirname, "../src/handlers/observe.ts"), "utf8");
+
+// 2026-06-22 APG/recharts dogfood:observe fallbackPool 选择器 `*:not(svg *)` 把所有
+// svg 后代整类排除,带交互信号(role/onclick/直绑 listener/可聚焦)的 svg 子元素
+// (recharts/d3 可点 rect·circle、流程图形状、地图区域)被整类漏召回——act 侧
+// SVG click 崩溃(click-synthetic-inline-scope SVG 用例)的 observe 对偶。
+// 此处 source-lock 内联补集查询 + 接线,防回退(scan 在 MAIN world inline,无法常规单测)。
+describe("observe SVG 交互元素补集(fallbackPool :not(svg *) 漏召回修复)", () => {
+  it("存在 svgInteractivePool 补集查询(仅带信号的 svg 后代)", () => {
+    expect(SRC).toContain("const svgInteractivePool = querySelectorAllDeep(");
+    // 信号选择器:role / onclick / 直绑 listener 标记 / 可聚焦
+    expect(SRC).toContain("svg [role],svg [onclick],svg [data-vtx-listener],svg [tabindex]:not([tabindex='-1'])");
+  });
+
+  it("fallback 收集循环把 svgInteractivePool 并入迭代", () => {
+    expect(SRC).toContain("for (const el of [...Array.from(fallbackPool), ...Array.from(svgInteractivePool)])");
+  });
+
+  it("尺寸门对 SVG(无 offsetWidth)退回 getBoundingClientRect", () => {
+    expect(SRC).toContain('if (typeof htmlEl.offsetWidth === "number")');
+    expect(SRC).toContain("const __r = el.getBoundingClientRect();");
+  });
+
+  it("主 fallbackPool 仍保留 :not(svg *) 排除(补集为加性,不改原噪声治理)", () => {
+    expect(SRC).toContain("*:not(svg *):not(script):not(style):not(meta):not(link):not(head):not(head *)");
+  });
+});


### PR DESCRIPTION
## 背景(dogfood iteration 19)

Ralph dogfood 在 **GitHub**(自定义元素全通,証伪)后,延续 iter-18 SVG 线索,经对照 spike 确诊一个 observe 真缺陷 —— iter-18(act 侧 SVG click 崩溃,#76)的 **observe 侧对偶**。

## 缺陷

`observe.ts` 的 `fallbackPool`(cursor:pointer / framework-click / 直绑 listener 兜底收集池)选择器:

```js
querySelectorAllDeep("*:not(svg *):not(script):not(style)...", document)
```

`:not(svg *)` **把所有 `<svg>` 后代整类排除**(原意:防装饰 path/g 刷屏)。但带交互信号(role / onclick / 直绑 listener / 可聚焦)的 svg 子元素是**真控件** —— recharts/d3 可点 `<rect>`·`<circle>`、draw.io/流程图形状、地图可点区域。无 role 仅靠 listener/cursor 信号的 svg 控件因此 observe **整类漏召回**,agent 看不到也点不到。

(APG `<g role=slider>` 有 `tabindex=0` 经主 INTERACTIVE 路径召回,故未暴露此洞;纯 listener/cursor 信号的 svg 元素走 fallbackPool 才中招。)

### 对照 spike 确诊

```
注入 <rect>/<circle> (addEventListener('click'), 无 role/name, cursor:auto) → observe 不召回
注入同条件 HTML <div> (click 监听, 无 role, cursor:auto)               → observe 召回 [listener]
→ 隔离「SVG 特有」

手动给 svg rect 打 data-vtx-listener="1" 后 observe 仍不召回
→ bug 在 scan 收集(非 T3 discovery),定位到 fallbackPool 的 :not(svg *)
```

## 修复

补 `svgInteractivePool` 查询,仅选**带交互信号**的 svg 后代,并入 fallbackPool 收集循环;仍走同一入池门(cursor / framework / listener + require-name)过滤装饰:

```js
const svgInteractivePool = querySelectorAllDeep(
  "svg [role],svg [onclick],svg [data-vtx-listener],svg [tabindex]:not([tabindex='-1'])",
  document,
);
// ...
for (const el of [...Array.from(fallbackPool), ...Array.from(svgInteractivePool)]) { ... }
```

并修尺寸门:SVG 元素无 `offsetWidth`(undefined),退回 `getBoundingClientRect`,否则 `undefined === 0` 恒 false 使零尺寸 svg defs/clip 漏过。主 fallbackPool 的 `:not(svg *)` 保留,补集为**纯加性**。

## 验证

- source-lock **4 测**(补集查询 / 接线 / SVG 尺寸门 / 主池 `:not(svg *)` 保留)
- extension 全量 **1305** 通过
- build dist 确认背景 bundle 含 `svg [role]` 补集
- **⚠ live + bench 顺延**:本轮 build 致会话 MCP 断连且久未自动重连;重连后补 live(注入带信号 svg 元素应被 observe 召回)+ bench,届时追加评论。

## 配套

与 #76(act 侧 SVG click 守卫)合起来才让 SVG 控件可用:#76 让点不崩溃,本 PR 让 observe 看得见。