### PR TITLE
fix(observe): label[for] 指向零尺寸 control 时继承其可及名

### DIFF
--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -998,6 +998,27 @@ async function scanOneFrame(
         const normName = (s: string | null | undefined): string =>
           (s ?? "").replace(/\s+/g, " ").trim().slice(0, 80);
 
+        // <label for=X> 指向零尺寸(visually-hidden)表单控件时,label 是该控件的可见代理。
+        // CSS-only 自定义 radio / Mantine Rating 星星把真 radio 设 0x0(被尺寸门跳过),
+        // 用 label[for] 关联的可见星星承接点击;label 自身无文本/aria-label → require-name
+        // 门挡掉 → 整控件 observe 隐形(2026-06-23 mantine.dev/core/rating dogfood)。
+        // 从关联控件继承可及名(aria-label/value),让可见 label 通过门并显示语义名。
+        // 限定 control 零尺寸:可见 control 自己召回,label 不代理(防双现)。
+        function labelForHiddenControlName(el: Element): string {
+          if (el.tagName !== "LABEL") return "";
+          const forId = el.getAttribute("for");
+          if (!forId) return "";
+          const root = el.getRootNode() as Document | ShadowRoot;
+          const ctrl =
+            typeof (root as Document).getElementById === "function"
+              ? (root as Document).getElementById(forId)
+              : document.getElementById(forId);
+          if (!ctrl) return "";
+          const h = ctrl as HTMLElement;
+          if (h.offsetWidth !== 0 || h.offsetHeight !== 0) return "";
+          return normName(h.getAttribute("aria-label") || (h as HTMLInputElement).value || "");
+        }
+
         function getAccessibleName(el: HTMLElement): string {
           const aria = el.getAttribute("aria-label");
           if (aria) return normName(aria);
@@ -1019,6 +1040,9 @@ async function scanOneFrame(
             }
             if (parts.length) return normName(parts.join(" "));
           }
+          // <label for=X> 代理零尺寸 control 时,可及名取自关联控件(见 helper 注释)。
+          const __hiddenCtrlName = labelForHiddenControlName(el);
+          if (__hiddenCtrlName) return __hiddenCtrlName;
           if (
             el.tagName === "INPUT" ||
             el.tagName === "TEXTAREA" ||
@@ -1954,7 +1978,9 @@ async function scanOneFrame(
           // 时尝试 icon-only fallback（CSS Modules 类名兜底，如 close/icon button）。
           // controlRoleFromClass:给无 role/无 name 的控件类(vxe-cell--checkbox)入池信号。
           // **不**加 iconFontName——round-12 约束(装饰字体图标不得进门),它只留显示路径。
-          const probe = ariaProbe || textProbe || iconNameFromClass(el) || controlRoleFromClass(el);
+          // labelForHiddenControlName:<label for=零尺寸 control> 从关联控件继承名(同 getAccessibleName),
+          // 让 Mantine Rating 等「可见 label 代理 0x0 radio」的星星过门(否则无名被 require-name 挡)。
+          const probe = ariaProbe || textProbe || iconNameFromClass(el) || controlRoleFromClass(el) || labelForHiddenControlName(el);
           // Require a name to avoid noise from purely decorative
           // cursor:pointer wrappers (e.g. close-button icons handled by
           // event delegation but visually rendered as bare divs).

--- a/packages/extension/tests/observe-labelfor-hidden-control.test.ts
+++ b/packages/extension/tests/observe-labelfor-hidden-control.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+/**
+ * Source-lock:label[for]→零尺寸 control 命名继承
+ * (2026-06-23 mantine.dev/core/rating dogfood).
+ *
+ * Mantine Rating(及 CSS-only 自定义 radio)把真 radio 设为 0x0(被尺寸门跳过),
+ * 用可见的 <label for=radioId> 星星承接点击。label 有 cursor:pointer 但无
+ * 文本/aria-label,被 require-name 门丢弃 → 整个评分控件对 observe 隐形。
+ *
+ * 修复:labelForHiddenControlName 从关联控件继承 aria-label/value 作为 label 的
+ * 可及名,在 probe 门(让 label 过 require-name)与 getAccessibleName(输出名)两处
+ * 共用。限定零尺寸控件:可见控件自己召回,label 不代理(防双现)。
+ *
+ * source-level 因 scan 内联于 executeScript;真行为在 mantine.dev/core/rating live 验证。
+ */
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OBSERVE_SRC = readFileSync(
+  join(__dirname, "..", "src", "handlers", "observe.ts"),
+  "utf8",
+);
+
+describe("observe label[for]→零尺寸 control 命名继承(source-lock)", () => {
+  it("定义 labelForHiddenControlName helper", () => {
+    expect(OBSERVE_SRC).toMatch(/function labelForHiddenControlName\(el: Element\): string/);
+  });
+
+  it("仅 LABEL 元素 + 有 for 属性才处理", () => {
+    expect(OBSERVE_SRC).toMatch(/if \(el\.tagName !== "LABEL"\) return "";/);
+    expect(OBSERVE_SRC).toMatch(/const forId = el\.getAttribute\("for"\);/);
+  });
+
+  it("零尺寸守卫:可见 control 不代理(防双现)", () => {
+    expect(OBSERVE_SRC).toMatch(/offsetWidth !== 0 \|\| h\.offsetHeight !== 0\)\s*return "";/);
+  });
+
+  it("name 取关联控件 aria-label 优先、value 兜底", () => {
+    expect(OBSERVE_SRC).toMatch(
+      /getAttribute\("aria-label"\) \|\| \(h as HTMLInputElement\)\.value/,
+    );
+  });
+
+  it("root.getRootNode 解析支持 shadow 内 label[for]", () => {
+    expect(OBSERVE_SRC).toMatch(/const root = el\.getRootNode\(\) as Document \| ShadowRoot;/);
+  });
+
+  it("probe 门调用 helper(让无名 label 过 require-name)", () => {
+    expect(OBSERVE_SRC).toMatch(
+      /controlRoleFromClass\(el\) \|\| labelForHiddenControlName\(el\)/,
+    );
+  });
+
+  it("getAccessibleName 输出也调用 helper(门与输出一致)", () => {
+    expect(OBSERVE_SRC).toMatch(/const __hiddenCtrlName = labelForHiddenControlName\(el\);/);
+    expect(OBSERVE_SRC).toMatch(/if \(__hiddenCtrlName\) return __hiddenCtrlName;/);
+  });
+});


### PR DESCRIPTION
## 问题（Dogfood 发现）

2026-06-23 dogfood 在 mantine.dev/core/rating 测评分组件时发现：整个 Rating 星级控件对 observe **完全隐形**——observe 召回了 demo 的配置控件（颜色按钮、Size slider），但 6 个评分星星 + 6 个 radio 一个都没召回，agent 看不到也无法操作评分。

## 根因（Spike 确诊）

Mantine Rating（及大量 CSS-only 自定义 radio / 星级评分）的 DOM 模式：
- 真 `<input type=radio>` 设为 **0x0 零尺寸**（`aria-label="0".."5"`），被 observe 尺寸门（`offsetWidth===0||offsetHeight===0 → continue`）跳过
- 可见的 `<label for=radioId>` 星星（`cursor:pointer`、20x20）承接点击，但**无文本/无 aria-label**

结果：radio 被尺寸门跳过，label 因无 name 被 require-name 门（`if(!probe) continue`）丢弃，且 label 是 `label[for]` **分离**模式（不匹配白名单的 `label:has(input[radio])` 包裹模式）→ 整个控件隐形。

## 修复

新增 `labelForHiddenControlName(el)`：当 `label[for]` 指向**零尺寸**控件时，从该控件继承 `aria-label`/`value` 作为 label 的可及名。在 **probe 门**（让无名 label 过 require-name）与 **getAccessibleName**（输出名）两处共用，门与输出一致。

**零尺寸守卫**是防双现的安全关键：可见控件自己召回，label 不代理。

## 验证

**真站三组对照**（注入 Mantine-style 结构 + 重建扩展自动重载）：

| 场景 | label 召回 | 机制 |
|---|---|---|
| `label[for]`→**0x0** radio，无文本（star） | ✅ name="1 star" | helper 代理（修复生效） |
| `label[for]`→**可见** radio，无文本（SHOULD_NOT_PROXY） | ❌ 不召回 | 零尺寸守卫拦截（防双现） |
| `label[for]`→可见 radio，有文本（Visible Option） | ✅ 召回 | textProbe（正常，与修复无关） |

**单测**：source-lock 7 测（helper 定义 / LABEL+for 守卫 / 零尺寸守卫 / name 来源 / shadow root / probe 门 / getAccessibleName 输出一致）。

**回归**：extension root-scoped 全绿（193 files / 1366 tests）。修复中触发的 `observe-icon-font-name` source-lock（probe 行正则假设单行）已通过把 probe 改回单行解决，测试原意图（不含 iconFontName）不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)