### PR TITLE
fix(observe): 变高 div 虚拟列表用中位数 band 替代严格等高检测

### DIFF
--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -2725,7 +2725,8 @@ async function scanOneFrame(
           // [inline detectDivVirtualScroller] A2-fb-div 纯 div 虚拟列表(react-window/react-virtuoso/
           // PrimeReact VirtualScroller:容器与行都无 table/ul/[role] 语义,上面语义路径整类漏扫)。
           // 真源 blindspot-detect.ts detectDivVirtualScroller,改一处须改两处。
-          // 强滚动 div 容器 + 内部 ≥3 等高重复子项 + estTotal>>渲染。廉价 scrollHeight 门先于 getComputedStyle。
+          // 强滚动 div 容器 + 内部 ≥3 高度成簇重复子项 + estTotal>>渲染。廉价 scrollHeight 门先于 getComputedStyle。
+          // 成簇用中位数 band[median×0.6,1.6] 替代严格等高:容纳 react-virtuoso 等变高虚拟列表(逐项测量行高不一)。
           for (const __sc of querySelectorAllDeep("div", document)) {
             if (__seenScrollers.has(__sc)) continue;
             const __sh2 = (__sc as HTMLElement).scrollHeight;
@@ -2733,18 +2734,24 @@ async function scanOneFrame(
             if (__ch2 <= 0 || __sh2 < __ch2 * 4) continue; // 廉价强滚动门
             const __oy2 = getComputedStyle(__sc as HTMLElement).overflowY;
             if (__oy2 !== "auto" && __oy2 !== "scroll") continue; // 确认裁剪滚动
-            let __divRows: Element[] = [];
+            let __divRows = 0;
+            let __divRowH = 0;
             for (const __w of Array.from((__sc as HTMLElement).querySelectorAll("div"))) {
               const __kids = Array.from(__w.children);
               if (__kids.length < 3) continue;
-              const __h0 = __kids[0].getBoundingClientRect().height;
-              if (__h0 < 4) continue;
-              const __uni = __kids.filter((n) => Math.abs(n.getBoundingClientRect().height - __h0) <= 2);
-              if (__uni.length >= 3 && __uni.length >= __kids.length * 0.7 && __uni.length > __divRows.length) __divRows = __uni;
+              const __heights = __kids.map((n) => n.getBoundingClientRect().height);
+              const __sorted = [...__heights].sort((a, b) => a - b);
+              const __median = __sorted[Math.floor(__sorted.length / 2)];
+              if (__median < 4) continue;
+              const __inBand = __heights.filter((h) => h >= __median * 0.6 && h <= __median * 1.6).length;
+              if (__inBand >= 3 && __inBand >= __kids.length * 0.7 && __inBand > __divRows) {
+                __divRows = __inBand;
+                __divRowH = __median;
+              }
             }
-            if (__divRows.length < 3) continue;
-            const __dRendered = __divRows.length;
-            const __dRowH = __divRows[0].getBoundingClientRect().height;
+            if (__divRows < 3) continue;
+            const __dRendered = __divRows;
+            const __dRowH = __divRowH;
             const __dEst = Math.round(__sh2 / __dRowH);
             if (__dEst > __dRendered && __dEst >= Math.max(__dRendered * 2, __dRendered + 20)) {
               __seenScrollers.add(__sc);

--- a/packages/extension/src/page-side/blindspot-detect.ts
+++ b/packages/extension/src/page-side/blindspot-detect.ts
@@ -104,9 +104,14 @@ export function detectVirtualByScroll(
  * 容器与行都是无 table/ul/[role] 语义的纯 div,detectVirtualByScroll 的语义候选/行选择器整类漏扫)。
  * 入参为疑似滚动容器。判据(与 detectVirtualByScroll 共享判定门,同 estTotal 公式):
  *  ① 强滚动:overflowY auto/scroll 且 scrollHeight ≥ clientHeight×4(普通内容达不到)
- *  ② 渲染窗口:内部存在某容器有 ≥3 个等高(±2px)重复子项,且等高占比 ≥70%(排除异构布局)
- *  ③ estTotal(scrollH/rowH)远大于渲染数(虚拟本质=只渲染窗口;全量渲染列表 estTotal≈渲染 不触发)。
+ *  ② 渲染窗口:内部存在某容器有 ≥3 个高度成簇的重复子项,且成簇占比 ≥70%(排除异构布局)
+ *  ③ estTotal(scrollH/中位行高)远大于渲染数(虚拟本质=只渲染窗口;全量渲染列表 estTotal≈渲染 不触发)。
  * 廉价 scrollHeight 门先于 getComputedStyle,使可在全 div 上遍历调用而不爆开销。confidence:low。
+ *
+ * 高度成簇用「中位数 band」而非严格等高:react-virtuoso 等变高虚拟列表逐项测量,行高不一
+ * (实测 100k-item demo 行高 73~107px,旧 ±2px 等高门只命中 2 行 <3 → 整类漏报)。
+ * band=[median×0.6, median×1.6] 容纳中等变高行,又靠 ≥70% 占比把异构内容(行高跨度悬殊的
+ * 非列表布局)挡在外面。等高列表方差为 0,median 即行高、band 全纳 → 与旧严格等高行为一致(无回归)。
  */
 export function detectDivVirtualScroller(scroller: HTMLElement): Blindspot | null {
   const sh = scroller.scrollHeight;
@@ -114,20 +119,25 @@ export function detectDivVirtualScroller(scroller: HTMLElement): Blindspot | nul
   if (ch <= 0 || sh < ch * 4) return null; // 廉价强滚动门(先于 getComputedStyle)
   const oy = getComputedStyle(scroller).overflowY;
   if (oy !== "auto" && oy !== "scroll") return null; // 确认裁剪滚动(排除内容自然撑高不裁剪的)
-  // 找渲染窗口:内部某 div 的直接子元素 ≥3 且高度近似一致(等高重复行=列表的特征)。
-  let rows: Element[] = [];
+  // 找渲染窗口:内部某 div 的直接子元素 ≥3 且高度成簇(中位数 band 内的重复行=列表特征)。
+  let bestRows = 0;
+  let bestRowH = 0;
   for (const w of Array.from(scroller.querySelectorAll("div"))) {
     const kids = Array.from(w.children);
     if (kids.length < 3) continue;
-    const h0 = kids[0].getBoundingClientRect().height;
-    if (h0 < 4) continue;
-    const uni = kids.filter((n) => Math.abs(n.getBoundingClientRect().height - h0) <= 2);
-    if (uni.length >= 3 && uni.length >= kids.length * 0.7 && uni.length > rows.length) rows = uni;
+    const heights = kids.map((n) => n.getBoundingClientRect().height);
+    const sorted = [...heights].sort((a, b) => a - b);
+    const median = sorted[Math.floor(sorted.length / 2)];
+    if (median < 4) continue;
+    const inBand = heights.filter((h) => h >= median * 0.6 && h <= median * 1.6).length;
+    if (inBand >= 3 && inBand >= kids.length * 0.7 && inBand > bestRows) {
+      bestRows = inBand;
+      bestRowH = median;
+    }
   }
-  if (rows.length < 3) return null;
-  const rendered = rows.length;
-  const rowH = rows[0].getBoundingClientRect().height;
-  const estTotal = Math.round(sh / rowH);
+  if (bestRows < 3) return null;
+  const rendered = bestRows;
+  const estTotal = Math.round(sh / bestRowH);
   if (estTotal > rendered && estTotal >= Math.max(rendered * 2, rendered + 20)) {
     return { kind: "virtual", total: estTotal, rendered, confidence: "low" };
   }

--- a/packages/extension/tests/blindspot-detect.test.ts
+++ b/packages/extension/tests/blindspot-detect.test.ts
@@ -158,6 +158,13 @@ describe("detectDivVirtualScroller (A2-fb-div 纯 div 虚拟列表)", () => {
     const sc = makeDivScroller({ scrollHeight: 5000000, clientHeight: 198, overflowY: "auto", childCount: 8, childHeight: [50, 120, 30, 200, 80, 50, 300, 40] });
     expect(detectDivVirtualScroller(sc)).toBeNull();
   });
+  it("变高虚拟列表(react-virtuoso 式 7 行 73~107px 成簇/scrollH 970000/clientH 590) → virtual ~10000 低置信", () => {
+    // react-virtuoso 逐项测量行高不一(实测 100k-item demo 行高 73~107px,旧 ±2px 等高门只命中
+    // 2 行 <3 → 整类漏报)。中位数 97,band[58.2,155.2] 全纳 7 行 → 触发。reactdatepicker/virtuoso.dev
+    // 2026-06-23 dogfood R14 实证盲区。
+    const sc = makeDivScroller({ scrollHeight: 970000, clientHeight: 590, overflowY: "auto", childCount: 7, childHeight: [73, 76, 89, 97, 103, 106, 107] });
+    expect(detectDivVirtualScroller(sc)).toEqual({ kind: "virtual", total: 10000, rendered: 7, confidence: "low" });
+  });
   it("子项过少(<3) → 不报（负例）", () => {
     const sc = makeDivScroller({ scrollHeight: 5000000, clientHeight: 198, overflowY: "scroll", childCount: 2, childHeight: 50 });
     expect(detectDivVirtualScroller(sc)).toBeNull();


### PR DESCRIPTION
## 问题

Dogfood R14(virtuoso.dev 100k-item demo)实证:`vortex_observe` 把 react-virtuoso 的 10 万项虚拟列表塌缩成单个 div + 拼接文本,**零 `[virtual:N/M]`/`#blindspots` 盲区信号**。agent 会误以为列表只有渲染窗口的 7~8 项,而不知背后有 ~10 万项 —— 正是 A2 盲区族要捕获的静默漏报。

## 根因

`detectDivVirtualScroller`(A2-fb-div 纯 div 虚拟列表检测)用 `Math.abs(h - kids[0])<=2` 严格等高聚类找渲染行。但 **react-virtuoso 逐项测量、行高不一**(实测 demo 行高 `[73,76,89,97,103,106,107]`px):h0=106 → 仅 106/107 两行入选 < 3 → `rows:0` 不触发。三条虚拟列表检测路径全漏:

- ARIA 路径:virtuoso 无 `role=grid/listbox`、无 `aria-rowcount`;
- 语义路径(`detectVirtualByScroll`):要 `li/tr/role=row`,virtuoso 是纯 div;
- div 路径(`detectDivVirtualScroller`):**等高 ±2px 假设对变高虚拟列表过严**。

白盒 spike:`virtuoso-scroller` overflowY:auto,scrollHeight 10,599,909 vs clientHeight 590(比 ~18000×),仅渲染 7/100000 项。检测的判别力其实在 `estTotal >> rendered` 门,等高门是冗余且制造漏报。

## 修复

把严格等高换成**中位数 band** 判定行成簇:`band=[median×0.6, median×1.6]`。

- 容纳中等变高行(virtuoso median 97,band [58.2,155.2] 全纳 7 行 → 触发);
- 靠 ≥70% 占比 + `estTotal>>渲染` 门排除异构非列表布局(异构负例 `[50,120,30,200,80,50,300,40]` median 80,band [48,128] 仅 4/8=50%<70% → 仍拒绝);
- 等高列表方差为 0、median 即行高、band 全纳 → **与旧行为一致,无回归**。

真源 `blindspot-detect.ts` + `observe.ts` 内联副本同步修改(改一处须改两处)。

## 验证

- 单测:`blindspot-detect.test.ts` 新增变高 virtuoso 正例(`[73,76,89,97,103,106,107]` → `virtual ~10000/7`),保留异构负例;`pnpm --filter @vortex-browser/extension exec vitest run` **1466/1466 通过**。
- Live 复证(virtuoso.dev 100k-item demo,修复前零信号):observe 现输出
  ```
  # blindspots: list virtual(~109277/7) (frame 21); list virtual(~92942/8) (frame 22)
  ```
- 无误报回归:react-dropzone(22 dropzone 无虚拟列表)observe 不冒虚假盲区信号。

## 测试计划

- [x] 单测全过(1466/1466)
- [x] virtuoso.dev live 复证盲区信号出现
- [x] react-dropzone live 确认无误报
- [ ] bench 回归(建议 ship 前 rerun 50-case)