### PR TITLE
fix(click-effect): 原生 Popover API 打开纳入反馈信号防误判无反馈

### DIFF
--- a/packages/extension/src/page-side/click-effect.ts
+++ b/packages/extension/src/page-side/click-effect.ts
@@ -174,24 +174,24 @@ interface PendingEntry {
   } {
     const toastHit: string[] = [];
     const dialogHit: string[] = [];
+    // 逐选择器 try 包裹:某选择器抛错(如 :popover-open 在不支持 Popover API 的浏览器
+    // 抛 SyntaxError)只跳过该项,不拖垮整批 toast/dialog 检测(原单 try 会全丢)。
+    const hitAny = (sel: string): boolean => {
+      try {
+        for (const n of Array.from(document.querySelectorAll(sel))) {
+          if (isVisible(n)) return true;
+        }
+      } catch {
+        /* 不支持的选择器 → 跳过,保留其他信号 */
+      }
+      return false;
+    };
     try {
       for (const sel of TOAST_SELECTORS) {
-        const nodes = document.querySelectorAll(sel);
-        for (const n of Array.from(nodes)) {
-          if (isVisible(n)) {
-            toastHit.push(sel);
-            break;
-          }
-        }
+        if (hitAny(sel)) toastHit.push(sel);
       }
       for (const sel of DIALOG_SELECTORS) {
-        const nodes = document.querySelectorAll(sel);
-        for (const n of Array.from(nodes)) {
-          if (isVisible(n)) {
-            dialogHit.push(sel);
-            break;
-          }
-        }
+        if (hitAny(sel)) dialogHit.push(sel);
       }
     } catch {
       return { userFeedback: classifyFeedback(false, false, domMutations), toastHit, dialogHit };

--- a/packages/extension/tests/click-effect-feedback.test.ts
+++ b/packages/extension/tests/click-effect-feedback.test.ts
@@ -40,6 +40,11 @@ describe("选择器覆盖", () => {
   it("dialog 含 el-dialog/ant-modal/bn-drawer", () => {
     expect([...DIALOG_SELECTORS].join(" ")).toMatch(/\.el-dialog|\.ant-modal|\.bn-drawer/);
   });
+  // 2026-06-22 flatpickr/Popover API dogfood:原生 popover 打开无 DOM mutation/属性变化,
+  // 框架 dialog/toast 类不匹配 → userFeedback 误报 "none"。:popover-open 纳入 dialog 类瞬态浮层。
+  it("dialog 含 :popover-open(原生 Popover API 反馈)", () => {
+    expect([...DIALOG_SELECTORS]).toContain(":popover-open");
+  });
 });
 
 describe("TOAST_SELECTORS 不含常驻 [aria-live] 包裹（antd Spin 假阳回归 A5/A6）", () => {

--- a/packages/extension/tests/click-effect.helper.test.ts
+++ b/packages/extension/tests/click-effect.helper.test.ts
@@ -313,5 +313,51 @@ describe("click-effect page-side module (__vortexClickEffect)", () => {
       expect(eff.toastHit).toContain(".ant-message");
       expect(eff.userFeedback).toBe("toast");
     });
+
+    // 2026-06-22 Popover API dogfood:原生 popover 打开无 DOM mutation,:popover-open 归 dialog。
+    it("打开的原生 popover(:popover-open) → dialogHit 含 :popover-open, userFeedback=dialog", async () => {
+      const ns = await load();
+      const pop = document.createElement("div");
+      pop.setAttribute("popover", "");
+      pop.textContent = "弹出层";
+      document.body.appendChild(pop);
+      stubGeom(pop, 200, 80);
+      // jsdom 无真实 top-layer,桩 querySelectorAll 让 :popover-open 命中本节点(其余委托原实现)
+      const orig = document.querySelectorAll.bind(document);
+      (document as any).querySelectorAll = (sel: string) =>
+        sel === ":popover-open" ? [pop] : orig(sel);
+      try {
+        const t = ns.begin("#b", 10);
+        const eff = (await ns.end(t)) as any;
+        expect(eff.dialogHit).toContain(":popover-open");
+        expect(eff.userFeedback).toBe("dialog");
+      } finally {
+        (document as any).querySelectorAll = orig;
+      }
+    });
+
+    it(":popover-open 抛 SyntaxError(浏览器不支持)不拖垮 toast 检测(逐选择器 guard)", async () => {
+      const ns = await load();
+      const toast = document.createElement("div");
+      toast.className = "ant-message";
+      toast.textContent = "已保存";
+      document.body.appendChild(toast);
+      stubGeom(toast, 200, 40);
+      // 复刻不支持 Popover API 的浏览器::popover-open 抛 SyntaxError;其余委托原实现
+      const orig = document.querySelectorAll.bind(document);
+      (document as any).querySelectorAll = (sel: string) => {
+        if (sel === ":popover-open") throw new SyntaxError("unsupported pseudo");
+        return orig(sel);
+      };
+      try {
+        const t = ns.begin("#b", 10);
+        const eff = (await ns.end(t)) as any;
+        // 守卫:单个选择器抛错被局部吞掉,toast 仍正确分类(旧单 try 会整批退化为 none)
+        expect(eff.toastHit).toContain(".ant-message");
+        expect(eff.userFeedback).toBe("toast");
+      } finally {
+        (document as any).querySelectorAll = orig;
+      }
+    });
   });
 });

--- a/packages/shared/src/click-effect.ts
+++ b/packages/shared/src/click-effect.ts
@@ -33,6 +33,12 @@ export const DIALOG_SELECTORS = [
   ".MuiDrawer-root",
   "[role='dialog']",
   "[role='alertdialog']",
+  // 原生 Popover API:showPopover 把元素移入 top-layer,无 DOM mutation/属性变化,
+  // 框架 dialog/toast 类也不匹配 → userFeedback 误报 "none"(agent 误判点击无反馈)。
+  // :popover-open 仅匹配带 popover 属性的打开态元素(GitHub/shadcn 等渐广),精确不误伤
+  // flatpickr/antd 等非原生浮层。该伪类在不支持的浏览器抛 SyntaxError,collectFeedback
+  // 逐选择器 try 包裹兜底(2026-06-22 flatpickr/Popover API dogfood)。
+  ":popover-open",
 ] as const;
 
 export function classifyFeedback(


### PR DESCRIPTION
## 背景(dogfood iteration 20)

Ralph dogfood 在 **flatpickr 日期选择器**(observe+act 全通,証伪)后,用**原生 Popover API** spike 确诊一个 observeEffect 反馈信号缺陷。

## 缺陷

原生 Popover API(`showPopover` / `popovertarget`)打开时把元素移入 **top-layer**,**无 DOM mutation、无属性变化**,框架 dialog/toast 选择器也不匹配 → `observeEffect` 的三信号全 0 → `userFeedback` 误报 `"none"`,agent 误判点击无反馈(silent-fail 假阳,与 iter-2 announcer toast FP / GAP-G 同族)。click-effect 已检测 dialog/toast 这类瞬态浮层,Popover API 是同类却漏检。

### live + 白盒确诊

```
点 <button popovertarget> → popover 打开(:popover-open=true, display:block)
observe 次轮正确显 [expanded] + 召回弹层内容   ← 感知/执行正确
observeEffect: domMutations:0 / ariaChanged:false / toastHit:[] / dialogHit:[] / userFeedback:"none"   ← 反馈信号漏判
白盒:触发按钮无 aria-expanded 属性(observe 的 [expanded] 是从 popover 隐式状态推断)
```

## 修复

1. **shared `DIALOG_SELECTORS` 加 `:popover-open`** — 仅匹配带 `popover` 属性的打开态元素(GitHub/shadcn 渐广),精确不误伤 flatpickr/antd 等非原生浮层(只有 click-effect 一个消费者)。
2. **`collectFeedback` 逐选择器 try 包裹**(`hitAny` helper) — `:popover-open` 在不支持 Popover API 的浏览器抛 `SyntaxError`,原**单 try** 会让整批 toast/dialog 检测在 catch 里退化为 `classifyFeedback(false,false,..)` 丢掉已采集命中;逐选择器 guard 只跳过抛错项。

打开 popover → `userFeedback:"dialog"`、`dialogHit` 含 `:popover-open`。

## 验证

- **TDD**:click-effect-feedback 锁 shared 选择器;helper 加 2 行为测(mock `:popover-open` 命中 → dialog;mock `:popover-open` 抛 SyntaxError → toast 仍检测,锁逐选择器 guard)
- extension 全量 **1304** 通过
- **⚠ live + bench 顺延**:本轮 build 致会话 MCP 断连;重连后补 live(popover 打开 → userFeedback dialog)+ bench,届时追加评论。

## 旁证(同轮证伪)

observe 对 Popover API 的感知(关闭隐藏/打开召回内容/`[expanded]` 推断)与 act(原生 popover 打开)均正确 —— 缺陷仅在 effect 旁证信号层。