### PR TITLE
feat(observe): 标注 HTML5 draggable 拖拽源信号 [draggable]

### DIFF
--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -109,6 +109,9 @@ interface ScannedElement {
   /** CDP getEventListeners 确认有 drop/dragenter/dragover 监听器 → 投放区,渲染 [dropzone]。
    * 入池信号(否则无 role/cursor 的 drop 区不可见),与 listenerInteractive 正交。@since dropzone-discovery */
   dropzoneInteractive?: true;
+  /** 显式 draggable=true 拖拽源 → 渲染 [draggable](vortex_drag startRef 源)。[draggable=true]
+   * 已在 INTERACTIVE_SELECTORS 白名单入池,此字段仅透传渲染标识,与 dropzoneInteractive 正交。@since draggable-source */
+  draggableInteractive?: true;
   /** 最近的已收集祖先的 frame-local index；根节点 undefined。@since a11y-tree */
   parentIndex?: number;
   /** role=link 的 href，供 compact 树渲染 /url。@since a11y-tree */
@@ -2542,6 +2545,13 @@ async function scanOneFrame(
             htmlEl.tagName !== "HTML"
               ? { dropzoneInteractive: true as const }
               : {}),
+            // 拖拽源:显式 draggable="true" → 渲染 [draggable] 信号(vortex_drag 的 startRef 源,
+            // 与 [dropzone] 正交)。用 getAttribute 精确匹配显式属性,与白名单 [draggable=true]
+            // selector 一致;img/a 的隐式默认 draggable 不写 DOM 属性,getAttribute 返回 null
+            // 故不会误标(2026-06-23 the-internet/drag_and_drop + SortableJS 评测)。
+            ...(htmlEl.getAttribute("draggable") === "true"
+              ? { draggableInteractive: true as const }
+              : {}),
             ...(__href !== undefined ? { href: __href } : {}),
             ...(__inputCompound !== undefined ? { compound: __inputCompound } : {}),
             ...(__vtxBlind ? { blindspot: __vtxBlind } : {}),
@@ -2948,6 +2958,8 @@ export function registerObserveHandlers(router: ActionRouter, debuggerMgr: Debug
         listenerInteractive?: true;
         /** 投放区(drop/dragenter/dragover 监听)真值信号 → 渲染 [dropzone]。@since dropzone-discovery */
         dropzoneInteractive?: true;
+        /** 拖拽源(显式 draggable=true)真值信号 → 渲染 [draggable]。@since draggable-source */
+        draggableInteractive?: true;
         frameId: number;
         // Issue #21 — populated only when input.includeBoxes && e.inViewport (T4).
         bbox?: [number, number, number, number];
@@ -3059,6 +3071,8 @@ export function registerObserveHandlers(router: ActionRouter, debuggerMgr: Debug
               ...(e.listenerInteractive ? { listenerInteractive: true as const } : {}),
               // 投放区真值信号透传渲染层（→ [dropzone]）。
               ...(e.dropzoneInteractive ? { dropzoneInteractive: true as const } : {}),
+              // 拖拽源真值信号透传渲染层（→ [draggable]）。
+              ...(e.draggableInteractive ? { draggableInteractive: true as const } : {}),
               // a11y-tree: 全局重映射后的父指针 + href（link 元素）。
               ...(globalParentIndex !== undefined ? { parentIndex: globalParentIndex } : {}),
               ...(e.href ? { href: e.href } : {}),
@@ -3103,6 +3117,8 @@ export function registerObserveHandlers(router: ActionRouter, debuggerMgr: Debug
               ...(e.listenerInteractive ? { listenerInteractive: true as const } : {}),
               // 投放区真值信号透传渲染层（→ [dropzone]）。
               ...(e.dropzoneInteractive ? { dropzoneInteractive: true as const } : {}),
+              // 拖拽源真值信号透传渲染层（→ [draggable]）。
+              ...(e.draggableInteractive ? { draggableInteractive: true as const } : {}),
               // a11y-tree: 全局重映射后的父指针 + href（link 元素）。
               ...(globalParentIndex !== undefined ? { parentIndex: globalParentIndex } : {}),
               ...(e.href ? { href: e.href } : {}),

--- a/packages/extension/tests/observe-draggable-selector.test.ts
+++ b/packages/extension/tests/observe-draggable-selector.test.ts
@@ -53,3 +53,34 @@ describe("observe [draggable=true] selector (@since 2026-06-14 real-site eval)",
     expect(OBSERVE_SRC).not.toMatch(/INTERACTIVE_SELECTORS\s*=\s*\[[\s\S]*?"\[draggable\]"/);
   });
 });
+
+/**
+ * Render-signal wiring lock for [draggable] (2026-06-23 the-internet + SortableJS eval).
+ *
+ * Whitelisting [draggable=true] pools the drag source, but without a render
+ * signal the agent sees a bare `group "A"` indistinguishable from a plain
+ * container — it cannot tell the element can be picked up (vortex_drag
+ * startRef). This locks the entry-construction wiring that reads the explicit
+ * draggable attribute → draggableInteractive, mirroring dropzoneInteractive.
+ * (Behavioral render test lives in mcp observe-tree-render.test.ts.)
+ */
+describe("observe draggableInteractive 渲染信号接线(source-lock)", () => {
+  it("entry 构造:显式 draggable=\"true\" → draggableInteractive 真值", () => {
+    expect(OBSERVE_SRC).toMatch(
+      /getAttribute\("draggable"\)\s*===\s*"true"[\s\S]{0,80}draggableInteractive:\s*true as const/,
+    );
+  });
+
+  it("用 getAttribute 精确匹配显式属性(img/a 隐式默认不误标)", () => {
+    // 必须 getAttribute==="true",不能用 IDL htmlEl.draggable(对 img/a 默认 true 会误标)
+    expect(OBSERVE_SRC).not.toMatch(/htmlEl\.draggable\s*===\s*true\s*\?\s*\{\s*draggableInteractive/);
+  });
+
+  it("透传渲染层:e.draggableInteractive → 输出 entry(compact + full 两路径)", () => {
+    const matches = OBSERVE_SRC.match(
+      /e\.draggableInteractive\s*\?\s*\{\s*draggableInteractive:\s*true as const\s*\}/g,
+    );
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBeGreaterThanOrEqual(2); // compact + full
+  });
+});

--- a/packages/mcp/src/lib/observe-render.ts
+++ b/packages/mcp/src/lib/observe-render.ts
@@ -22,6 +22,8 @@ export interface CompactElement {
   listenerInteractive?: true;
   /** CDP getEventListeners 确认有 drop/dragenter/dragover 监听器 → 渲染 [dropzone]（投放区，vortex_drag endRef 目标）。@since dropzone-discovery */
   dropzoneInteractive?: true;
+  /** HTML5 draggable=true 拖拽源 → 渲染 [draggable]（可被拖起，vortex_drag startRef 源）。与 [dropzone] 正交对称。@since draggable-source */
+  draggableInteractive?: true;
   /** role=link 的 href，渲染 /url: 属性行。@since a11y-tree */
   href?: string;
   /** AX nameSource：名称来源(label/placeholder/title/heuristic 等)。@since ax-overlay */
@@ -432,6 +434,8 @@ export function renderObserveTree(
     const listener = e.listenerInteractive ? " [listener]" : "";
     // 投放区信号：[dropzone] 告知 agent 此元素接受拖放，是 vortex_drag 的 endRef 目标。
     const dropzone = e.dropzoneInteractive ? " [dropzone]" : "";
+    // 拖拽源信号：[draggable] 告知 agent 此元素可被拖起，是 vortex_drag 的 startRef 源（与 dropzone 正交）。
+    const draggable = e.draggableInteractive ? " [draggable]" : "";
     const valueSeg =
       e.valueNow !== undefined
         ? ` value=${/\s/.test(e.valueNow) ? JSON.stringify(e.valueNow) : e.valueNow}`
@@ -483,7 +487,7 @@ export function renderObserveTree(
     const isNew = prevKeys !== null && !prevKeys.has(buildElementKey(e));
     const newPrefix = isNew ? "* " : "";
     lines.push(
-      `${indent}${newPrefix}- ${e.role}${name}${ref}${stateFlags(e.state)}${weak}${cursor}${listener}${dropzone}${valueSeg}${comp}${err}${ctrl}${desc}${offscreenSeg}${blindspotTag(e.blindspot)}${bboxSeg}${hasChildren ? ":" : ""}`,
+      `${indent}${newPrefix}- ${e.role}${name}${ref}${stateFlags(e.state)}${weak}${cursor}${listener}${dropzone}${draggable}${valueSeg}${comp}${err}${ctrl}${desc}${offscreenSeg}${blindspotTag(e.blindspot)}${bboxSeg}${hasChildren ? ":" : ""}`,
     );
     if (hasUrl) lines.push(`${indent}  - /url: ${e.href}`);
     for (const k of kids) emit(k, depth + 1);

--- a/packages/mcp/tests/observe-tree-render.test.ts
+++ b/packages/mcp/tests/observe-tree-render.test.ts
@@ -88,4 +88,29 @@ describe("renderObserveTree", () => {
     ]), null);
     expect(body(out)).toBe(`- button "Self" [ref=@e3]`);
   });
+
+  // 拖拽源信号:[draggable] 与投放区 [dropzone] 正交对称——前者是 vortex_drag 的
+  // startRef 源(能被拖起),后者是 endRef 目标(接受投放)。HTML5 draggable=true 控件
+  // (看板卡片/文件管理器/sortable)入池后此前无任何拖拽源标识,agent 无法区分它和
+  // 普通 group 容器(2026-06-23 the-internet/drag_and_drop + SortableJS 评测)。
+  it("draggableInteractive → [draggable] 拖拽源标记(vortex_drag startRef 目标)", () => {
+    const out = renderObserveTree(base([
+      mk({ index: 0, role: "group", name: "看板卡片", draggableInteractive: true }),
+    ]), null);
+    expect(body(out)).toBe(`- group "看板卡片" [ref=@e0] [draggable]`);
+  });
+
+  it("draggable 与 dropzone 正交共存(the-internet A/B 既可拖起又可投放)", () => {
+    const out = renderObserveTree(base([
+      mk({ index: 0, role: "group", name: "A", draggableInteractive: true, dropzoneInteractive: true }),
+    ]), null);
+    expect(body(out)).toBe(`- group "A" [ref=@e0] [dropzone] [draggable]`);
+  });
+
+  it("无 draggableInteractive 不打 [draggable](避免噪声)", () => {
+    const out = renderObserveTree(base([
+      mk({ index: 0, role: "button", name: "普通按钮" }),
+    ]), null);
+    expect(body(out)).not.toContain("[draggable]");
+  });
 });


### PR DESCRIPTION
## 问题（Dogfood 发现）

2026-06-23 dogfood 在 the-internet/drag_and_drop 与 SortableJS 评测拖拽承重原语时发现：observe 已将 `[draggable=true]` 收入 `INTERACTIVE_SELECTORS` 白名单（入池拖拽源，2026-06-14 加入），但**渲染层只标注 `[dropzone]`（投放区），完全缺拖拽源标识**。

agent 看到 `group "A" [dropzone]` 或纯 draggable 卡片的 `group "看板卡片"`，无法区分它和普通容器，**不知道该元素能否被拖起**（vortex_drag 的 startRef 源）。dropzone（拖到哪）有标注，draggable（什么能拖）整块缺失——是拖拽语义可见性的一半盲区。

## 根因

`grep draggable` 在 `src` 中对**标注逻辑**零命中——缺口是渲染信号，非入池（白名单已覆盖入池）。

## 修复

加 `draggableInteractive` 信号，与 `dropzoneInteractive` **完全对称**：

- `observe.ts` entry 构造读显式 `getAttribute("draggable") === "true"`（精确匹配显式属性，避免 `img`/`a` 隐式默认 IDL `draggable=true` 误标，与白名单 `[draggable=true]` selector 一致）→ 设 `draggableInteractive`
- 两路径（compact + full）透传至渲染层
- `observe-render.ts` 渲染 ` [draggable]`（拼在 `[dropzone]` 之后，正交共存）

## 验证

**真站端到端**（the-internet/drag_and_drop，重建 dist + mcp server 重连后实测）：
```
- group "A" [ref=@d893:e0] [dropzone] [draggable]
- group "B" [ref=@d893:e1] [dropzone] [draggable]
- link "Elemental Selenium" [cursor=pointer]   ← 普通链接无 [draggable]，不误标
```

**单测**：
- 渲染行为测试（`observe-tree-render.test.ts`）：`draggableInteractive → [draggable]`、与 dropzone 正交共存、无信号不误打
- source-lock 接线测试（`observe-draggable-selector.test.ts`）：entry 读显式属性 → 透传，禁用 IDL `htmlEl.draggable`（防 img/a 误标回归）

**回归**：主仓库全绿（extension 1356 + mcp 525 passed）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)