### PR TITLE
fix(fill): kind=select 统一路由通用 ARIA 控件,不再独占 Element Plus

### DIFF
--- a/packages/extension/src/handlers/dom.ts
+++ b/packages/extension/src/handlers/dom.ts
@@ -1842,10 +1842,21 @@ export function registerDomHandlers(
       if (driver.kind === "checkbox-group") {
         await loadPageSideModule(tid, frameId, "commit-checkbox-group");
       } else if (driver.kind === "select") {
+        // kind="select" 是「select-like 控件」统一入口:不再独占绑定 Element Plus。
+        // 同时加载 EP 专用 driver 与通用 ARIA driver,page-side 按要素结构二段路由
+        // (DEF-006:Headless UI / MUI / Radix / antd / react-select 等非 EP 的
+        // combobox/listbox 此前必须显式 kind="aria-select" 才能命中,代理凭直觉用
+        // kind="select" 100% UNSUPPORTED_TARGET)。
         await loadPageSideModule(tid, frameId, "commit-select");
+        await loadPageSideModule(tid, frameId, "commit-aria-select");
       } else if (driver.kind === "aria-select") {
         await loadPageSideModule(tid, frameId, "commit-aria-select");
       }
+
+      // 通用 ARIA driver 的 closestSelector:kind="select" 二段路由的 EP 未命中回退用。
+      const ariaClosestSelector =
+        findDriver("aria-select")?.closestSelector ??
+        '[role="combobox"], [aria-haspopup="listbox"], [role="listbox"]';
 
       const res = await nativePageQuery<{
         result?: unknown;
@@ -1856,19 +1867,50 @@ export function registerDomHandlers(
       } | undefined>(
         tid,
         frameId,
-        (sel: string, closestSelector: string, val: unknown, timeoutMs: number, driverId: string) => {
+        (
+          sel: string,
+          closestSelector: string,
+          ariaClosest: string,
+          val: unknown,
+          timeoutMs: number,
+          driverId: string,
+        ) => {
+          const w = window as any;
           if (driverId === "element-plus-checkbox-group") {
-            return (window as any).__vortexCommitCheckboxGroup.run(sel, closestSelector, val, timeoutMs);
-          }
-          if (driverId === "element-plus-select") {
-            return (window as any).__vortexCommitSelect.run(sel, closestSelector, val, timeoutMs);
+            return w.__vortexCommitCheckboxGroup.run(sel, closestSelector, val, timeoutMs);
           }
           if (driverId === "generic-aria-select") {
-            return (window as any).__vortexCommitAriaSelect.run(sel, closestSelector, val, timeoutMs);
+            return w.__vortexCommitAriaSelect.run(sel, ariaClosest, val, timeoutMs);
+          }
+          if (driverId === "element-plus-select") {
+            // kind="select" 二段路由:先认 Element Plus el-select(其专属 driver 处理
+            // filterable 虚拟列表等 EP 特有交互),否则回退通用 ARIA combobox/listbox
+            // driver。原生 <select> 不属任一组件 driver,明确指引改用 action "select"。
+            const els = document.querySelectorAll(sel);
+            if (els.length === 0)
+              return { error: `Element not found: ${sel}`, errorCode: "ELEMENT_NOT_FOUND" };
+            if (els.length > 1)
+              return {
+                error: `Selector "${sel}" matched ${els.length} elements`,
+                errorCode: "SELECTOR_AMBIGUOUS",
+                extras: { matchCount: els.length },
+              };
+            const target = els[0] as HTMLElement;
+            if (target.closest(closestSelector) || target.querySelector(closestSelector)) {
+              return w.__vortexCommitSelect.run(sel, closestSelector, val, timeoutMs);
+            }
+            if (target.tagName === "SELECT" || target.closest("select")) {
+              return {
+                error: `Target is a native <select>; kind="select" is for component-library widgets (Element Plus / Headless UI / MUI / Radix / antd …). Use action "select" (vortex_act) or vortex_fill_form without kind.`,
+                errorCode: "UNSUPPORTED_TARGET",
+                extras: { driverId: "element-plus-select", nativeSelect: true },
+              };
+            }
+            return w.__vortexCommitAriaSelect.run(sel, ariaClosest, val, timeoutMs);
           }
           return { error: `Unknown driver id: ${driverId}`, errorCode: "INVALID_PARAMS" };
         },
-        [selector, driver.closestSelector, value as never, timeout, driver.id],
+        [selector, driver.closestSelector, ariaClosestSelector, value as never, timeout, driver.id],
       );
 
       if (res?.error) {

--- a/packages/extension/tests/def006-select-routing.test.ts
+++ b/packages/extension/tests/def006-select-routing.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { COMMIT_DRIVERS, findDriver } from "../src/patterns/commit-drivers.js";
+
+/**
+ * 回归锁:DEF-006 —— kind="select" 不再独占绑定 Element Plus。
+ *
+ * 根因:`findDriver("select")` 1:1 固定映射到 element-plus-select(closestSelector
+ * ".el-select"),非 EP 的 select-like 控件(Headless UI / MUI / Radix / antd /
+ * react-select 等 ARIA combobox/listbox)在代理直觉性 kind="select" 下 100% 返回
+ * UNSUPPORTED_TARGET,必须改用 kind="aria-select" 才能命中(V1 DEF-002 同源)。
+ *
+ * 修复:kind="select" 升级为「select-like 控件」统一入口。COMMIT handler 同时加载
+ * EP 专用 driver 与通用 ARIA driver,page-side 按要素结构二段路由:
+ *   target 落在/含 .el-select  → __vortexCommitSelect(EP 专属 filterable 等交互)
+ *   原生 <select>             → UNSUPPORTED_TARGET + 指引 action "select"
+ *   其余 combobox/listbox     → __vortexCommitAriaSelect(通用 ARIA)
+ *
+ * 后向兼容:driver 注册表与 COMMIT_KINDS 不变(kind="aria-select" 保留作显式入口),
+ * 仅 dom.ts 路由层与 kind="select" 的 page-side 分派语义扩展。
+ * page-side 注入 func 不可 import → source-grep 守护 + 真站 live(headlessui iframe)。
+ */
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DOM_SRC = readFileSync(join(__dirname, "../src/handlers/dom.ts"), "utf8");
+
+// 抽出 COMMIT handler 内 kind="select" 的 page-side 注入 func 文本(driverId
+// === "element-plus-select" 分支),便于针对路由逻辑做更聚焦的断言。
+const COMMIT_BLOCK = DOM_SRC.slice(
+  DOM_SRC.indexOf('driverId === "element-plus-select"'),
+);
+
+describe("DEF-006 注册表保持不变(后向兼容)", () => {
+  it("findDriver('select') 仍是 element-plus-select", () => {
+    expect(findDriver("select")?.id).toBe("element-plus-select");
+    expect(findDriver("select")?.closestSelector).toBe(".el-select");
+  });
+  it("findDriver('aria-select') 仍是 generic-aria-select", () => {
+    expect(findDriver("aria-select")?.id).toBe("generic-aria-select");
+  });
+  it("两个 driver 都在注册表中", () => {
+    const ids = COMMIT_DRIVERS.map((d) => d.id);
+    expect(ids).toContain("element-plus-select");
+    expect(ids).toContain("generic-aria-select");
+  });
+});
+
+describe("DEF-006 COMMIT handler 为 kind=select 同时加载两个 page-side 模块", () => {
+  it("kind=select 分支加载 commit-select", () => {
+    expect(DOM_SRC).toMatch(
+      /driver\.kind === "select"[\s\S]{0,800}"commit-select"/,
+    );
+  });
+  it("kind=select 分支也加载 commit-aria-select(回退用)", () => {
+    expect(DOM_SRC).toMatch(
+      /driver\.kind === "select"[\s\S]{0,800}"commit-aria-select"/,
+    );
+  });
+});
+
+describe("DEF-006 page-side 二段路由逻辑", () => {
+  it("element-plus-select 分支先判定 .el-select(closest 或 querySelector)", () => {
+    expect(COMMIT_BLOCK).toMatch(
+      /target\.closest\(closestSelector\)\s*\|\|\s*target\.querySelector\(closestSelector\)/,
+    );
+  });
+  it("命中 el-select 走 __vortexCommitSelect", () => {
+    expect(COMMIT_BLOCK).toMatch(/__vortexCommitSelect\.run/);
+  });
+  it("未命中 el-select 且非原生 select 时回退 __vortexCommitAriaSelect", () => {
+    // aria 回退发生在 element-plus-select 分支末尾(EP 与 native 判定之后)
+    expect(COMMIT_BLOCK).toMatch(/__vortexCommitAriaSelect\.run\(sel, ariaClosest/);
+  });
+  it("原生 <select> 明确指引 action select,不静默回退", () => {
+    expect(COMMIT_BLOCK).toMatch(/tagName === "SELECT"/);
+    expect(COMMIT_BLOCK).toMatch(/native <select>/);
+    expect(COMMIT_BLOCK).toMatch(/nativeSelect: true/);
+  });
+  it("element-plus-select 分支自带 ELEMENT_NOT_FOUND / SELECTOR_AMBIGUOUS 守卫", () => {
+    expect(COMMIT_BLOCK).toMatch(/ELEMENT_NOT_FOUND/);
+    expect(COMMIT_BLOCK).toMatch(/SELECTOR_AMBIGUOUS/);
+  });
+});
+
+describe("DEF-006 注入参数携带 aria closestSelector", () => {
+  it("host 侧计算 generic-aria-select 的 closestSelector 传入", () => {
+    expect(DOM_SRC).toMatch(/ariaClosestSelector\s*=\s*[\s\S]{0,120}findDriver\("aria-select"\)\?\.closestSelector/);
+  });
+  it("nativePageQuery 实参含 ariaClosestSelector", () => {
+    expect(DOM_SRC).toMatch(/\[selector, driver\.closestSelector, ariaClosestSelector,/);
+  });
+  it("注入 func 形参含 ariaClosest", () => {
+    expect(DOM_SRC).toMatch(/ariaClosest: string,/);
+  });
+});
+
+describe("DEF-006 page-side func 注入安全(无模块级 helper 引用)", () => {
+  it("driver 调用经 window 取得,不引用模块作用域符号", () => {
+    // 注入后模块作用域剥离,只能经 window/document/形参访问(page-side func 内联陷阱)。
+    // `const w = window as any` 在注入 func 顶部(checkbox-group 分支之前),不在
+    // element-plus-select 分支切片内,故对 DOM_SRC 全文断言。
+    expect(DOM_SRC).toMatch(/const w = window as any/);
+    expect(COMMIT_BLOCK).toMatch(/w\.__vortexCommitSelect/);
+    expect(COMMIT_BLOCK).toMatch(/w\.__vortexCommitAriaSelect/);
+  });
+});

--- a/packages/extension/tests/dom-commit.test.ts
+++ b/packages/extension/tests/dom-commit.test.ts
@@ -121,7 +121,7 @@ describe("dom.commit handler (@since 0.4.0)", () => {
     expect(resp.error?.message).toContain("No commit driver");
   });
 
-  it("passes selector + closestSelector + value + timeout + driverId into executeScript args", async () => {
+  it("passes selector + closestSelector + ariaClosest + value + timeout + driverId into executeScript args", async () => {
     executeScript.mockResolvedValue([
       {
         result: {
@@ -153,9 +153,12 @@ describe("dom.commit handler (@since 0.4.0)", () => {
     const call = executeScript.mock.calls[0][0];
     expect(call.args[0]).toBe(".roles");                       // selector
     expect(call.args[1]).toBe(".el-checkbox-group");           // closestSelector
-    expect(call.args[2]).toEqual(["a", "b"]);                  // value
-    expect(call.args[3]).toBe(5000);                           // timeoutMs
-    expect(call.args[4]).toBe("element-plus-checkbox-group");  // driverId
+    // args[2] 是 kind="select" 二段路由用的 aria closestSelector(DEF-006),
+    // checkbox-group 不读它但所有 commit 注入统一携带,故 value 后移到 args[3]。
+    expect(call.args[2]).toMatch(/role="combobox"/);           // ariaClosest
+    expect(call.args[3]).toEqual(["a", "b"]);                  // value
+    expect(call.args[4]).toBe(5000);                           // timeoutMs
+    expect(call.args[5]).toBe("element-plus-checkbox-group");  // driverId
   });
 
   it("maps page-side COMMIT_FAILED result to COMMIT_FAILED error with stage in context", async () => {


### PR DESCRIPTION
## 背景 (DEF-006)

`kind="select"` 此前经 `findDriver` **1:1 固定映射**到 `element-plus-select`(closestSelector `.el-select`)。非 Element Plus 的 select-like 控件(Headless UI / MUI / Radix / antd / react-select 等 ARIA combobox/listbox)在代理直觉性 `kind="select"` 下 **100% 返回 `UNSUPPORTED_TARGET`**,必须显式改用 `kind="aria-select"` 才能命中(与 V1 DEF-002 同源)。

## 根因(白盒确诊)

- `kind` 由 LLM 直接指定,无自动检测;`select.ts` 深度依赖 `.el-select-dropdown__item` 等 EP 专属类,`generic-aria-select` 走 `[role=option]` —— 两者本质不同 driver,合并会破坏 EP filterable 虚拟列表等特有交互。
- 根因 = 注册表 schema 误设计:`kind="select"` 语义本应是「所有 select-like 控件」,实际被 Element Plus 独占。

## 修复

把 `kind="select"` 升级为「select-like 控件统一入口」。closestSelector 匹配依赖 DOM,host 侧无 DOM,故路由在 **page-side** 进行。COMMIT handler:

1. `kind="select"` 时同时加载 `commit-select` + `commit-aria-select` 两个 page-side driver;
2. 按要素结构二段路由:命中 `.el-select` → EP driver(行为不变);原生 `<select>` → 明确指引 `action "select"`;其余 combobox/listbox → 通用 ARIA driver。

**后向兼容**:`COMMIT_DRIVERS` 与 `COMMIT_KINDS` 不变,`kind="aria-select"` 保留作显式入口。无 breaking change。

## 验证

- 单测:extension 1516 绿 + mcp 525 绿(新增 `def006-select-routing.test.ts` 锁路由配线,更新 `dom-commit.test.ts` 注入参数位移)
- build:tsc 无类型错误 + page-side bundle 全量重建
- 实机:
  - Headless UI listbox(iframe 内)`kind=select` → 自动回退 `generic-aria-select` → 选中成功并回读反映 ✅(修复前 `UNSUPPORTED_TARGET`)
  - Element Plus el-select `kind=select` → 仍走 `element-plus-select` ✅(后向兼容)

Refs DEF-006

🤖 Generated with [Claude Code](https://claude.com/claude-code)