### PR TITLE
fix(observe): 还原 CDP AX value/valuetext 的 UTF-8 双重编码 mojibake

### DIFF
--- a/packages/extension/src/handlers/observe-ax-overlay.ts
+++ b/packages/extension/src/handlers/observe-ax-overlay.ts
@@ -12,6 +12,35 @@ function getProp(n: CDPAXNode, name: string): unknown {
   return n.properties?.find((p) => p.name === name)?.value?.value;
 }
 
+/**
+ * 还原 Chrome Accessibility.getFullAXTree 对 value/valuetext 类 AXValue 的双重编码。
+ * Chrome 把这些属性的 UTF-8 字节当 Latin-1 逐字节映射成 JS 字符串返回(name 不受影响),
+ * 例:DOM aria-valuetext="弱 – Weak"(U+5F31 U+2013 …)→ CDP 返回 "å¼± â Weak"
+ * (字节 0xE5 0xBC 0xB1 0xE2 0x80 0x93 各自当 Latin-1 码位)。2026-06-23 react-aria
+ * DatePicker dogfood:spinbutton value "6 – June" 被渲染成 "6 â June"。
+ *
+ * 还原:把每个码位当单字节取回原 UTF-8 字节序列,再按 UTF-8 严格解码。
+ * 安全护栏:① 含真正多字节字符(码位 > 0xFF)说明非 mojibake,原样返回;
+ * ② fatal UTF-8 解码失败说明本就是合法 Latin-1 文本(如 "café" 的孤立 0xE9),原样返回。
+ * 仅作用于 value 路径——name/description 经 dogfood 实证未被 Chrome 双重编码。
+ */
+function repairCdpUtf8(s: string): string {
+  let hasHigh = false;
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c > 0xff) return s; // 含真多字节字符 → 非 mojibake,原样返回
+    if (c >= 0x80) hasHigh = true;
+  }
+  if (!hasHigh) return s; // 纯 ASCII → 无双重编码可能
+  try {
+    const bytes = new Uint8Array(s.length);
+    for (let i = 0; i < s.length; i++) bytes[i] = s.charCodeAt(i);
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return s; // 非合法 UTF-8 字节序列 → 真 Latin-1 文本,保留原值
+  }
+}
+
 function getRelated(n: CDPAXNode, name: string): Array<{ backendDOMNodeId?: number; text?: string }> {
   return n.properties?.find((p) => p.name === name)?.value?.relatedNodes ?? [];
 }
@@ -65,8 +94,9 @@ export function computeAXOverlay(
 
   const valuetext = getProp(node, "valuetext");
   let rawValue: string | undefined;
-  if (typeof valuetext === "string" && valuetext) rawValue = valuetext;
-  else if (node.value?.value) rawValue = String(node.value.value);
+  // CDP 双重编码还原:value/valuetext 的非 ASCII 字符须经 repairCdpUtf8(详见上方注释)。
+  if (typeof valuetext === "string" && valuetext) rawValue = repairCdpUtf8(valuetext);
+  else if (node.value?.value) rawValue = repairCdpUtf8(String(node.value.value));
   // 对齐 page-side getValueInfo 纪律:归一化空白(换行/制表→单空格)+截断 200。
   // AX node.value.value 对 contentEditable/textarea 给「全文」,无截断会撑爆 observe
   // 输出 token(长文档编辑器/Notion/工单)且 \n 破坏单行渲染(2026-06-23 prosemirror dogfood)。

--- a/packages/extension/tests/observe-ax-overlay.test.ts
+++ b/packages/extension/tests/observe-ax-overlay.test.ts
@@ -102,6 +102,69 @@ describe("computeAXOverlay", () => {
     const r = computeAXOverlay({ backendId: 32, role: "slider", name: "" }, node);
     expect(r.valueNow).toBe("50%");
   });
+
+  // CDP UTF-8 双重编码还原(2026-06-23 react-aria DatePicker dogfood):
+  // Chrome Accessibility.getFullAXTree 把 value/valuetext 的 UTF-8 字节当 Latin-1 逐字节
+  // 映射返回(name 不受影响)。例:DOM aria-valuetext="6 – June"(含 U+2013 en-dash)→
+  // CDP 返回 "6 â June" → observe 渲染 mojibake。computeAXOverlay 须还原。
+  // mojibake() 复刻 Chrome 的双重编码:UTF-8 编码后每字节当一个 Latin-1 码位。
+  const mojibake = (s: string): string =>
+    String.fromCharCode(...new TextEncoder().encode(s));
+
+  it("valuetext mojibake(en-dash)还原为原 UTF-8(react-aria spinbutton)", () => {
+    const node = ax({
+      role: { value: "spinbutton" },
+      properties: [{ name: "valuetext", value: { value: mojibake("6 – June") } }],
+    });
+    const r = computeAXOverlay({ backendId: 40, role: "spinbutton", name: "month" }, node);
+    expect(r.valueNow).toBe("6 – June");
+  });
+
+  it("valuetext mojibake(CJK+en-dash)还原(slider 弱 – Weak)", () => {
+    const node = ax({
+      role: { value: "slider" },
+      properties: [{ name: "valuetext", value: { value: mojibake("弱 – Weak") } }],
+    });
+    const r = computeAXOverlay({ backendId: 41, role: "slider", name: "Vol" }, node);
+    expect(r.valueNow).toBe("弱 – Weak");
+  });
+
+  it("node.value.value mojibake 也还原(value 路径,非 valuetext)", () => {
+    const node = ax({ role: { value: "textbox" }, value: { value: mojibake("café — 中文") } });
+    const r = computeAXOverlay({ backendId: 42, role: "textbox", name: "" }, node);
+    expect(r.valueNow).toBe("café — 中文");
+  });
+
+  it("纯 ASCII valuetext 原样返回(无误伤)", () => {
+    const node = ax({
+      role: { value: "slider" },
+      properties: [{ name: "valuetext", value: { value: "6 - June" } }],
+    });
+    const r = computeAXOverlay({ backendId: 43, role: "slider", name: "" }, node);
+    expect(r.valueNow).toBe("6 - June");
+  });
+
+  // 真多字节字符(码位 > 0xFF)说明 CDP 这次没有双重编码(或测试桩传入正常 UTF-16),
+  // 不应被当 mojibake 再解码——护栏 ① 须原样返回,防把正常中文当字节流二次解码成乱码。
+  it("已正常的 UTF-16 valuetext(含真 CJK)不被二次还原(护栏①)", () => {
+    const node = ax({
+      role: { value: "slider" },
+      properties: [{ name: "valuetext", value: { value: "中文 50%" } }],
+    });
+    const r = computeAXOverlay({ backendId: 44, role: "slider", name: "" }, node);
+    expect(r.valueNow).toBe("中文 50%");
+  });
+
+  // 合法 Latin-1 文本(孤立高位字节,非合法 UTF-8 序列)fatal 解码失败 → 原样保留(护栏②)。
+  it("合法 Latin-1 文本(孤立 0xE9)非 UTF-8 序列时原样保留(护栏②)", () => {
+    const node = ax({
+      role: { value: "slider" },
+      // "café" 直接作为已是 UTF-16 的合法字符串:0xE9 孤立,非完整 UTF-8 多字节序列
+      properties: [{ name: "valuetext", value: { value: "café" } }],
+    });
+    const r = computeAXOverlay({ backendId: 45, role: "slider", name: "" }, node);
+    expect(r.valueNow).toBe("café");
+  });
 });
 
 describe("extractCompound", () => {


### PR DESCRIPTION
## 问题(Round 5 dogfood — react-aria DatePicker)

`vortex_observe` 对 React Aria DatePicker 的分段日期输入,渲染出 mojibake 的 value:

- spinbutton "month, Date" `value="6 â June"`(DOM aria-valuetext 实为 `"6 – June"`,含 U+2013 en-dash)
- 合成 slider 复现:`aria-valuetext="弱 – Weak"` → `value="å¼± â Weak"`

`弱`(U+5F31)的 UTF-8 字节 `E5 BC B1` 被逐字节当 Latin-1 码位映射成 `å¼±`,en-dash `E2 80 93` → `â`(后两字节是不可见 C1 控制符)——**典型「UTF-8 字节被当 Latin-1 解码」双重编码**。

## 根因

经实机白盒锁定(非静态推测):

1. `vortex_evaluate` 读 DOM `aria-valuetext` = `"6 – June"` 正确;page-side `getValueInfo`(`observe.ts`)读到的也正确。
2. **鉴别实验**:注入带非 ASCII **accessible name** 的 button + 带 en-dash **valuetext** 的 slider。observe 结果:button name `"测试 – Probe Aé中"` **完全正确**,slider value `"å¼± â Weak"` **mojibake**。
3. name 与 value 同在一个 elements 数组、同一 structured-clone / NM / WebSocket / render 路径——name 正确证明该 transport 对非 ASCII 无损。
4. `applyOverlay` / `captureAXNodeMap` 全是纯字符串操作与 Map 映射,无字节级 decode。

→ 结论:**Chrome `Accessibility.getFullAXTree` 在返回时就把 `value`/`valuetext` 类 AXValue 双重编码**(`name`/`description` 不受影响)。AX overlay 用该 CDP 值覆盖了 page-side 已读到的正确值。

## 修复

`observe-ax-overlay.ts` 新增 `repairCdpUtf8`:把每个码位当单字节取回原 UTF-8 字节序列,再按 UTF-8 **严格(fatal)** 解码。仅作用于 value 路径(`valuetext` 与 `node.value.value`)。

双护栏防误伤合法文本:
- ① 含真正多字节字符(码位 > 0xFF)→ 非 mojibake,原样返回;
- ② fatal UTF-8 解码失败(合法 Latin-1,如孤立 `0xE9` 的 "café")→ 原样返回。

不改 override 语义,故 contentEditable/textarea 等 AX value fallback 路径同样受益。

## 验证

- **6 新单测**(`observe-ax-overlay.test.ts`):en-dash / CJK+en-dash / `node.value.value` 路径还原;纯 ASCII、真 UTF-16 CJK(护栏①)、合法 Latin-1(护栏②)不误伤。
- **Live**(react-aria DatePicker,新构建经 dev_reload 生效):spinbutton `value="6 – June"` ✓、slider `value="弱 – Weak"` ✓、button name `"测试 – Probe Aé中"` 无回归 ✓。
- **回归**:extension 1454 + mcp 525 全过。

## 测试计划

- [x] extension vitest 全量(1454)
- [x] mcp vitest 全量(525)
- [x] react-aria DatePicker live 还原验证
- [ ] reviewer 核实护栏②误伤边界(合法 Latin-1 但恰为合法 UTF-8 序列的极少数情况)