### PR TITLE
fix(observe): AX overlay valueNow 对齐 page-side 截断纪律

### DIFF
--- a/packages/extension/src/handlers/observe-ax-overlay.ts
+++ b/packages/extension/src/handlers/observe-ax-overlay.ts
@@ -64,8 +64,14 @@ export function computeAXOverlay(
   if (Object.keys(state).length > 0) out.state = state;
 
   const valuetext = getProp(node, "valuetext");
-  if (typeof valuetext === "string" && valuetext) out.valueNow = valuetext;
-  else if (node.value?.value) out.valueNow = String(node.value.value);
+  let rawValue: string | undefined;
+  if (typeof valuetext === "string" && valuetext) rawValue = valuetext;
+  else if (node.value?.value) rawValue = String(node.value.value);
+  // 对齐 page-side getValueInfo 纪律:归一化空白(换行/制表→单空格)+截断 200。
+  // AX node.value.value 对 contentEditable/textarea 给「全文」,无截断会撑爆 observe
+  // 输出 token(长文档编辑器/Notion/工单)且 \n 破坏单行渲染(2026-06-23 prosemirror dogfood)。
+  // slider/range 等短值(如 "50%")不受影响。
+  if (rawValue) out.valueNow = rawValue.replace(/\s+/g, " ").trim().slice(0, 200);
 
   const controls = getRelated(node, "controls").map((r) => r.backendDOMNodeId).filter((x): x is number => x != null);
   if (controls.length) out.controls = controls;

--- a/packages/extension/tests/observe-ax-overlay.test.ts
+++ b/packages/extension/tests/observe-ax-overlay.test.ts
@@ -77,6 +77,31 @@ describe("computeAXOverlay", () => {
     const r = computeAXOverlay({ backendId: 13, role: "slider", name: "" }, node);
     expect(r.valueNow).toBe("50%");
   });
+
+  // 2026-06-23 prosemirror.net dogfood:AX node.value.value 对 contentEditable/textarea
+  // 给「全文」(508 字符富文本文档),applyOverlay 无截断覆盖 page-side getValueInfo 已
+  // slice(0,200) 的 valueNow → observe 渲染全文,长文档(Notion/工单)token 爆炸 + \n\n
+  // 破坏单行输出。AX overlay valueNow 须对齐 page-side 纪律:归一化空白 + 截断 200。
+  it("长 value 截断到 200(防长 contentEditable/textarea token 爆炸)", () => {
+    const node = ax({ role: { value: "textbox" }, value: { value: "A".repeat(500) } });
+    const r = computeAXOverlay({ backendId: 30, role: "textbox", name: "" }, node);
+    expect(r.valueNow!.length).toBe(200);
+  });
+
+  it("value 含换行/制表归一化为单空格(防破坏单行渲染)", () => {
+    const node = ax({ role: { value: "textbox" }, value: { value: "Hello\n\nWorld\ttab" } });
+    const r = computeAXOverlay({ backendId: 31, role: "textbox", name: "" }, node);
+    expect(r.valueNow).toBe("Hello World tab");
+  });
+
+  it("短 valuetext 不受截断/归一化影响(slider 50% 保持)", () => {
+    const node = ax({
+      role: { value: "slider" },
+      properties: [{ name: "valuetext", value: { value: "50%" } }],
+    });
+    const r = computeAXOverlay({ backendId: 32, role: "slider", name: "" }, node);
+    expect(r.valueNow).toBe("50%");
+  });
 });
 
 describe("extractCompound", () => {


### PR DESCRIPTION
## 问题（Dogfood 发现）

2026-06-23 dogfood 在 prosemirror.net 测富文本编辑器时发现：observe 把 contenteditable 编辑器的**全文 508 字符**当 `value=` 渲染，且含原始 `\n\n` 换行：

```
div [ref=@e10] [listener] [dropzone] value="Hello ProseMirror\n\nThis is editable text...menu."
```

对长文档编辑器（Notion / 工单 / 邮件正文，可达数千字符），这会导致 **observe 输出 token 爆炸**，且换行破坏单行渲染格式。

## 根因

page-side `getValueInfo`（dom.ts:1582）对 contenteditable **已截断到 200 字符 + 归一化空白**，但 `observe-ax-overlay.ts:66-68` 的 `computeAXOverlay` 从 CDP AX node 取 `valuetext`/`node.value.value` 设 `valueNow` 时**无截断、无归一化**，而 `applyOverlay:168` 用它**覆盖**了 page-side 已截断的值。

对 contenteditable/textarea，Chrome AX tree 把全文当 `node.value.value`，AX overlay 无节制地透传 → 绕过 page-side 的截断纪律。

证据确凿：渲染的 value 含 `\n\n` 且 508 字符，而 getValueInfo 会 `replace(/\s+/g," ").slice(0,200)`，不可能产生此输出 → 必来自 AX overlay。

## 修复

AX overlay `valueNow` 对齐 page-side `getValueInfo` 纪律：归一化空白（`\s+`→单空格）+ 截断 200。保持原 `valuetext` 优先 `value` 的判断逻辑不变。slider/range 等短值（如 `"50%"`）远 < 200，不受影响。

## 验证

**真站端到端**（prosemirror.net/examples/basic，重建 + 扩展自动重载后实测）：

| | 修复前 | 修复后 |
|---|---|---|
| value | `"Hello ProseMirror\n\nThis is...menu."` 508 字符含 `\n\n` | `"Hello ProseMirror This is...supports emphasi"` 200 字符单行 |

**单测**（`observe-ax-overlay.test.ts`，3 新增）：长 value 截断 200、含换行归一化、短 valuetext 不受影响。

**回归**：extension root-scoped 全绿（192 files / 1359 tests）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)