### PR TITLE
fix(observe): 召回嵌套 portal 弹层(Cascader 等)选项免遭截断

### DIFF
--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -342,6 +342,11 @@ export const FOCUS_CONTAINER_ROLES = new Set<string>([
 ]);
 export const ATOMIC_INTERACTIVE_SELECTORS =
   "button,a[href],summary,input:not([type=hidden]),select,textarea,label,[role=button],[role=link],[role=textbox],[role=checkbox],[role=radio],[role=tab],[role=menuitem],[role=treeitem],[role=option],[contenteditable],[onclick]";
+// 信号二(portal overlay)「含交互后代」门专用:ATOMIC 基础上补 menuitemcheckbox/menuitemradio。
+// Cascader/多选菜单弹层只含这两类 role(ATOMIC 漏),不补则弹层被判「无交互后代」装饰浮层而不前置。
+// 仅用于 overlay 根判定,不改全局收集语义(blast radius 受守)。collectPortalOverlayRoots 默认值用它。
+export const OVERLAY_DESCENDANT_SELECTORS =
+  ATOMIC_INTERACTIVE_SELECTORS + ",[role=menuitemcheckbox],[role=menuitemradio]";
 export function isFocusContainerOnly(el: Element): boolean {
   const role = el.getAttribute("role")?.trim().split(/\s+/)[0];
   if (role && FOCUS_CONTAINER_ROLES.has(role)) return true;
@@ -475,6 +480,44 @@ export function partitionOverlayFirst(candidates: Element[], overlayRoots: Eleme
   const rest: Element[] = [];
   for (const el of candidates) (inOverlay(el) ? front : rest).push(el);
   return front.length > 0 ? [...front, ...rest] : candidates;
+}
+
+/**
+ * 信号二:portal 弹层根收集(无 ARIA 弹层 role 时的兜底,如 el-select popper)。
+ * 判据:脱流(position absolute/fixed)+ z-index 抬升(>0)+ 可见 + 含交互后代。
+ *
+ * **扫描深度=body 直接子 + 直接子的直接子(body 孙)**:rc-component(antd Cascader/Dropdown/
+ * Popover/Tooltip 等)经 rc-trigger 把真正定位(z 抬升)的弹层嵌在 body 直接子的「static 透明
+ * 包裹层」下一层(`body > div(static) > div.popup(absolute,z:1050)`),只扫 body 直接子会漏掉
+ * 整层 portal → 其交互后代不前置、密集页上遭 maxElements 截断(2026-06-23 Cascader dogfood
+ * R24 实证:role=menu 列又被 isPersistentMenu 排除,signal-1 也漏 → 选项 observe 完全不可见)。
+ * static 透明 wrapper / SPA app-root 自身因不满足 absolute+z>0 不会被误纳,blast radius 受守。
+ * inject func(scanOneFrame)内联同名逻辑,改一处须同步;本导出由 observe-overlay-priority.test.ts 锁守护。
+ */
+export function collectPortalOverlayRoots(
+  body: Element,
+  isVisibleForOverlay: (el: Element) => boolean,
+  atomicSelector: string = OVERLAY_DESCENDANT_SELECTORS,
+  alreadyRoots: Element[] = [],
+): Element[] {
+  const roots: Element[] = [];
+  // body 直接子 + rc-trigger 透明包裹层下一层(body 孙)。
+  const cands: Element[] = [];
+  for (const child of Array.from(body.children)) {
+    cands.push(child);
+    for (const gc of Array.from(child.children)) cands.push(gc);
+  }
+  for (const el of cands) {
+    if (alreadyRoots.includes(el) || roots.includes(el)) continue;
+    const cs = getComputedStyle(el as HTMLElement);
+    if (cs.position !== "fixed" && cs.position !== "absolute") continue;
+    const z = parseInt(cs.zIndex, 10);
+    if (!(z > 0)) continue;
+    if (!isVisibleForOverlay(el)) continue;
+    if (!el.querySelector(atomicSelector)) continue;
+    roots.push(el);
+  }
+  return roots;
 }
 
 /**
@@ -1911,6 +1954,10 @@ async function scanOneFrame(
         ]);
         const ATOMIC_INTERACTIVE_SELECTORS =
           "button,a[href],summary,input:not([type=hidden]),select,textarea,label,[role=button],[role=link],[role=textbox],[role=checkbox],[role=radio],[role=tab],[role=menuitem],[role=treeitem],[role=option],[contenteditable],[onclick]";
+        // 信号二 portal overlay「含交互后代」门专用(补 menuitemcheckbox/menuitemradio,Cascader/
+        // 多选菜单弹层只含这两类 role)。模块级 OVERLAY_DESCENDANT_SELECTORS 同名,改一处须同步。
+        const OVERLAY_DESCENDANT_SELECTORS =
+          ATOMIC_INTERACTIVE_SELECTORS + ",[role=menuitemcheckbox],[role=menuitemradio]";
         const isFocusContainerOnly = (anc: Element): boolean => {
           const role = anc.getAttribute("role")?.trim().split(/\s+/)[0];
           if (role && FOCUS_CONTAINER_ROLES.has(role)) return true;
@@ -2246,17 +2293,27 @@ async function scanOneFrame(
           if (!role || !OVERLAY_POPUP_ROLES.has(role)) continue;
           if (isVisibleForOverlay(el) && isFloatingOverlay(el) && !isPersistentMenu(el, role)) overlayRoots.push(el);
         }
-        // 信号二:body 直接子节点的 portal(脱流 + z-index 抬升 + 含交互后代),
-        // 兜住无 ARIA role 的自定义弹层(如 el-select popper)。
+        // 信号二:portal 弹层(脱流 + z-index 抬升 + 含交互后代),兜住无 ARIA 弹层 role 的
+        // 自定义弹层(如 el-select popper)。扫描深度=body 直接子 + 直接子的直接子(body 孙):
+        // rc-component(antd Cascader/Dropdown/Popover 等)经 rc-trigger 把真正定位(z 抬升)的弹层
+        // 嵌在 body 直接子的 static 透明包裹层下一层,只扫 body 直接子会整层漏掉(2026-06-23
+        // Cascader dogfood R24 实证)。「含交互后代」门用 OVERLAY_DESCENDANT_SELECTORS:在 ATOMIC
+        // 基础上补 menuitemcheckbox/menuitemradio(Cascader/多选菜单弹层只含这两类 role,ATOMIC 漏),
+        // 否则弹层因「无交互后代」被判装饰浮层而不前置。模块级 collectPortalOverlayRoots 同名,改一处须同步。
         if (docBody) {
-          for (const el of Array.from(docBody.children)) {
+          const portalCands: Element[] = [];
+          for (const child of Array.from(docBody.children)) {
+            portalCands.push(child);
+            for (const gc of Array.from(child.children)) portalCands.push(gc);
+          }
+          for (const el of portalCands) {
             if (overlayRoots.includes(el)) continue;
             const cs = getComputedStyle(el as HTMLElement);
             if (cs.position !== "fixed" && cs.position !== "absolute") continue;
             const z = parseInt(cs.zIndex, 10);
             if (!(z > 0)) continue;
             if (!isVisibleForOverlay(el)) continue;
-            if (!el.querySelector(ATOMIC_INTERACTIVE_SELECTORS)) continue;
+            if (!el.querySelector(OVERLAY_DESCENDANT_SELECTORS)) continue;
             overlayRoots.push(el);
           }
         }

--- a/packages/extension/tests/observe-overlay-priority.test.ts
+++ b/packages/extension/tests/observe-overlay-priority.test.ts
@@ -26,6 +26,9 @@ import {
   isOverlayFloating,
   isPersistentNavMenu,
   partitionOverlayFirst,
+  collectPortalOverlayRoots,
+  OVERLAY_DESCENDANT_SELECTORS,
+  ATOMIC_INTERACTIVE_SELECTORS,
 } from "../src/handlers/observe.js";
 
 describe("overlay-priority (DEFECT-1)", () => {
@@ -98,6 +101,98 @@ describe("overlay-priority (DEFECT-1)", () => {
     });
   });
 
+  describe("collectPortalOverlayRoots(信号二:body 直接子 + rc-trigger 嵌套 wrapper 下一层)", () => {
+    const ATOMIC = "a[href],button,[role=option],[role=menuitem],[role=menuitemcheckbox]";
+    const vis = () => true; // jsdom 无布局,注入可见判定(隔离 getBoundingClientRect 限制)
+
+    it("body 直接子 portal(absolute + z>0 + 含交互后代)→ 收集", () => {
+      document.body.innerHTML =
+        `<div id="pop" role="listbox" style="position:absolute;z-index:1050">` +
+        `<div role="option">Jack</div></div>`;
+      const roots = collectPortalOverlayRoots(document.body, vis, ATOMIC);
+      expect(roots.map((e) => (e as HTMLElement).id)).toEqual(["pop"]);
+    });
+
+    it("rc-trigger 嵌套:body > static 透明 wrapper > absolute z 弹层 → 收集弹层(Cascader 实证)", () => {
+      // antd Cascader 结构:body 直接子是 static 透明包裹层,真正定位的 .ant-cascader-dropdown
+      // (absolute,z:1050,role=menu 列)嵌在下一层。只扫 body 直接子会整层漏掉。
+      document.body.innerHTML =
+        `<div id="wrap" style="position:static">` +
+        `<div id="dropdown" style="position:absolute;z-index:1050">` +
+        `<ul role="menu"><li role="menuitemcheckbox">Zhejiang</li><li role="menuitemcheckbox">Jiangsu</li></ul>` +
+        `</div></div>`;
+      const roots = collectPortalOverlayRoots(document.body, vis, ATOMIC);
+      expect(roots.map((e) => (e as HTMLElement).id)).toEqual(["dropdown"]);
+    });
+
+    it("static 透明 wrapper 自身不被误纳(无 absolute/z)", () => {
+      document.body.innerHTML =
+        `<div id="wrap" style="position:static">` +
+        `<div id="dropdown" style="position:absolute;z-index:1050"><button>x</button></div></div>`;
+      const roots = collectPortalOverlayRoots(document.body, vis, ATOMIC);
+      expect(roots.map((e) => (e as HTMLElement).id)).toEqual(["dropdown"]);
+      expect(roots.some((e) => (e as HTMLElement).id === "wrap")).toBe(false);
+    });
+
+    it("SPA app-root(body > div#root static,内含全部交互但无 absolute+z 弹层)→ 不误纳", () => {
+      document.body.innerHTML =
+        `<div id="root" style="position:relative"><main><button>a</button><a href="/x">b</a></main></div>`;
+      expect(collectPortalOverlayRoots(document.body, vis, ATOMIC)).toEqual([]);
+    });
+
+    it("脱流但 z-index auto(z 不 >0)→ 不收集(保 baseline,与直接子门一致)", () => {
+      document.body.innerHTML =
+        `<div style="position:static"><div id="pop" role="menu" style="position:absolute">` +
+        `<div role="menuitem">x</div></div></div>`;
+      expect(collectPortalOverlayRoots(document.body, vis, ATOMIC)).toEqual([]);
+    });
+
+    it("absolute + z>0 但无交互后代 → 不收集(纯装饰浮层)", () => {
+      document.body.innerHTML =
+        `<div style="position:static"><div id="deco" style="position:absolute;z-index:99"><span>纯文本</span></div></div>`;
+      expect(collectPortalOverlayRoots(document.body, vis, ATOMIC)).toEqual([]);
+    });
+
+    it("已在 alreadyRoots(signal-1 已收)→ 去重不重复收集", () => {
+      document.body.innerHTML =
+        `<div id="pop" role="listbox" style="position:absolute;z-index:1050"><div role="option">x</div></div>`;
+      const pop = document.getElementById("pop")!;
+      expect(collectPortalOverlayRoots(document.body, vis, ATOMIC, [pop])).toEqual([]);
+    });
+
+    it("不可见弹层(注入 isVisible=false)→ 不收集", () => {
+      document.body.innerHTML =
+        `<div style="position:static"><div id="pop" style="position:absolute;z-index:1050"><button>x</button></div></div>`;
+      expect(collectPortalOverlayRoots(document.body, () => false, ATOMIC)).toEqual([]);
+    });
+
+    it("弹层只含 menuitemcheckbox(Cascader/多选菜单)→ 默认 OVERLAY_DESCENDANT_SELECTORS 仍收集", () => {
+      // antd Cascader 弹层只含 role=menuitemcheckbox(无 button/a/menuitem)。默认门须认它为交互后代。
+      document.body.innerHTML =
+        `<div style="position:static"><div id="dropdown" style="position:absolute;z-index:1050">` +
+        `<ul role="menu"><li role="menuitemcheckbox">Zhejiang</li></ul></div></div>`;
+      const roots = collectPortalOverlayRoots(document.body, () => true); // 用默认 selector
+      expect(roots.map((e) => (e as HTMLElement).id)).toEqual(["dropdown"]);
+    });
+
+    it("证伪门:菜单弹层用旧 ATOMIC(不含 menuitemcheckbox/radio)→ 漏判(回归守卫)", () => {
+      // 锁住根因:ATOMIC 缺 menuitemcheckbox 时,只含该 role 的 Cascader 弹层被判「无交互后代」漏掉。
+      document.body.innerHTML =
+        `<div style="position:static"><div id="dropdown" style="position:absolute;z-index:1050">` +
+        `<ul role="menu"><li role="menuitemcheckbox">Zhejiang</li></ul></div></div>`;
+      expect(collectPortalOverlayRoots(document.body, () => true, ATOMIC_INTERACTIVE_SELECTORS)).toEqual([]);
+      // 而 OVERLAY_DESCENDANT_SELECTORS 修复它:
+      const fixed = collectPortalOverlayRoots(document.body, () => true, OVERLAY_DESCENDANT_SELECTORS);
+      expect(fixed.map((e) => (e as HTMLElement).id)).toEqual(["dropdown"]);
+    });
+
+    it("OVERLAY_DESCENDANT_SELECTORS = ATOMIC + menuitemcheckbox/radio", () => {
+      expect(OVERLAY_DESCENDANT_SELECTORS).toContain("[role=menuitemcheckbox]");
+      expect(OVERLAY_DESCENDANT_SELECTORS).toContain("[role=menuitemradio]");
+      expect(OVERLAY_DESCENDANT_SELECTORS.startsWith(ATOMIC_INTERACTIVE_SELECTORS)).toBe(true);
+    });
+  });
+
   describe("inject func 内联副本 drift 锁(改一处须同步)", () => {
     const SRC = readFileSync(
       join(dirname(fileURLToPath(import.meta.url)), "..", "src", "handlers", "observe.ts"),
@@ -116,6 +211,14 @@ describe("overlay-priority (DEFECT-1)", () => {
     it("内联保留 portal 信号(body 直接子 + z-index)", () => {
       expect(SRC).toMatch(/docBody\.children/);
       expect(SRC).toMatch(/zIndex/);
+    });
+    it("内联 portal 扫描穿 rc-trigger 透明 wrapper 下一层(body 孙,改一处须同步)", () => {
+      // 内联须遍历 body 直接子的 children(child.children),与模块级 collectPortalOverlayRoots 一致。
+      expect(SRC).toMatch(/for \(const gc of Array\.from\(child\.children\)\)/);
+    });
+    it("内联 portal「含交互后代」门用 OVERLAY_DESCENDANT_SELECTORS(补 menuitemcheckbox/radio)", () => {
+      expect(SRC).toMatch(/querySelector\(OVERLAY_DESCENDANT_SELECTORS\)/);
+      expect(SRC).toMatch(/role=menuitemcheckbox.*role=menuitemradio|menuitemcheckbox/);
     });
     it("内联保留无浮层零漂移(overlayRoots.length === 0 → baseCandidates)", () => {
       expect(SRC).toMatch(/overlayRoots\.length === 0/);

--- a/packages/vortex-bench/playground/public/synth/nested-portal-overlay-priority.html
+++ b/packages/vortex-bench/playground/public/synth/nested-portal-overlay-priority.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="zh"><head><meta charset="utf-8"><title>nested portal overlay priority</title></head>
+<body>
+<h1>密集页 + rc-trigger 嵌套 portal 弹层(Cascader 截断盲区)</h1>
+<!--
+  复现 2026-06-23 Cascader dogfood R24:antd Cascader/Dropdown 经 rc-trigger 把真正定位
+  (absolute,z 抬升)的弹层嵌在 body 直接子的「static 透明包裹层」下一层:
+    body > div(static wrapper) > div.dropdown(absolute,z:1050) > ul[role=menu] > li[role=menuitemcheckbox]
+  且弹层列用 role=menu 但无 aria-controls 关联 → signal-1 被 isPersistentMenu 当持久导航排除,
+  signal-2 旧版只扫 body 直接子又漏掉整层 portal → 密集页(>80)上选项被 maxElements 截断、observe 完全不可见。
+  修复:signal-2 扫描深度扩到 body 孙(穿透 rc-trigger 透明 wrapper)→ 弹层交互后代前置免遭截断。
+-->
+<nav id="nav"></nav>
+<script>
+  // 90 个导航链接(DOM 序在前,填满 80 cap)
+  var nav = document.getElementById("nav");
+  for (var i = 0; i < 90; i++) {
+    var a = document.createElement("a");
+    a.href = "#link" + i;
+    a.textContent = "导航链接 " + i;
+    a.style.display = "block";
+    nav.appendChild(a);
+  }
+</script>
+<!-- rc-trigger 透明包裹层:position static、z auto(不自带定位/抬升) -->
+<div id="rc-wrapper" style="position:static">
+  <!-- 真正定位的弹层:absolute、视口内、z-index 抬升,嵌在 wrapper 下一层 -->
+  <div id="dropdown" style="position:absolute;top:90px;left:320px;z-index:1050;background:#fff;border:1px solid #ccc;width:160px">
+    <ul role="menu" style="list-style:none;margin:0;padding:0">
+      <li role="menuitemcheckbox" data-vtx-oracle="opt-zhejiang" style="padding:6px;cursor:pointer">Zhejiang</li>
+      <li role="menuitemcheckbox" data-vtx-oracle="opt-jiangsu" style="padding:6px;cursor:pointer">Jiangsu</li>
+    </ul>
+  </div>
+</div>
+</body></html>

--- a/packages/vortex-bench/playground/public/synth/nested-portal-overlay-priority.manifest.json
+++ b/packages/vortex-bench/playground/public/synth/nested-portal-overlay-priority.manifest.json
@@ -1,0 +1,10 @@
+{
+  "fixture": "nested-portal-overlay-priority",
+  "path": "/synth/nested-portal-overlay-priority.html",
+  "tier": "medium",
+  "frames": "main",
+  "entries": [
+    { "id": "opt-zhejiang", "interactive": true, "expectedName": "Zhejiang", "expectedRole": "menuitemcheckbox", "pattern": "nested-portal-overlay-priority", "note": "rc-trigger 嵌套 portal(body > static wrapper > absolute z 弹层)的选项,须经 signal-2 穿透 wrapper + overlay-priority 前置免遭 80 截断" },
+    { "id": "opt-jiangsu", "interactive": true, "expectedName": "Jiangsu", "expectedRole": "menuitemcheckbox", "pattern": "nested-portal-overlay-priority" }
+  ]
+}


### PR DESCRIPTION
## 问题（Dogfood R24）

打开 antd **Cascader** 后,`vortex_observe` 完全看不到弹层选项(Zhejiang/Jiangsu),agent 无法选择。实测 `ant.design/components/cascader`:combobox 已 `[expanded]`,但 651 候选返回的前 80 全是导航/demo,选项一个不在。

## 根因（活浏览器白盒 spike 确认）

overlay 前置的**两个门同时漏判**,缺一不可:

1. **信号二只扫 body 直接子**。rc-component(Cascader/Dropdown/Popover 等)经 rc-trigger 把真正定位(`absolute; z:1050`)的弹层嵌在 body 直接子的 **static 透明包裹层**下一层:
   `body > div(static) > div.ant-cascader-dropdown(absolute,z:1050)` → 整层 portal 被漏掉。
2. **「含交互后代」门用 `ATOMIC_INTERACTIVE_SELECTORS`,缺 `menuitemcheckbox`/`menuitemradio`**。Cascader 弹层只含 `li[role=menuitemcheckbox]`(无 button/a/menuitem),被判「无交互后代」装饰浮层。

二者叠加 → 弹层不入 `overlayRoots` → 选项(经 cursor:pointer fallback 收集进 baseCandidates)不前置 → 密集页(>80)上遭 `maxElements` 截断。信号一(`role=menu`)又被 `isPersistentMenu` 当持久导航排除,无兜底。

## 修复

- ① 信号二扫描深度扩到 **body 孙**(穿透 rc-trigger 透明 wrapper);
- ② 新增 `OVERLAY_DESCENDANT_SELECTORS`(`ATOMIC` + menuitemcheckbox/menuitemradio),**仅用于 overlay 根判定**,不改全局收集语义(blast radius 受守);
- 提取模块级纯函数 `collectPortalOverlayRoots` 供 jsdom 直测,内联副本镜像 + drift-lock;
- `static wrapper` / SPA app-root 因不满足 `absolute + z>0` 不会误纳。

## 验证

- **真站端到端**(`ant.design/components/cascader`):修前选项缺失 → 修后 `div "Zhejiang" [ref=e0]` / `div "Jiangsu" [ref=e1]` **前置到 0-1 位**,click ref 成功推进级联(domMutations:34)。
- **TDD**:`collectPortalOverlayRoots` jsdom 直测 RED→GREEN(嵌套/证伪门/去重/不可见/app-root 负例)。
- 扩展单测 **1484 全过**(overlay-priority 31→35)。
- 新增 synth fixture `nested-portal-overlay-priority`(密集页 + rc-trigger 嵌套 + menuitemcheckbox)永久回归。

## Test plan

- [ ] CI: `pnpm --filter @vortex-browser/extension test`
- [ ] CI: `pnpm --filter @vortex-browser/vortex-bench bench scan nested-portal-overlay-priority`(recall 2/2)
- [ ] CI: bench `run --all` ratchet 50/50(本地交互 session 与 live 扩展冲突未跑,留 CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)