### PR TITLE
feat(observe): tree 展开/折叠 switcher surface 成独立 toggle ref

### DIFF
--- a/packages/extension/src/handlers/observe-ax-overlay.ts
+++ b/packages/extension/src/handlers/observe-ax-overlay.ts
@@ -171,6 +171,9 @@ export interface OverlayableElement {
   };
   controls?: number[]; owns?: number[]; errorMessage?: string; description?: string;
   tag?: string;
+  /** tree 展开/折叠 toggle(R25):page-side 已定 role=button/name=expand|collapse,
+   *  CDP AX 视 caret 为 presentational(role=img/name="caret-down"),overlay 须跳过覆盖。 */
+  treeToggle?: boolean;
 }
 
 /**
@@ -197,8 +200,10 @@ export function applyOverlay(
       { backendId: backendId!, role: el.role, name: el.name, heuristicInteractive: el.reactClickable === true },
       node,
     );
-    if (ov.role) el.role = ov.role;
-    if (ov.name) el.name = ov.name;
+    // tree 展开/折叠 toggle:保留 page-side 的 role=button/name=expand|collapse,
+    // 不被 CDP AX 的 presentational caret(role=img/name="caret-down")覆盖(R25)。
+    if (ov.role && !el.treeToggle) el.role = ov.role;
+    if (ov.name && !el.treeToggle) el.name = ov.name;
     el.nameSource = ov.nameSource ?? "heuristic";
     if (ov.state) el.state = { ...(el.state ?? {}), ...ov.state };
     if (ov.valueNow !== undefined) el.valueNow = ov.valueNow;

--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -2305,11 +2305,41 @@ async function scanOneFrame(
           }
         }
 
-        const baseCandidates: Element[] = [
-          ...Array.from(nodeList),
-          ...cursorPointerLeaves,
-          ...iconCtaExtras,
-        ];
+        const baseCandidates: Element[] = (() => {
+          const raw: Element[] = [
+            ...Array.from(nodeList),
+            ...cursorPointerLeaves,
+            ...iconCtaExtras,
+          ];
+          // tree 展开/折叠 toggle 排序(R25):cursorPointerLeaves 排在 nodeList 之后,密集树上
+          // toggle 遭 maxElements 截断、与其 treeitem 远隔。把每个 toggle 重排到其 treeitem 紧后,
+          // 二者随后续 overlay/main-content 分区同进退,toggle 与已召回的 treeitem 同框免截断。
+          // 无 toggle → 原数组同序(零漂移)。
+          const toggles: Element[] = [];
+          const rest: Element[] = [];
+          for (const el of raw) (isTreeExpandToggle(el) ? toggles : rest).push(el);
+          if (toggles.length === 0) return raw;
+          const byTreeitem = new Map<Element, Element[]>();
+          for (const t of toggles) {
+            const ti = t.closest('[role="treeitem"]');
+            if (ti) {
+              const arr = byTreeitem.get(ti) || [];
+              arr.push(t);
+              byTreeitem.set(ti, arr);
+            }
+          }
+          const out: Element[] = [];
+          for (const el of rest) {
+            out.push(el);
+            const ts = byTreeitem.get(el);
+            if (ts) {
+              out.push(...ts);
+              byTreeitem.delete(el);
+            }
+          }
+          for (const ts of byTreeitem.values()) out.push(...ts); // treeitem 未入候选的孤儿 toggle 兜底
+          return out;
+        })();
 
         // ── overlay-priority(DEFECT-1):可见浮层的交互后代前置,免遭 maxElements 截断 ──
         // Portal 弹层(下拉/菜单/Modal)挂 body 末尾,DOM 序排最后。密集页(交互元素
@@ -2618,7 +2648,11 @@ async function scanOneFrame(
             if (v) attrs[attrName] = v.slice(0, 160);
           }
 
-          const role = withAX ? getRole(htmlEl) : htmlEl.tagName.toLowerCase();
+          // tree 展开/折叠 toggle(R25):role 强制 button(它是动作控件非装饰 img),name 走
+          // getAccessibleName 的 expand/collapse 分支。treeToggle 标记透传给 applyOverlay,使
+          // AX overlay 不把 role/name 改回 img/"caret-down"(CDP AX 视 caret 为 presentational)。
+          const isTreeTog = isTreeExpandToggle(htmlEl);
+          const role = isTreeTog ? "button" : withAX ? getRole(htmlEl) : htmlEl.tagName.toLowerCase();
           const name = withText ? getAccessibleName(htmlEl) : "";
 
           // 内容卡内「无文本 icon-link 子」(京东客服 16x16 ×60)是冗余噪声,且占
@@ -2762,6 +2796,8 @@ async function scanOneFrame(
             ...(htmlEl.getAttribute("draggable") === "true"
               ? { draggableInteractive: true as const }
               : {}),
+            // tree 展开/折叠 toggle(R25):透传给扩展侧 applyOverlay,跳过 AX role/name 覆盖。
+            ...(isTreeTog ? { treeToggle: true as const } : {}),
             ...(__href !== undefined ? { href: __href } : {}),
             ...(__inputCompound !== undefined ? { compound: __inputCompound } : {}),
             ...(__vtxBlind ? { blindspot: __vtxBlind } : {}),

--- a/packages/extension/src/handlers/observe.ts
+++ b/packages/extension/src/handlers/observe.ts
@@ -542,6 +542,55 @@ export function isNavMenuRoot(el: Element, role: string): boolean {
   return links >= items.length * 0.6;
 }
 
+// curated 展开图标类(antd/rc-tree/element-plus):switcher caret / expand-icon。
+const TREE_SWITCHER_CLASS_RE =
+  /(?:^|[\s_-])(?:ant-tree-switcher|rc-tree-switcher|el-tree-node__expand-icon)(?:[\s_-]|$)/;
+// noop/leaf 占位(无子可展开):明确非 toggle。
+const TREE_SWITCHER_NOOP_RE = /(?:switcher-noop|is-leaf)/;
+function elClass(n: Element): string {
+  return typeof n.className === "string" ? n.className : n.getAttribute("class") || "";
+}
+
+/**
+ * tree 展开/折叠 switcher 识别(R25 dogfood:antd Tree 点 treeitem-title 仅选中、点 switcher
+ * caret 才展开;switcher 因祖先 treeitem ∈ ATOMIC_INTERACTIVE_SELECTORS 被 cursor:pointer
+ * fallback 的跨池祖先短路吸收 → 无独立 ref,纯 observe agent 无法展开/折叠树节点)。
+ *
+ * Hybrid 检测(用户拍板):① ARIA 门——必在「带 aria-expanded 的 treeitem」内(只对可展开节点
+ * 生效,叶子无 aria-expanded → 零噪声);② curated 类优先(antd/rc-tree/element-plus,排除
+ * noop/is-leaf 占位);③ 几何兜底——curated 漏(未知库)时,treeitem 内 DOM 序首个小图标
+ * (≤32×32)cursor:pointer 非 checkbox 元素(caret 通常是行首最左小图标)。命中者豁免祖先短路、
+ * surface 成独立 toggle ref(naming 见 getAccessibleName:按 treeitem aria-expanded 给 expand/collapse)。
+ * 几何路用注入 getter(cursorOf/rectOf)以便 jsdom 直测;浏览器默认 getComputedStyle/bbox。
+ * inject func 内联同名逻辑,改一处须同步;本导出由 observe-tree-switcher.test.ts 锁守护。
+ */
+export function isTreeExpandToggle(
+  el: Element,
+  cursorOf: (e: Element) => string = (e) => getComputedStyle(e as HTMLElement).cursor,
+  rectOf: (e: Element) => { width: number; height: number } = (e) => e.getBoundingClientRect(),
+): boolean {
+  const treeitem = el.closest('[role="treeitem"]');
+  if (!treeitem || !treeitem.hasAttribute("aria-expanded") || el === treeitem) return false;
+  // checkbox/radio/原生 input 各有独立 ref,不当 toggle。
+  if (el.matches('[role="checkbox"],[role="radio"],input')) return false;
+  // ② curated 类:自身或到 treeitem 的祖先链命中 switcher 类。
+  for (let n: Element | null = el; n && n !== treeitem; n = n.parentElement) {
+    const cls = elClass(n);
+    if (TREE_SWITCHER_NOOP_RE.test(cls)) return false; // noop 占位明确非 toggle
+    if (TREE_SWITCHER_CLASS_RE.test(cls)) return true;
+  }
+  // ③ 几何兜底(未知库):el 是小图标 cursor:pointer,且是 treeitem 内 DOM 序首个这样的非 checkbox 图标。
+  const r = rectOf(el);
+  if (cursorOf(el) !== "pointer" || r.width === 0 || r.width > 32 || r.height > 32) return false;
+  const icons = Array.from(treeitem.querySelectorAll("*")).filter((c) => {
+    if (c === el) return true;
+    if (c.matches('[role="checkbox"],[role="radio"],input')) return false;
+    const cr = rectOf(c);
+    return cursorOf(c) === "pointer" && cr.width > 0 && cr.width <= 32 && cr.height <= 32;
+  });
+  return icons.length > 0 && icons[0] === el;
+}
+
 /**
  * main-content-priority(A-1):文档站「左导航 + 右主内容」布局下,导航(DOM 序在前)
  * 霸占 maxElements 配额、主内容 0 召回(semi.design Select dogfood 实证:154 个 nav
@@ -1096,7 +1145,48 @@ async function scanOneFrame(
           return normName(h.getAttribute("aria-label") || (h as HTMLInputElement).value || "");
         }
 
+        // tree 展开/折叠 switcher 识别(R25)——模块级 isTreeExpandToggle 同名,改一处须同步。
+        // Hybrid:ARIA 门(带 aria-expanded 的 treeitem 内)+ curated 类(antd/rc-tree/element-plus,
+        // 排除 noop/is-leaf 占位)+ 几何兜底(treeitem 内首个 ≤32×32 cursor:pointer 非 checkbox 图标)。
+        // 命中者:① getAccessibleName 给 expand/collapse 名;② 豁免 cursor:pointer fallback 的跨池祖先
+        // 短路(否则被祖先 treeitem ∈ ATOMIC 吞掉无独立 ref,纯 observe agent 无法展开)。
+        const TREE_SWITCHER_CLASS_RE =
+          /(?:^|[\s_-])(?:ant-tree-switcher|rc-tree-switcher|el-tree-node__expand-icon)(?:[\s_-]|$)/;
+        const TREE_SWITCHER_NOOP_RE = /(?:switcher-noop|is-leaf)/;
+        const treeElClass = (n: Element): string =>
+          typeof n.className === "string" ? n.className : n.getAttribute("class") || "";
+        const isTreeExpandToggle = (el: Element): boolean => {
+          const treeitem = el.closest('[role="treeitem"]');
+          if (!treeitem || !treeitem.hasAttribute("aria-expanded") || el === treeitem) return false;
+          if (el.matches('[role="checkbox"],[role="radio"],input')) return false;
+          for (let n: Element | null = el; n && n !== treeitem; n = n.parentElement) {
+            const cls = treeElClass(n);
+            if (TREE_SWITCHER_NOOP_RE.test(cls)) return false;
+            if (TREE_SWITCHER_CLASS_RE.test(cls)) return true;
+          }
+          const r = el.getBoundingClientRect();
+          if (getComputedStyle(el as HTMLElement).cursor !== "pointer" || r.width === 0 || r.width > 32 || r.height > 32)
+            return false;
+          const icons = Array.from(treeitem.querySelectorAll("*")).filter((c) => {
+            if (c === el) return true;
+            if (c.matches('[role="checkbox"],[role="radio"],input')) return false;
+            const cr = c.getBoundingClientRect();
+            return (
+              getComputedStyle(c as HTMLElement).cursor === "pointer" &&
+              cr.width > 0 &&
+              cr.width <= 32 &&
+              cr.height <= 32
+            );
+          });
+          return icons.length > 0 && icons[0] === el;
+        };
         function getAccessibleName(el: HTMLElement): string {
+          // tree 展开 toggle:无文本 caret,按父 treeitem aria-expanded 给动作名(expand/collapse),
+          // 否则落到下方图标/坐标兜底得 "caret-down"/坐标名(R25,agent 一眼识别是展开控件)。
+          if (isTreeExpandToggle(el)) {
+            const ti = el.closest('[role="treeitem"]');
+            return ti?.getAttribute("aria-expanded") === "true" ? "collapse" : "expand";
+          }
           const aria = el.getAttribute("aria-label");
           if (aria) return normName(aria);
           const labelledBy = el.getAttribute("aria-labelledby");
@@ -2003,7 +2093,10 @@ async function scanOneFrame(
               break;
             }
           }
-          if (hasInteractiveAncestor) continue;
+          // tree 展开 toggle 豁免:祖先 treeitem ∈ ATOMIC 本会短路吸收它,但 switcher 是独立动作
+          // (点 title 仅选中、点 switcher 才展开),须 surface 成独立 ref(R25)。只在确有交互祖先
+          // 时调用(限可展开 treeitem 内的 cursor:pointer 小图标子集),开销受控。
+          if (hasInteractiveAncestor && !isTreeExpandToggle(el)) continue;
           const htmlEl = el as HTMLElement;
           // SVG 元素无 offsetWidth/offsetHeight(undefined),退回 getBoundingClientRect 测尺寸,
           // 否则 `undefined === 0` 恒 false 使零尺寸 svg defs/clip 漏过尺寸门。

--- a/packages/extension/tests/observe-tree-switcher.test.ts
+++ b/packages/extension/tests/observe-tree-switcher.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+/**
+ * Author: qingwa
+ * Description: R25 dogfood — tree 展开/折叠 switcher 无独立 ref 修复。
+ *   antd Tree 点 treeitem-title 仅选中、点 switcher caret 才展开;switcher 因祖先 treeitem ∈
+ *   ATOMIC 被 cursor:pointer fallback 的跨池祖先短路吸收 → 纯 observe agent 无法展开。
+ *   Hybrid 检测(ARIA 门 + curated 类 + 几何兜底)把 toggle surface 成独立 ref。
+ *   本测试直测纯导出 isTreeExpandToggle,并 source-lock inject func 内联副本不漂移。
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { isTreeExpandToggle } from "../src/handlers/observe.js";
+
+// 几何路 stub:jsdom 无布局,注入 cursor/rect。
+const ptr = () => "pointer";
+const small = () => ({ width: 24, height: 24 });
+
+describe("isTreeExpandToggle — ARIA 门", () => {
+  it("switcher 不在 treeitem 内 → false", () => {
+    document.body.innerHTML = `<span class="ant-tree-switcher" id="s"></span>`;
+    expect(isTreeExpandToggle(document.getElementById("s")!)).toBe(false);
+  });
+  it("treeitem 无 aria-expanded(叶子)→ false（即便 curated 类命中）", () => {
+    document.body.innerHTML = `<div role="treeitem"><span class="ant-tree-switcher" id="s"></span></div>`;
+    expect(isTreeExpandToggle(document.getElementById("s")!)).toBe(false);
+  });
+  it("treeitem 自身 → false", () => {
+    document.body.innerHTML = `<div role="treeitem" aria-expanded="true" id="t"></div>`;
+    expect(isTreeExpandToggle(document.getElementById("t")!)).toBe(false);
+  });
+});
+
+describe("isTreeExpandToggle — curated 类", () => {
+  const wrap = (inner: string) => `<div role="treeitem" aria-expanded="true">${inner}</div>`;
+  it("antd .ant-tree-switcher(可展开)→ true", () => {
+    document.body.innerHTML = wrap(`<span class="ant-tree-switcher ant-tree-switcher_open" id="s"></span>`);
+    expect(isTreeExpandToggle(document.getElementById("s")!)).toBe(true);
+  });
+  it("antd .ant-tree-switcher-noop(叶子占位)→ false", () => {
+    document.body.innerHTML = wrap(`<span class="ant-tree-switcher ant-tree-switcher-noop" id="s"></span>`);
+    expect(isTreeExpandToggle(document.getElementById("s")!)).toBe(false);
+  });
+  it("rc-tree .rc-tree-switcher → true", () => {
+    document.body.innerHTML = wrap(`<span class="rc-tree-switcher rc-tree-switcher_close" id="s"></span>`);
+    expect(isTreeExpandToggle(document.getElementById("s")!)).toBe(true);
+  });
+  it("element-plus .el-tree-node__expand-icon → true", () => {
+    document.body.innerHTML = wrap(`<i class="el-tree-node__expand-icon" id="s"></i>`);
+    expect(isTreeExpandToggle(document.getElementById("s")!)).toBe(true);
+  });
+  it("element-plus expand-icon.is-leaf → false", () => {
+    document.body.innerHTML = wrap(`<i class="el-tree-node__expand-icon is-leaf" id="s"></i>`);
+    expect(isTreeExpandToggle(document.getElementById("s")!)).toBe(false);
+  });
+  it("switcher 内的 caret 子图标(祖先链命中)→ true", () => {
+    document.body.innerHTML = wrap(`<span class="ant-tree-switcher ant-tree-switcher_open"><span class="anticon" id="caret"></span></span>`);
+    expect(isTreeExpandToggle(document.getElementById("caret")!)).toBe(true);
+  });
+  it("checkbox 在可展开 treeitem 内 → false(各有独立 ref)", () => {
+    document.body.innerHTML = wrap(`<span role="checkbox" class="ant-tree-checkbox" id="cb"></span>`);
+    expect(isTreeExpandToggle(document.getElementById("cb")!)).toBe(false);
+  });
+});
+
+describe("isTreeExpandToggle — 几何兜底(未知库,注入 cursor/rect)", () => {
+  const wrap = (inner: string) => `<div role="treeitem" aria-expanded="true">${inner}</div>`;
+  it("treeitem 内首个小图标 cursor:pointer → true", () => {
+    document.body.innerHTML = wrap(`<span id="caret"></span><span id="label">node</span>`);
+    expect(isTreeExpandToggle(document.getElementById("caret")!, ptr, small)).toBe(true);
+  });
+  it("第二个图标(非首个)→ false", () => {
+    document.body.innerHTML = wrap(`<span id="first"></span><span id="second"></span>`);
+    // first/second 均小图标 pointer → 只有 first 命中
+    expect(isTreeExpandToggle(document.getElementById("second")!, ptr, small)).toBe(false);
+    expect(isTreeExpandToggle(document.getElementById("first")!, ptr, small)).toBe(true);
+  });
+  it("大尺寸内容区(>32px)即便 cursor:pointer → false", () => {
+    document.body.innerHTML = wrap(`<span id="content"></span>`);
+    expect(isTreeExpandToggle(document.getElementById("content")!, ptr, () => ({ width: 200, height: 30 }))).toBe(false);
+  });
+  it("cursor 非 pointer → false", () => {
+    document.body.innerHTML = wrap(`<span id="x"></span>`);
+    expect(isTreeExpandToggle(document.getElementById("x")!, () => "auto", small)).toBe(false);
+  });
+  it("零尺寸(未渲染)→ false", () => {
+    document.body.innerHTML = wrap(`<span id="x"></span>`);
+    expect(isTreeExpandToggle(document.getElementById("x")!, ptr, () => ({ width: 0, height: 0 }))).toBe(false);
+  });
+});
+
+describe("inject func 内联 isTreeExpandToggle drift 锁(改一处须同步)", () => {
+  const SRC = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "..", "src", "handlers", "observe.ts"),
+    "utf8",
+  );
+  it("内联保留 curated switcher 类正则(antd/rc-tree/element-plus)", () => {
+    expect(SRC).toMatch(/ant-tree-switcher\|rc-tree-switcher\|el-tree-node__expand-icon/);
+  });
+  it("内联保留 ARIA 门(treeitem + aria-expanded)", () => {
+    expect(SRC).toMatch(/role="treeitem"/);
+    expect(SRC).toMatch(/aria-expanded/);
+  });
+  it("内联保留 noop/is-leaf 排除", () => {
+    expect(SRC).toMatch(/switcher-noop\|is-leaf/);
+  });
+});

--- a/packages/vortex-bench/playground/public/synth/tree-switcher-toggle.html
+++ b/packages/vortex-bench/playground/public/synth/tree-switcher-toggle.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="zh"><head><meta charset="utf-8"><title>tree switcher toggle</title>
+<style>
+  .ant-tree-switcher{display:inline-block;width:24px;height:24px;cursor:pointer;text-align:center}
+  .ant-tree-switcher-noop{cursor:auto}
+  .ant-tree-node-content-wrapper{display:inline-block;cursor:pointer;padding:0 4px}
+  .ant-tree-treenode{display:block;line-height:24px}
+</style></head>
+<body>
+<h1>tree 展开/折叠 switcher 独立 toggle(R25)</h1>
+<!--
+  复现 R25:antd Tree 点 treeitem-title 仅选中、点 switcher caret 才展开。switcher
+  (.ant-tree-switcher,cursor:pointer)此前因祖先 treeitem ∈ ATOMIC 被 cursor:pointer
+  fallback 跨池祖先短路吸收 → 无独立 ref,纯 observe agent 无法展开。
+  修复:可展开 treeitem(有 aria-expanded)内的 curated switcher → surface 成独立
+  button "expand"/"collapse"(role 强制 button,AX overlay 跳过改名)。叶子(无
+  aria-expanded / switcher-noop)不出 toggle。
+-->
+<div role="tree">
+  <div class="ant-tree-treenode" role="treeitem" aria-expanded="true">
+    <span class="ant-tree-switcher ant-tree-switcher_open" data-vtx-oracle="toggle-expanded"><span role="img" aria-label="caret-down">▾</span></span>
+    <span class="ant-tree-node-content-wrapper">Node A (expanded)</span>
+  </div>
+  <div class="ant-tree-treenode" role="treeitem" aria-expanded="false">
+    <span class="ant-tree-switcher ant-tree-switcher_close" data-vtx-oracle="toggle-collapsed"><span role="img" aria-label="caret-right">▸</span></span>
+    <span class="ant-tree-node-content-wrapper">Node B (collapsed)</span>
+  </div>
+  <div class="ant-tree-treenode" role="treeitem">
+    <span class="ant-tree-switcher ant-tree-switcher-noop"></span>
+    <span class="ant-tree-node-content-wrapper" data-vtx-oracle="leaf-content">Leaf C</span>
+  </div>
+</div>
+</body></html>

--- a/packages/vortex-bench/playground/public/synth/tree-switcher-toggle.manifest.json
+++ b/packages/vortex-bench/playground/public/synth/tree-switcher-toggle.manifest.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "tree-switcher-toggle",
+  "path": "/synth/tree-switcher-toggle.html",
+  "tier": "medium",
+  "frames": "main",
+  "entries": [
+    { "id": "toggle-expanded", "interactive": true, "expectedName": "collapse", "expectedRole": "button", "pattern": "tree-switcher-toggle", "note": "可展开 treeitem(aria-expanded=true)的 switcher → 独立 button \"collapse\"(R25)" },
+    { "id": "toggle-collapsed", "interactive": true, "expectedName": "expand", "expectedRole": "button", "pattern": "tree-switcher-toggle", "note": "折叠 treeitem(aria-expanded=false)的 switcher → button \"expand\"" },
+    { "id": "leaf-content", "interactive": true, "expectedName": "Leaf C", "expectedRole": "treeitem", "pattern": "tree-switcher-toggle", "note": "叶子(switcher-noop,无 aria-expanded)不出 toggle" }
+  ]
+}


### PR DESCRIPTION
## 问题（R25 Dogfood）

antd Tree 点 treeitem-title 仅**选中**（aria-selected），点 switcher caret 才**展开**（aria-expanded）。而 switcher（`.ant-tree-switcher`，cursor:pointer）因祖先 treeitem ∈ `ATOMIC_INTERACTIVE_SELECTORS` 被 cursor:pointer fallback 的**跨池祖先短路吸收** → 折进 treeitem 名（"caret-down caret-down 0-0"）、**无独立 ref**，纯 observe agent 无法展开/折叠树节点（键盘 ArrowRight 亦不通）。

## 方案（Hybrid，用户拍板）

**检测** `isTreeExpandToggle`：① ARIA 门 `[role=treeitem][aria-expanded]`（只对可展开节点生效、零噪声）；② curated 类优先（antd `.ant-tree-switcher` / rc-tree / element-plus `.el-tree-node__expand-icon`，排除 noop/is-leaf）；③ 几何兜底（未知库：treeitem 内首个 ≤32×32 cursor:pointer 非 checkbox 图标）。模块级可测 + 内联副本 + drift-lock。

**三处 wiring**：
1. **收集豁免**：cursor:pointer fallback 跨池祖先短路对 toggle 放行（不再被祖先 treeitem 吞掉）。
2. **AX 命名覆盖**（关键）：elements entry 给 toggle `role=button` + `treeToggle` 标记；`applyOverlay` 对 `treeToggle` **跳过** role/name 覆盖，保住 page-side 的 `button`/`"expand"|"collapse"`（否则被 CDP AX 的 presentational caret `role=img`/`name="caret-down"` 改回）。
3. **排序截断**：`cursorPointerLeaves` 排候选末尾，密集树上 toggle 遭 `maxElements=80` 截断、跨视图不一致。`baseCandidates` 组装后把每个 toggle 重排到其 treeitem 紧后，二者同进退免截断（**无 toggle 时零漂移**）。

## 验证

- **真站端到端**（`ant.design/components/tree`，全变体一致）：basic-controlled / draggable / search 树的可展开节点均出 `button "collapse"`（展开态）/ `button "expand"`（折叠态）；叶子（switcher-noop / 无 aria-expanded）**无** toggle；点 toggle ref 正确展开/折叠（aria-expanded 翻转 + 子节点显隐）。
- **修前对比**：caret 折进名无 ref / 偶现时名为 "caret-down" 且密集视图被截断 → 修后稳定 `button "expand|collapse"`。
- **TDD**：`isTreeExpandToggle` jsdom 直测 18 例（ARIA 门 / curated / 几何 / drift-lock）。
- 扩展全量单测 + 全 monorepo **2529 全过**；新增 synth fixture `tree-switcher-toggle`。

## Test plan

- [ ] CI: `pnpm --filter @vortex-browser/extension test`
- [ ] CI: `pnpm --filter @vortex-browser/vortex-bench bench scan tree-switcher-toggle`（toggle/leaf recall）
- [ ] CI: bench `run --all` ratchet（synth 无树 fixture，预期零漂移）

🤖 Generated with [Claude Code](https://claude.com/claude-code)