### PR TITLE
fix(dom): 坐标敏感控件默认 click silent success 降级到 CDP 真鼠标

### DIFF
--- a/packages/extension/src/handlers/dom.ts
+++ b/packages/extension/src/handlers/dom.ts
@@ -444,6 +444,35 @@ export function registerDomHandlers(
                 },
               };
             }
+            // 坐标敏感控件(role=slider / input[type=range]):值由指针 clientX/Y 命中位置
+            // 计算,合成 el.click() 的 clientX=clientY=0 → 控件按位置 0 取最小值,值不变却
+            // 返回 success → silent success(Shoelace sl-rating / 原生 range / canvas slider)。
+            // 这类控件不带 vortexReactClickable(非 React onClick 桩,纯坐标驱动),故 react-clickable
+            // 门漏掉。CDP real mouse 点中元素中心 → 落到真实坐标驱动控件改值(中心≈中间档)。
+            // cdpAvailable=false 时不 defer,退回 el.click() 至少触发监听器(无 CDP 不堵路,
+            // 与 submit-intent/react-clickable 同策)。(2026-06-23 shoelace rating dogfood:
+            // 默认 click slider value 恒 0;useRealMouse 中心点击 value=3 实证)
+            // __hasClickMethod 守卫:仅当 el.click() 真会被调(下方 508 行分支)才需 defer——
+            // 无 .click() 方法的 SVG role=slider(<g> 等,APG multi-thumb)走 dispatchEvent
+            // 分支,属 2026-06-22 APG dogfood 既有处理,不在本修复范围内,放行保留其行为。
+            const __hasClickMethod = typeof (el as { click?: unknown }).click === "function";
+            const __roleAttr = (el.getAttribute("role") || "").toLowerCase();
+            const __isCoordSensitive =
+              __hasClickMethod &&
+              (__roleAttr === "slider" ||
+                (__tagLc === "input" && __typeAttr === "range"));
+            if (__isCoordSensitive && cdpAvailable) {
+              return {
+                result: {
+                  deferToCdp: true,
+                  element: {
+                    tag: __tagLc,
+                    id: el.id || undefined,
+                    text: (el as HTMLElement).innerText?.slice(0, 200),
+                  },
+                },
+              };
+            }
             // GAP-G(N0062): 派发前启动效果信号采集(opt-in)。begin 在 focus/dispatch 之前,
             // 捕获点击前 url/activeElement/aria 快照,使后续 focus/dispatch 引起的变化都计入。
             // 经 window.__vortexClickEffect(loadPageSideModule 预注入),禁止 inline 复制逻辑。

--- a/packages/extension/tests/click-coord-sensitive-slider-cdp.test.ts
+++ b/packages/extension/tests/click-coord-sensitive-slider-cdp.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Author: qingwa
+ * Description: Dogfood 2026-06-23 shoelace.style/components/rating — 坐标敏感控件
+ *   (role=slider / input[type=range]) 默认 click silent success 修复。
+ *
+ * 背景:
+ *   - 非 trusted 模式(普通 Chrome,/trusted-mode=false,常见情形)下 click 走合成
+ *     el.click() 路径。该路径 deferToCdp 门原只认 submit-intent 与
+ *     dataset.vortexReactClickable(React/Vue onClick 桩 / cursor:pointer)。
+ *   - Shoelace sl-rating 的 div[role=slider] 值由指针 clientX 命中位置计算,带
+ *     click listener(observe 标 data-vtx-listener / [listener]) 但不带
+ *     vortexReactClickable → 漏过 defer 门 → 纯 el.click() clientX=0 → rating 算成
+ *     0,值不变却返回 success → silent success(agent 误判已设值)。
+ *   - 实证: 默认 click slider value 恒 0; useRealMouse 中心点击 value=3。
+ *
+ * 修复: 在 react-clickable 门之后追加坐标敏感门 —— role=slider 或
+ *   input[type=range] 且 cdpAvailable → deferToCdp,落到元素中心真实坐标驱动控件。
+ *   cdpAvailable=false 不 defer(与 submit-intent/react-clickable 同策,无 CDP 不堵路)。
+ *
+ * 关键契约:
+ *   1. page-side func 探测 role=slider → deferToCdp(handler 改走 cdpClickElement)
+ *   2. 坐标敏感门在 react-clickable 门之后(顺序: submit → react-clickable → coord)
+ *   3. cdpAvailable 守卫存在(deferToCdp 仅在 CDP 可用时,无 CDP 退回合成)
+ *   4. handler 收到 deferToCdp:true → 走 cdpClickElement(共享 defer 路由,行为级)
+ *
+ * Why source-lock: page-side func inline 于 executeScript,jsdom 不能直接调;
+ *   inline 探测逻辑以源码契约锁定,defer 路由以 executeScript mock 行为验证
+ *   (与 click-react-clickable-dataset-cdp.test.ts 同模式)。真行为在 shoelace
+ *   rating live 验证。
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import type { NmRequest } from "@vortex-browser/shared";
+import { DomActions } from "@vortex-browser/shared";
+import { ActionRouter } from "../src/lib/router.js";
+import { registerDomHandlers } from "../src/handlers/dom.js";
+
+vi.mock("../src/action/auto-wait.js", () => ({
+  waitActionable: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../src/adapter/page-side-loader.js", () => ({
+  loadPageSideModule: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../src/adapter/cdp.js", () => ({
+  cdpClickElement: vi.fn(),
+  clickBBox: vi.fn(),
+}));
+
+function mkReq(args: Record<string, unknown>): NmRequest {
+  return { type: "tool_request", tool: DomActions.CLICK, args, requestId: "r-1" };
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(join(__dirname, "..", "src", "handlers", "dom.ts"), "utf8");
+
+describe("CLICK 坐标敏感控件 deferToCdp — 源码契约 (shoelace rating dogfood)", () => {
+  it("契约 1: page-side func 探测 role=slider 作坐标敏感信号", () => {
+    expect(SRC).toMatch(/__roleAttr === "slider"/);
+  });
+
+  it("契约 1b: 原生 input[type=range] 也纳入坐标敏感", () => {
+    expect(SRC).toMatch(/__tagLc === "input" && __typeAttr === "range"/);
+  });
+
+  it("契约 2: 坐标敏感门在 react-clickable 门之后 (顺序敏感)", () => {
+    const reactIdx = SRC.indexOf("vortexReactClickable");
+    const coordIdx = SRC.indexOf("__isCoordSensitive");
+    expect(reactIdx).toBeGreaterThan(-1);
+    expect(coordIdx).toBeGreaterThan(-1);
+    expect(coordIdx).toBeGreaterThan(reactIdx);
+  });
+
+  it("契约 3: cdpAvailable 守卫存在 (无 CDP 退回合成,不堵路)", () => {
+    expect(SRC).toMatch(/__isCoordSensitive && cdpAvailable/);
+  });
+
+  it("契约 3b: __hasClickMethod 守卫排除无 .click() 的 SVG slider (不碰 APG dispatchEvent 路径)", () => {
+    expect(SRC).toMatch(/__hasClickMethod &&/);
+    // 守卫必须前置于 role 判定,确保 SVG <g role=slider> 放行
+    const guardIdx = SRC.indexOf("__hasClickMethod =");
+    const coordIdx = SRC.indexOf("__isCoordSensitive =");
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(coordIdx).toBeGreaterThan(guardIdx);
+  });
+});
+
+describe("CLICK 坐标敏感控件 → CDP real mouse (行为级, 共享 defer 路由)", () => {
+  let router: ActionRouter;
+  let executeScript: ReturnType<typeof vi.fn>;
+  let cdpClickElement: ReturnType<typeof vi.fn>;
+  let debuggerMgr: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    executeScript = vi.fn();
+    vi.stubGlobal("chrome", {
+      tabs: { query: vi.fn().mockResolvedValue([{ id: 42 }]) },
+      webNavigation: {
+        getAllFrames: vi.fn().mockResolvedValue([{ frameId: 0, parentFrameId: -1, url: "https://x/" }]),
+      },
+      scripting: { executeScript },
+      runtime: { getManifest: vi.fn().mockReturnValue({ host_permissions: ["<all_urls>"] }) },
+    });
+    const cdp = await import("../src/adapter/cdp.js");
+    cdpClickElement = vi.mocked(cdp.cdpClickElement as any);
+    debuggerMgr = { attach: vi.fn().mockResolvedValue(undefined), sendCommand: vi.fn().mockResolvedValue(undefined) };
+    router = new ActionRouter();
+    registerDomHandlers(router, debuggerMgr);
+  });
+
+  it("契约 4: page-side 探测坐标敏感 → deferToCdp → 走 cdpClickElement 中心点击", async () => {
+    // page-side func 对 role=slider 返回 deferToCdp(模拟坐标敏感门命中)
+    executeScript.mockResolvedValue([
+      { result: { result: { deferToCdp: true, element: { tag: "div" } } } },
+    ]);
+    cdpClickElement.mockResolvedValue({
+      success: true, element: { tag: "div" }, x: 435, y: 317, mode: "realMouse",
+    });
+
+    const resp = await router.dispatch(
+      mkReq({ selector: "sl-rating [role=slider]", action: "click", tabId: 42 }),
+    );
+
+    expect(resp.error).toBeUndefined();
+    expect(cdpClickElement).toHaveBeenCalledTimes(1);
+    expect(resp.result).toMatchObject({ mode: "realMouse" });
+  });
+});


### PR DESCRIPTION
## 问题

Dogfood `shoelace.style/components/rating`:`vortex_act click @ref`(默认,无 useRealMouse)对 Shoelace `sl-rating` 的 shadow 内 `div[role=slider]` 返回 `success:true` 但 **value 恒为 0**——典型 silent success(agent 误判已设值)。

## 根因(全程 live ground truth 证据链)

1. `/trusted-mode` 端点 = `false`(普通 Chrome 未带 `--silent-debugger-extension-api`,**这是常见情形**)→ click 走合成 `el.click()` 路径(`dom.ts` 268+)。
2. 该路径的 `deferToCdp` 门(改走 CDP 真鼠标)原只认两类:**submit-intent** 按钮、`dataset.vortexReactClickable`(React/Vue onClick 桩 / cursor:pointer)。
3. `div[role=slider]` 值由指针 `clientX` 命中位置计算,带 click listener(observe 标 `data-vtx-listener` / `[listener]`)但**不带** `vortexReactClickable` → 漏过 defer 门 → 纯 `el.click()`,其 `clientX=clientY=0` → Shoelace 把 rating 算成 0 → 值不变却返回 `success`。
4. 对照:同页 `<button>` 之所以"看似 CDP"(返回 `mode:realMouse`),是因它经 submit-intent/react-clickable **deferToCdp**,**非** trustedMode——这曾让 R4 静态分析误判为"trustedMode 矛盾"。

> 决定性实验:同一 trustedMode 缓存窗口内背靠背点 light 按钮(CDP)与 slider(合成),排除 ps/缓存时间性假设,定位到元素信号差异。

## 修复

在 react-clickable 门之后追加**坐标敏感门**:`role=slider` 或 `input[type=range]`、且有 `.click()` 方法、且 `cdpAvailable` → `deferToCdp`,由 `cdpClickElement` 点中元素中心真实坐标驱动控件。

- `__hasClickMethod` 守卫:放行无 `.click()` 的 SVG `role=slider`(APG multi-thumb,走 dispatchEvent 分支,属 2026-06-22 APG dogfood 既有处理,**不在本修复范围**),避免破坏其 P0 回归锁。
- `cdpAvailable=false` 不 defer,退回 `el.click()` 至少触发监听器(与 submit-intent/react-clickable 同策,无 CDP 不堵路)。

## 验证

**Live(shoelace.style/components/rating,构建后经 server watcher 自动 reload 扩展)**:
- 修复前:默认 click slider → `{success:true}` 无 mode,`value=0`(silent)。
- 修复后:默认 click slider → `mode:realMouse` + 坐标,`value` 0→**3**。
- 普通按钮 click 仍正常(REACT 切换按钮 → success,无回归)。

**回归**:`@vortex-browser/extension` 全量 **199 文件 / 1448 测试通过**(含 I1 depcruise 封装不变量、APG SVG slider P0 锁);新增 `click-coord-sensitive-slider-cdp.test.ts` 6 个源码契约 + 行为测试。

## 影响面

窄:仅 **非 trusted 模式 + 坐标敏感 HTML 控件**(slider/range)。普通控件(button/link/input)、SVG slider、trusted 模式均不受影响。silent success 危害大(报成功却无效),故值得修。