### PR TITLE
fix(observe): 可及名排除 visibility:hidden 子树文本(修 hover-swap 叠字)

### DIFF
--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -998,6 +998,40 @@ async function scanOneFrame(
         const normName = (s: string | null | undefined): string =>
           (s ?? "").replace(/\s+/g, " ").trim().slice(0, 80);
 
+        // 取元素后代文本但排除 visibility:hidden / display:none 子树(对齐 ACCNAME 规范:
+        // 隐藏子树不计入可及名)。getAccessibleName 末位兜底刻意用 textContent(绕过
+        // text-overflow:ellipsis 截断,见上方注释)——副作用是连 visibility:hidden 的镜像
+        // 文本也拼进去。Radix header「hover-swap」用 visible + visibility:hidden 两份同文
+        // span,textContent 得 "ThemesThemes";平时 AX overlay(CDP,正确排除 hidden)盖住,
+        // 但 Select/Dialog 打开等致 AX overlay 跳过、回退本启发式时叠字暴露(2026-06-23
+        // radix-ui.com Select-open dogfood)。本函数保留 visibility:visible 元素被 ellipsis
+        // 裁剪的文本(其 computed visibility 仍 visible,不排除),兼顾两者。
+        // perf:叶子(无子元素)走 textContent 快路径;text 超 96(normName 截 80 留余量)
+        // 或访问超 250 元素节点即停,防大容器/深树拖慢扫描热路径。
+        const visibleTextContent = (el: Element): string => {
+          if (el.childElementCount === 0) return el.textContent ?? "";
+          let out = "";
+          let count = 0;
+          const visit = (node: Node): void => {
+            const kids = node.childNodes;
+            for (let i = 0; i < kids.length; i++) {
+              if (out.length > 96 || count > 250) return;
+              const child = kids[i];
+              if (child.nodeType === 3) {
+                out += child.nodeValue || "";
+                continue;
+              }
+              if (child.nodeType !== 1) continue;
+              count++;
+              const cs = getComputedStyle(child as Element);
+              if (cs.visibility === "hidden" || cs.display === "none") continue;
+              visit(child);
+            }
+          };
+          visit(el);
+          return out;
+        };
+
         // <label for=X> 指向零尺寸(visually-hidden)表单控件时,label 是该控件的可见代理。
         // CSS-only 自定义 radio / Mantine Rating 星星把真 radio 设 0x0(被尺寸门跳过),
         // 用 label[for] 关联的可见星星承接点击;label 自身无文本/aria-label → require-name
@@ -1136,7 +1170,7 @@ async function scanOneFrame(
               "input[type=checkbox], input[type=radio]",
             );
             if (wrapsCheckRadio) {
-              const labelText = normName(el.textContent);
+              const labelText = normName(visibleTextContent(el));
               if (labelText) return labelText;
               // 缺陷① (2026-06-07 v4 淘宝评测): <label> 包 radio/checkbox 但
               // labelText 为空 (淘宝 emoji 雪碧图、Element Plus 纯图标 label、
@@ -1187,7 +1221,7 @@ async function scanOneFrame(
           // 用自身 textContent (信息最丰富,标题/价格/销量/店铺名)。先于
           // isContainer 判定,确保"自身有商品信息"不被当容器丢弃。
           const PRODUCT_HINTS = /[\u00a5￥]\d|人付款|回头客|已售|月销/;
-          const text = normName(el.textContent);
+          const text = normName(visibleTextContent(el));
           if (text && PRODUCT_HINTS.test(text)) return text;
           const isContainer =
             el.querySelector(

--- a/packages/extension/tests/observe-label-radio-fallback.test.ts
+++ b/packages/extension/tests/observe-label-radio-fallback.test.ts
@@ -45,7 +45,7 @@ describe("缺陷①: <label> 包 radio/checkbox 但无文本 — 通用兜底名
 
   it("现有 labelText 非空时优先返回 labelText (Element Plus '北京' 等场景)", () => {
     expect(OBSERVE_SRC).toMatch(
-      /const labelText = normName\(el\.textContent\);[\s\S]{0,50}?if \(labelText\) return labelText;/,
+      /const labelText = normName\(visibleTextContent\(el\)\);[\s\S]{0,50}?if \(labelText\) return labelText;/,
     );
   });
 

--- a/packages/extension/tests/observe-label-title-name.test.ts
+++ b/packages/extension/tests/observe-label-title-name.test.ts
@@ -44,7 +44,7 @@ describe("observe accessible-name — nested-control aria-label + title fallback
 
   it("the LABEL nested-aria block runs before the textContent fallback (so 角标 '1' doesn't win)", () => {
     const labelIdx = OBSERVE_SRC.search(/if \(el\.tagName === "LABEL"\)/);
-    const textIdx = OBSERVE_SRC.search(/const text = normName\(el\.textContent\);/);
+    const textIdx = OBSERVE_SRC.search(/const text = normName\(visibleTextContent\(el\)\);/);
     expect(labelIdx).toBeGreaterThan(0);
     expect(textIdx).toBeGreaterThan(0);
     expect(labelIdx).toBeLessThan(textIdx);
@@ -57,7 +57,7 @@ describe("observe accessible-name — nested-control aria-label + title fallback
   });
 
   it("the title fallback sits after textContent and before iconNameFromClass", () => {
-    const textIdx = OBSERVE_SRC.search(/const text = normName\(el\.textContent\);/);
+    const textIdx = OBSERVE_SRC.search(/const text = normName\(visibleTextContent\(el\)\);/);
     const titleIdx = OBSERVE_SRC.search(/const titleAttr = el\.getAttribute\("title"\);/);
     const classIdx = OBSERVE_SRC.indexOf("const fromIcon = iconNameFromClass(el);");
     expect(textIdx).toBeLessThan(titleIdx);

--- a/packages/extension/tests/observe-native-checkbox.test.ts
+++ b/packages/extension/tests/observe-native-checkbox.test.ts
@@ -76,7 +76,7 @@ describe("observe native checkbox/radio visibility (AB,2026-06-02 dogfood)", () 
       /wrapsCheckRadio\s*=\s*el\.querySelector\(\s*["']input\[type=checkbox\], input\[type=radio\]["']/,
     );
     expect(OBSERVE_SRC).toMatch(
-      /if \(wrapsCheckRadio\)[\s\S]{0,120}normName\(el\.textContent\)[\s\S]{0,60}return labelText/,
+      /if \(wrapsCheckRadio\)[\s\S]{0,160}normName\(visibleTextContent\(el\)\)[\s\S]{0,60}return labelText/,
     );
   });
 

--- a/packages/extension/tests/observe-visible-text-content.test.ts
+++ b/packages/extension/tests/observe-visible-text-content.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+/**
+ * getAccessibleName 末位兜底用 textContent(绕 text-overflow:ellipsis 截断),副作用是把
+ * visibility:hidden 的镜像文本也拼进名。Radix header「hover-swap」用 visible + visibility:hidden
+ * 两份同文 span → "ThemesThemes";平时 AX overlay(CDP 正确排除 hidden)盖住,但 Select/Dialog
+ * 打开等致 AX overlay 跳过、回退本启发式时叠字暴露(2026-06-23 radix-ui.com Select-open dogfood,
+ * live 复证)。visibleTextContent 排除 visibility:hidden/display:none 子树(对齐 ACCNAME 规范),
+ * 但保留 visibility:visible 元素被 ellipsis 裁剪的文本。
+ *
+ * scan 内联于 executeScript,source-lock 守护关键契约;行为用 jsdom 复刻函数直测。
+ */
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OBSERVE_SRC = readFileSync(
+  join(__dirname, "..", "src", "handlers", "observe.ts"),
+  "utf8",
+);
+
+describe("visibleTextContent source-lock(排除 visibility:hidden/display:none 子树)", () => {
+  it("定义 visibleTextContent helper", () => {
+    expect(OBSERVE_SRC).toMatch(/const visibleTextContent = \(el: Element\): string =>/);
+  });
+
+  it("叶子(无子元素)走 textContent 快路径", () => {
+    expect(OBSERVE_SRC).toMatch(/if \(el\.childElementCount === 0\) return el\.textContent \?\? "";/);
+  });
+
+  it("排除 visibility:hidden / display:none 子树", () => {
+    expect(OBSERVE_SRC).toMatch(
+      /if \(cs\.visibility === "hidden" \|\| cs\.display === "none"\) continue;/,
+    );
+  });
+
+  it("perf 双 early-exit:文本超 96 或访问超 250 节点即停", () => {
+    expect(OBSERVE_SRC).toMatch(/if \(out\.length > 96 \|\| count > 250\) return;/);
+  });
+
+  it("名提取末位兜底改用 visibleTextContent(叠字修复点)", () => {
+    expect(OBSERVE_SRC).toMatch(/const text = normName\(visibleTextContent\(el\)\);/);
+  });
+
+  it("checkbox/radio 包裹 label 文本也用 visibleTextContent", () => {
+    expect(OBSERVE_SRC).toMatch(/const labelText = normName\(visibleTextContent\(el\)\);/);
+  });
+});
+
+// jsdom 行为复刻(与 observe.ts 内联体同语义;source-lock 守护对齐)。
+function visibleTextContent(el: Element): string {
+  if (el.childElementCount === 0) return el.textContent ?? "";
+  let out = "";
+  let count = 0;
+  const visit = (node: Node): void => {
+    const kids = node.childNodes;
+    for (let i = 0; i < kids.length; i++) {
+      if (out.length > 96 || count > 250) return;
+      const child = kids[i];
+      if (child.nodeType === 3) {
+        out += child.nodeValue || "";
+        continue;
+      }
+      if (child.nodeType !== 1) continue;
+      count++;
+      const cs = getComputedStyle(child as Element);
+      if (cs.visibility === "hidden" || cs.display === "none") continue;
+      visit(child);
+    }
+  };
+  visit(el);
+  return out;
+}
+
+describe("visibleTextContent 行为(jsdom)", () => {
+  it("Radix hover-swap:visible + visibility:hidden 同文 span → 不叠字", () => {
+    const a = document.createElement("a");
+    a.innerHTML =
+      '<span style="visibility:visible">Themes</span>' +
+      '<span style="visibility:hidden">Themes</span>';
+    expect(visibleTextContent(a).replace(/\s+/g, " ").trim()).toBe("Themes");
+  });
+
+  it("display:none 子树文本被排除", () => {
+    const div = document.createElement("div");
+    div.innerHTML = 'Save<span style="display:none">(hidden tip)</span>';
+    expect(visibleTextContent(div).replace(/\s+/g, " ").trim()).toBe("Save");
+  });
+
+  it("全可见多 span 文本保留(无误删)", () => {
+    const div = document.createElement("div");
+    div.innerHTML = "<span>Hello</span> <span>World</span>";
+    expect(visibleTextContent(div).replace(/\s+/g, " ").trim()).toBe("Hello World");
+  });
+
+  it("叶子元素走快路径返回 textContent", () => {
+    const b = document.createElement("button");
+    b.textContent = "Click me";
+    expect(visibleTextContent(b)).toBe("Click me");
+  });
+
+  it("visibility:visible 元素文本保留(ellipsis 场景:元素可见仅被裁剪)", () => {
+    // text-overflow:ellipsis 不改 computed visibility(仍 visible)→ 文本保留,
+    // 这是当初用 textContent 而非 innerText 的初衷,本函数不回退该行为。
+    const cell = document.createElement("div");
+    cell.setAttribute(
+      "style",
+      "white-space:nowrap;overflow:hidden;text-overflow:ellipsis;width:10px;visibility:visible",
+    );
+    cell.textContent = "A very long cell value that gets clipped";
+    expect(visibleTextContent(cell)).toBe("A very long cell value that gets clipped");
+  });
+});


### PR DESCRIPTION
## 问题(Round 9 dogfood — radix-ui.com Select)

`vortex_observe` 在 Radix Select **打开态**下,顶部导航链接的可及名渲染成叠字:
`link "ThemesThemes"`(应为 `"Themes"`)。Select 关闭时则正常显示 `"Themes"`。

## 根因(实机白盒锁定)

- Radix header 用「hover-swap」模式:同一链接含两份同文 span —— 一份 `visibility:visible "Themes"`,一份 `visibility:hidden "Themes"`(hover 时无布局抖动地切换)。
- `el.textContent` = `"ThemesThemes"`(含隐藏副本);`el.innerText` = `"Themes"`(排除 visibility:hidden)。
- `getAccessibleName` 末位兜底**刻意用 textContent**(绕过 `text-overflow:ellipsis` 截断——innerText 会丢被裁剪的文本),副作用即把 visibility:hidden 镜像文本拼进名。
- 平时 **AX overlay**(CDP `getFullAXTree`,按 ACCNAME 规范正确排除 hidden 子树)盖住该启发式 → `"Themes"`。但 Radix Select/Dialog 打开的 portal/focus-lock 使 AX overlay 跳过、**回退 page-side 启发式** → 叠字暴露。
- 关闭 Select(`snap` 对照)恢复 `"Themes"`,确证是「AX overlay 在场 vs 缺席」的差异。

## 修复

新增 `visibleTextContent`:取后代文本但排除 `visibility:hidden` / `display:none` 子树(对齐 ACCNAME 规范),**保留** visibility:visible 元素被 ellipsis 裁剪的文本(其 computed visibility 仍 visible)——兼顾两个目标:
- 「绕 ellipsis 截断」(当初用 textContent 而非 innerText 的初衷,不回退);
- 「不重复 hover-swap 隐藏副本」(修叠字)。

应用于 `getAccessibleName` 两处自身后代文本提取(leaf 兜底 + checkbox/radio 包裹 label)。

**安全性**:`sr-only` 普遍用 `clip`/`position:absolute`(computed visibility 仍 `visible`)→ 不受影响、可及名仍取到;`aria-labelledby` 走另一分支(按规范引用 hidden 节点文本)不变。

**perf**(扫描热路径):叶子(无子元素)走 `textContent` 快路径;文本超 96 字符(`normName` 截 80 留余量)或访问超 250 元素节点**双 early-exit**,bound 大容器/深树开销。

## 验证

- **11 新单测**(`observe-visible-text-content.test.ts`):6 source-lock + 5 jsdom 行为(hover-swap 不叠字 / display:none 排除 / 全可见保留 / 叶子快路径 / **ellipsis 元素文本保留**)。
- 3 处旧 source-lock 断言随 `el.textContent`→`visibleTextContent(el)` 形式更新。
- **Live**(radix-ui.com Select 打开态,新构建经 dev_reload 生效):nav 链接由 `"ThemesThemes"` 恢复为 `"Themes"`;选项名(Apple/[disabled]Carrot/[selected]Blueberry)无回归。
- **回归**:ext 1465 + mcp 525 全过。

## 测试计划

- [x] ext vitest 全量(1465)
- [x] mcp vitest 全量(525)
- [x] radix-ui.com Select-open live 复证(叠字消失)
- [ ] reviewer 关注:大列表 page-side 扫描 perf(已 early-exit,建议 bench 抽查)