### PR TITLE
fix(press): macOS Cmd+A 等编辑快捷键随 keyDown 传 commands 触发编辑命令

### DIFF
--- a/packages/extension/src/handlers/keyboard.ts
+++ b/packages/extension/src/handlers/keyboard.ts
@@ -79,6 +79,44 @@ const MODIFIERS: Record<string, number> = {
   Cmd: 4, Command: 4, Win: 4, Windows: 4, Super: 4, Option: 1, Opt: 1,
 };
 
+// 当前浏览器宿主是否 macOS。macOS 的编辑类键盘快捷键(Cmd+A 全选等)经 OS 的
+// NSResponder 键绑定层解析成编辑命令,而合成的 CDP Input.dispatchKeyEvent **绕过 OS**
+// → 命令不会自动触发(Cmd+A 返回 success 却不全选,2026-06-23 Quill dogfood R15 实证)。
+// 须随 keyDown 显式传 `commands` 字段(对齐 Playwright macEditingCommands 做法)。
+const IS_MAC: boolean = (() => {
+  try {
+    const uad = (navigator as unknown as { userAgentData?: { platform?: string } })
+      .userAgentData;
+    if (uad?.platform) return uad.platform === "macOS";
+    return /Mac/i.test(navigator.platform || navigator.userAgent || "");
+  } catch {
+    return false;
+  }
+})();
+
+/**
+ * macOS 下某 (物理码, 修饰键) 组合对应的编辑命令(CDP `commands` 字段值)。非 macOS 或
+ * 非编辑快捷键返回 undefined。仅处理纯 Meta(Cmd)且不叠加 Ctrl/Alt/Shift 的编辑快捷键,
+ * 避免误触别的命令。当前仅 Cmd+A→selectAll(R15 实证的静默失败点);此表是后续 mac 编辑
+ * 命令(copy/cut/paste/undo 等)的扩展点,新增时须各自实测命令名正确再加。
+ *
+ * isMac 显式入参(而非直接读 IS_MAC)便于单测;生产调用方传 IS_MAC。
+ */
+export function editingCommandsForKey(
+  code: string,
+  modifiers: number,
+  isMac: boolean,
+): string[] | undefined {
+  if (!isMac) return undefined;
+  const alt = (modifiers & 1) !== 0;
+  const ctrl = (modifiers & 2) !== 0;
+  const meta = (modifiers & 4) !== 0;
+  const shift = (modifiers & 8) !== 0;
+  if (!meta || ctrl || alt || shift) return undefined;
+  if (code === "KeyA") return ["selectAll"];
+  return undefined;
+}
+
 async function getActiveTabId(tabId?: number): Promise<number> {
   if (tabId) return tabId;
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -180,6 +218,10 @@ async function dispatchKey(
   // 也不插。Shift-only 等带修饰键的大小写场景仍走 type/fill。(2026-06-13 EP dogfood A3)
   const isPrintable = modifiers === 0 && [...key].length === 1;
 
+  // macOS 编辑快捷键(Cmd+A 等)须随 keyDown 显式传 commands,否则合成事件不触发编辑命令
+  // (见 IS_MAC / editingCommandsForKey 注释)。非 macOS / 非编辑快捷键时为 undefined,不附字段。
+  const commands = editingCommandsForKey(physicalCode, modifiers, IS_MAC);
+
   await debuggerMgr.sendCommand(tabId, "Input.dispatchKeyEvent", {
     type: "keyDown",
     key,
@@ -188,6 +230,7 @@ async function dispatchKey(
     nativeVirtualKeyCode: vk,
     modifiers,
     ...(isPrintable ? { text: key, unmodifiedText: key } : {}),
+    ...(commands ? { commands } : {}),
   });
 
   await debuggerMgr.sendCommand(tabId, "Input.dispatchKeyEvent", {

--- a/packages/extension/tests/keyboard-press-combos.test.ts
+++ b/packages/extension/tests/keyboard-press-combos.test.ts
@@ -4,6 +4,7 @@ import {
   registerKeyboardHandlers,
   parseKeyExpression,
   keyToCode,
+  editingCommandsForKey,
 } from "../src/handlers/keyboard.js";
 
 /**
@@ -109,6 +110,32 @@ describe("keyToCode 标点 → 合法物理码", () => {
     expect(keyToCode("1")).toBe("Digit1");
     expect(keyToCode("Meta")).toBe("MetaLeft");
     expect(keyToCode("Enter")).toBe("Enter");
+  });
+});
+
+// macOS 编辑快捷键(Cmd+A 全选等)经 OS NSResponder 键绑定解析,合成 CDP 事件绕过 OS →
+// 命令不触发(Cmd+A 返回 success 却不全选,2026-06-23 Quill dogfood R15 实证)。须随 keyDown
+// 显式传 commands 字段。editingCommandsForKey 计算该字段;dispatch 级 IS_MAC 串联由 macOS live 验证。
+describe("editingCommandsForKey (macOS 编辑命令补偿)", () => {
+  it("macOS Cmd+A(KeyA + Meta) → selectAll", () => {
+    expect(editingCommandsForKey("KeyA", 4, true)).toEqual(["selectAll"]);
+  });
+  it("非 macOS 一律 undefined(Win/Linux Ctrl+A 由 Chrome 内部解析,无须附 commands)", () => {
+    expect(editingCommandsForKey("KeyA", 4, false)).toBeUndefined();
+    expect(editingCommandsForKey("KeyA", 2, false)).toBeUndefined();
+  });
+  it("macOS 无 Meta 不附(Ctrl+A 在 mac 非全选;无修饰是打字)", () => {
+    expect(editingCommandsForKey("KeyA", 0, true)).toBeUndefined();
+    expect(editingCommandsForKey("KeyA", 2, true)).toBeUndefined(); // Ctrl
+  });
+  it("macOS 叠加 Ctrl/Alt/Shift 的 Meta 组合不附(避免误触别的命令)", () => {
+    expect(editingCommandsForKey("KeyA", 4 | 8, true)).toBeUndefined(); // Cmd+Shift+A
+    expect(editingCommandsForKey("KeyA", 4 | 1, true)).toBeUndefined(); // Cmd+Alt+A
+    expect(editingCommandsForKey("KeyA", 4 | 2, true)).toBeUndefined(); // Cmd+Ctrl+A
+  });
+  it("非 selectAll 键暂不在表内(扩展点)→ undefined", () => {
+    expect(editingCommandsForKey("KeyC", 4, true)).toBeUndefined();
+    expect(editingCommandsForKey("KeyS", 4, true)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## 问题

Dogfood R15(Quill 富文本编辑器)实证:`vortex_press('Meta+a')`(macOS 全选)返回 `success:true` 却**不全选** —— silent false success。

- same-origin textarea(`example.com` 注入):光标置末尾 → `Meta+a` → `selectionStart/End` 仍 20/20,未选中;
- 跨域 Quill 编辑器:`Meta+a` + `Backspace` 只删 1 个字符(光标末尾),而非清空全文。

`Control+a` 同样无效 —— 但那是 macOS 上的正确行为(Mac 全选是 Cmd+A,Ctrl+A 是行首导航)。

## 根因

macOS 的编辑类键盘快捷键(Cmd+A→selectAll、Cmd+C→copy 等)经 OS 的 **NSResponder 键绑定层**解析成编辑命令。而合成的 CDP `Input.dispatchKeyEvent` **绕过 OS** → 即便事件形态完全正确(`key="a"` / `code="KeyA"` / `windowsVirtualKeyCode=65` / `modifiers=4(Meta)`),编辑命令也不会自动触发。

读码确认 `keyboard.ts` 的 `MODIFIERS`(Meta=4)、`keyToVk("a")=65`、`keyToCode("a")="KeyA"`、combo 路径传 modifiers 均正确 —— 缺的是 CDP `commands` 字段。这正是 Playwright `macEditingCommands` 处理的同一问题。

## 修复

`dispatchKey` 在 **macOS + 纯 Meta 编辑快捷键**时给 `keyDown` 附 `commands` 字段(当前 `Cmd+A → ["selectAll"]`):

- 非 macOS(Win/Linux Ctrl+A 由 Chrome 内部解析,无须附)→ 不附;
- 叠加 Ctrl/Alt/Shift 的 Meta 组合 → 不附(避免误触别的命令);
- `editingCommandsForKey(code, modifiers, isMac)` 抽为纯函数便于单测;`IS_MAC` 由 `navigator.userAgentData.platform` / `navigator.platform` 探测;
- 命令表是后续 mac 编辑命令(copy/cut/paste/undo)的扩展点,新增须各自实测命令名再加。

页面自带 `Cmd+A` 监听器若 `preventDefault()` 仍会抑制该 selectAll 命令(默认动作),不影响自定义处理;JS keydown 事件照常派发 → 无回归。

## 验证

- 单测:`keyboard-press-combos.test.ts` 新增 `editingCommandsForKey` 5 例(selectAll 映射 / 非 mac / 无 Meta / 叠加修饰键 / 非表内键);`pnpm --filter @vortex-browser/extension exec vitest run` **1471/1471 通过**。
- Live 复证(修复前 selection 不变):
  - same-origin textarea:`Meta+a` → `selectedAll=true`(selection [0,20]);
  - 跨域 Quill 编辑器:`Meta+a` + `Backspace` → 编辑器清空(`value=`)。

## 测试计划

- [x] 单测全过(1471/1471)
- [x] same-origin textarea Meta+a 全选 live
- [x] 跨域 Quill Meta+a+Backspace 清空 live
- [ ] bench 回归(建议 ship 前 rerun)
- [ ] Win/Linux Ctrl+A 回归(本机 macOS 无法验,代码路径上非 mac 不附 commands 即旧行为)